### PR TITLE
temporary fix for README.md to have the correct npm path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ It is a monorepo that contains the following components:
 ## Install
 
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/WC-Generator/master/componentDocs/partials/usage/componentInstall_esm.md) -->
-[![Build Status](https://img.shields.io/github/actions/workflow/status/AlaskaAirlines/-formkit/-formkit/build-tools/testPublish.yml?style=for-the-badge)](https://github.com/AlaskaAirlines/-formkit/-formkit/build-tools/actions/workflows/testPublish.yml)
-[![See it on NPM!](https://img.shields.io/npm/v/@auro-formkit/-formkit/-formkit/build-tools?style=for-the-badge&color=orange)](https://www.npmjs.com/package/@auro-formkit/-formkit/-formkit/build-tools)
-[![License](https://img.shields.io/npm/l/@auro-formkit/-formkit/-formkit/build-tools?color=blue&style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/AlaskaAirlines/auro-formkit/testPublish.yml?style=for-the-badge)](https://github.com/AlaskaAirlines/auro-formkit/actions/workflows/testPublish.yml)
+[![See it on NPM!](https://img.shields.io/npm/v/@aurodesignsystem/auro-formkit?style=for-the-badge&color=orange)](https://www.npmjs.com/package/@aurodesignsystem/auro-formkit)
+[![License](https://img.shields.io/npm/l/@aurodesignsystem/auro-formkit?color=blue&style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0)
 ![ESM supported](https://img.shields.io/badge/ESM-compatible-FFE900?style=for-the-badge)
 
 ```shell
-$ npm i @auro-formkit/-formkit/-formkit/build-tools
+$ npm i @aurodesignsystem/auro-formkit
 ```
 
 Installing as a direct, dev or peer dependency is up to the user installing the package. If you are unsure as to what type of dependency you should use, consider reading this [stack overflow](https://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies) answer.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "postinstall": "node ./node_modules/@aurodesignsystem/auro-library/scripts/build/postinstall.mjs",
     "build:docs": "turbo run build:docs",
-    "build:docs:kit": "turbo run --filter=@auro-formkit/build-tools build:docs:kit",
+    "build:docs:kit": "node ./packages/build-tools/src/kitDocProcessor.mjs",
     "sweep": "find ./components ./packages -type d -name 'dist' -exec rm -rf {} + && find ./components ./packages -not -path '*/node_modules/*' -type f \\( -name '*.css' -o -name '*-css.js' \\) -delete",
     "preCommit": "node ./node_modules/@aurodesignsystem/auro-library/scripts/build/pre-commit.mjs",
     "prepare": "husky"

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -11,8 +11,5 @@
     "./formVersionWriter": "./src/formVersionWriter.mjs",
     "./docProcessor": "./src/docProcessor.mjs",
     "./kitDocProcessor": "./src/kitDocProcessor.mjs"
-  },
-  "scripts": {
-    "build:docs:kit": "node src/kitDocProcessor.mjs"
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Fix the npm package path in the README.md and update the build:docs:kit script for direct execution of kitDocProcessor.mjs.

Enhancements:
- Update the build:docs:kit script to directly call the kitDocProcessor.mjs file.

Documentation:
- Correct the npm package path in the README.md file to reflect the accurate package location.