### PR TITLE
fix(auro-menu): ensure correct aria-selected states for unselected menuoptions

### DIFF
--- a/components/menu/demo/api.min.js
+++ b/components/menu/demo/api.min.js
@@ -666,7 +666,7 @@ class AuroMenuOption extends r {
     });
   }
 
-  // Add observer for selected property changes
+  // observer for selected property changes
   updated(changedProperties) {
     if (changedProperties.has('selected')) {
       this.setAttribute('aria-selected', this.selected.toString());
@@ -873,7 +873,6 @@ class AuroMenu extends r {
       this.items.forEach((item) => {
         item.classList.remove('active');
         item.removeAttribute('selected');
-        item.setAttribute('aria-selected', 'false');
       });
     }
   }

--- a/components/menu/demo/api.min.js
+++ b/components/menu/demo/api.min.js
@@ -589,9 +589,9 @@ class AuroMenuOption extends r {
     const versioning = new AuroDependencyVersioning();
     this.iconTag = versioning.generateTag('auro-icon', iconVersion, AuroIcon);
 
+    this.selected = false;
     this.nocheckmark = false;
     this.disabled = false;
-    this.selected = false;
 
     /**
      * @private
@@ -654,6 +654,7 @@ class AuroMenuOption extends r {
     this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
 
     this.setAttribute('role', 'option');
+    this.setAttribute('aria-selected', 'false');
 
     this.addEventListener('mouseover', () => {
       this.dispatchEvent(new CustomEvent('auroMenuOption-mouseover', {
@@ -665,6 +666,12 @@ class AuroMenuOption extends r {
     });
   }
 
+  // Add observer for selected property changes
+  updated(changedProperties) {
+    if (changedProperties.has('selected')) {
+      this.setAttribute('aria-selected', this.selected.toString());
+    }
+  }
 
   /**
    * Generates an HTML element containing an SVG icon based on the provided `svgContent`.
@@ -866,7 +873,7 @@ class AuroMenu extends r {
       this.items.forEach((item) => {
         item.classList.remove('active');
         item.removeAttribute('selected');
-        item.removeAttribute('aria-selected');
+        item.setAttribute('aria-selected', 'false');
       });
     }
   }

--- a/components/menu/demo/index.min.js
+++ b/components/menu/demo/index.min.js
@@ -632,7 +632,7 @@ class AuroMenuOption extends r {
     });
   }
 
-  // Add observer for selected property changes
+  // observer for selected property changes
   updated(changedProperties) {
     if (changedProperties.has('selected')) {
       this.setAttribute('aria-selected', this.selected.toString());
@@ -839,7 +839,6 @@ class AuroMenu extends r {
       this.items.forEach((item) => {
         item.classList.remove('active');
         item.removeAttribute('selected');
-        item.setAttribute('aria-selected', 'false');
       });
     }
   }

--- a/components/menu/demo/index.min.js
+++ b/components/menu/demo/index.min.js
@@ -555,9 +555,9 @@ class AuroMenuOption extends r {
     const versioning = new AuroDependencyVersioning();
     this.iconTag = versioning.generateTag('auro-icon', iconVersion, AuroIcon);
 
+    this.selected = false;
     this.nocheckmark = false;
     this.disabled = false;
-    this.selected = false;
 
     /**
      * @private
@@ -620,6 +620,7 @@ class AuroMenuOption extends r {
     this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
 
     this.setAttribute('role', 'option');
+    this.setAttribute('aria-selected', 'false');
 
     this.addEventListener('mouseover', () => {
       this.dispatchEvent(new CustomEvent('auroMenuOption-mouseover', {
@@ -631,6 +632,12 @@ class AuroMenuOption extends r {
     });
   }
 
+  // Add observer for selected property changes
+  updated(changedProperties) {
+    if (changedProperties.has('selected')) {
+      this.setAttribute('aria-selected', this.selected.toString());
+    }
+  }
 
   /**
    * Generates an HTML element containing an SVG icon based on the provided `svgContent`.
@@ -832,7 +839,7 @@ class AuroMenu extends r {
       this.items.forEach((item) => {
         item.classList.remove('active');
         item.removeAttribute('selected');
-        item.removeAttribute('aria-selected');
+        item.setAttribute('aria-selected', 'false');
       });
     }
   }

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -185,7 +185,6 @@ export class AuroMenu extends LitElement {
       this.items.forEach((item) => {
         item.classList.remove('active');
         item.removeAttribute('selected');
-        item.setAttribute('aria-selected', 'false');
       });
     }
   }

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -185,7 +185,7 @@ export class AuroMenu extends LitElement {
       this.items.forEach((item) => {
         item.classList.remove('active');
         item.removeAttribute('selected');
-        item.removeAttribute('aria-selected');
+        item.setAttribute('aria-selected', 'false');
       });
     }
   }

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -17,7 +17,6 @@ import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts
 import { AuroIcon } from '@aurodesignsystem/auro-icon/src/auro-icon.js';
 import iconVersion from './iconVersion.js';
 
-
 import checkmarkIcon from '@alaskaairux/icons/dist/icons/interface/checkmark-sm.mjs';
 
 /**
@@ -40,9 +39,9 @@ export class AuroMenuOption extends LitElement {
     const versioning = new AuroDependencyVersioning();
     this.iconTag = versioning.generateTag('auro-icon', iconVersion, AuroIcon);
 
+    this.selected = false;
     this.nocheckmark = false;
     this.disabled = false;
-    this.selected = false;
 
     /**
      * @private
@@ -105,6 +104,7 @@ export class AuroMenuOption extends LitElement {
     this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
 
     this.setAttribute('role', 'option');
+    this.setAttribute('aria-selected', 'false');
 
     this.addEventListener('mouseover', () => {
       this.dispatchEvent(new CustomEvent('auroMenuOption-mouseover', {
@@ -116,6 +116,12 @@ export class AuroMenuOption extends LitElement {
     });
   }
 
+  // observer for selected property changes
+  updated(changedProperties) {
+    if (changedProperties.has('selected')) {
+      this.setAttribute('aria-selected', this.selected.toString());
+    }
+  }
 
   /**
    * Generates an HTML element containing an SVG icon based on the provided `svgContent`.


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Ensure correct `aria-selected` states for unselected `auro-menu` options by setting `aria-selected` to `false` when a menu `option` is not selected.

Issues originally opened in: https://github.com/AlaskaAirlines/auro-menu/issues/187

## Updates

- Initialize `aria-selected` attribute to `false` during component connection
- Added an `update` observer for `aria-selected` attributes when selected property changes
- Changed removal of `aria-selected`, setting it to `false` when clearing selections

## Testing
![Screenshot 2024-12-16 at 12 09 14 PM](https://github.com/user-attachments/assets/349c1c92-1232-4cdd-bac5-2e36aa86a81c)

https://github.com/user-attachments/assets/7077290d-0280-4fc2-a31d-a9408725dc45