### PR TITLE
Fix viewable month render in calendar when `maxDate` is set on datepicker

### DIFF
--- a/components/datepicker/apiExamples/alertValue.html
+++ b/components/datepicker/apiExamples/alertValue.html
@@ -1,3 +1,4 @@
 <auro-datepicker id="datePickerValueAlert">
   <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/centralDate.html
+++ b/components/datepicker/apiExamples/centralDate.html
@@ -1,3 +1,4 @@
 <auro-datepicker centralDate="06/16/1980">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/disabled.html
+++ b/components/datepicker/apiExamples/disabled.html
@@ -1,3 +1,4 @@
 <auro-datepicker disabled>
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/dynamicSlot.html
+++ b/components/datepicker/apiExamples/dynamicSlot.html
@@ -1,4 +1,5 @@
 <auro-datepicker id="slotContentExample" centralDate="12/13/2023" minDate="12/13/2023" maxDate="01/18/2024" range>
-  <span slot="fromLabel">Choose a date</span>
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/error.html
+++ b/components/datepicker/apiExamples/error.html
@@ -1,5 +1,6 @@
 <auro-datepicker error="Custom error message" id="errorExample">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
 
 <auro-button id="undefinedValueExampleBtnAddError">Set Error</auro-button>

--- a/components/datepicker/apiExamples/focus.html
+++ b/components/datepicker/apiExamples/focus.html
@@ -1,6 +1,8 @@
+<auro-datepicker id="focusExampleElem" range>
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
+  <span slot="mobileDateLabel">Choose a date</span>
+</auro-datepicker>
+
 <auro-button id="focusExampleBtn">Apply focus to datepicker</auro-button>
 <auro-button id="focusExampleBtnTwo">Apply focus to the second input in datepicker</auro-button>
-<br /><br />
-<auro-datepicker id="focusExampleElem" range>
-  <span slot="label">Choose a date</span>
-</auro-datepicker>

--- a/components/datepicker/apiExamples/helpText.html
+++ b/components/datepicker/apiExamples/helpText.html
@@ -1,4 +1,5 @@
 <auro-datepicker>
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
   <span slot="helpText">Choose a date must be today or earlier.</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/noValidate.html
+++ b/components/datepicker/apiExamples/noValidate.html
@@ -1,3 +1,4 @@
 <auro-datepicker required noValidate>
   <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/resetState.html
+++ b/components/datepicker/apiExamples/resetState.html
@@ -1,7 +1,7 @@
-<auro-button id="resetStateBtn">Reset</auro-button>
-<br /><br />
-
 <auro-datepicker id="resetStateExample" range minDate="06/30/2025" calendarStartDate="06/30/2025" calendarFocusDate="06/30/2025" value="02/14/2025" valueEnd="04/05/2025" setCustomValidityRangeUnderflow="The date you entered is too early.">
-  <span slot="fromLabel">Choose a date</span>
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
   <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
+
+<auro-button id="resetStateBtn">Reset</auro-button>

--- a/components/datepicker/apiExamples/selectedDate.html
+++ b/components/datepicker/apiExamples/selectedDate.html
@@ -1,3 +1,4 @@
 <auro-datepicker selectedDate="06/16/2022">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/updateMaxDate.html
+++ b/components/datepicker/apiExamples/updateMaxDate.html
@@ -1,5 +1,6 @@
 <auro-datepicker id="maxDateExample" setCustomValidityRangeOverflow="Selected date is later than maximum date.">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
 <auro-button id="maxDateChange">Change maxDate to Today's Date</auro-button>
 <auro-button id="resetMaxDate">Reset Datepicker to Initial Example</auro-button>

--- a/components/datepicker/apiExamples/updateMinDate.html
+++ b/components/datepicker/apiExamples/updateMinDate.html
@@ -1,5 +1,6 @@
 <auro-datepicker id="minDateExample" setCustomValidityRangeUnderflow="Selected date is earlier than the minimum date.">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
 <auro-button id="minDateChange">Change minDate to a week from Today</auro-button>
 <auro-button id="resetMinDate">Reset Datepicker to Initial Example</auro-button>

--- a/components/datepicker/apiExamples/validity.html
+++ b/components/datepicker/apiExamples/validity.html
@@ -1,4 +1,5 @@
 <auro-datepicker required id="validityExample">
   <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>
 <auro-button id="validityExampleBtn">Get validity</auro-button>

--- a/components/datepicker/apiExamples/value.html
+++ b/components/datepicker/apiExamples/value.html
@@ -1,3 +1,4 @@
 <auro-datepicker id="valueExample" value="02/02/2022">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/valueEnd.html
+++ b/components/datepicker/apiExamples/valueEnd.html
@@ -1,3 +1,5 @@
 <auro-datepicker id="valueEndExample" range valueEnd="03/03/2023">
-  <span slot="label">Choose a date</span>
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
+  <span slot="mobileDateLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -844,11 +844,14 @@ export class AuroDatePicker extends LitElement {
     // a later date than the current value date
     if (changedProperties.has('minDate')) {
       if (this.minDate) {
-        const minDateMonth = Number(this.minDate.charAt(1));
+        const minDateMonth = Number(this.minDate.split('/')[0]);
+        const minDateYear = Number(this.minDate.split('/')[2]);
 
         // This sets the visible month of the calendar to the minDate when the minDate is later
         // than the current visible date
-        if (minDateMonth > this.calendar.month) {
+        if (minDateYear > this.calendar.year) {
+          this.calendarRenderUtil.updateCentralDate(this, this.minDate);
+        } else if (minDateYear === this.calendar.year && minDateMonth > this.calendar.month) {
           this.calendarRenderUtil.updateCentralDate(this, this.minDate);
         }
 
@@ -869,6 +872,17 @@ export class AuroDatePicker extends LitElement {
     // This resets the datepicker when the maxDate is set to a new value that is
     // an earlier date than the current value date
     if (changedProperties.has('maxDate')) {
+      const maxDateMonth = Number(this.maxDate.split('/')[0]);
+      const maxDateYear = Number(this.maxDate.split('/')[2]);
+
+      // This sets the visible month of the calendar to the maxDate when the maxDate is earlier
+      // than the current visible date
+      if (maxDateYear < this.calendar.year) {
+        this.calendarRenderUtil.updateCentralDate(this, this.maxDate);
+      } else if (maxDateYear === this.calendar.year && maxDateMonth < this.calendar.month) {
+        this.calendarRenderUtil.updateCentralDate(this, this.maxDate);
+      }
+
       if (this.maxDate) {
         if (this.value) {
           if (new Date(this.maxDate).getTime() < new Date(this.value).getTime()) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Fix the calendar rendering issue in the datepicker when maxDate is set, ensuring correct month and year display. Enhance datepicker to handle minDate and maxDate changes more accurately. Update documentation to reflect the latest component versions.

Bug Fixes:
- Fix the rendering of the viewable month in the calendar when the maxDate is set on the datepicker, ensuring the calendar displays the correct month and year.

Enhancements:
- Update the datepicker component to correctly handle changes in minDate and maxDate, adjusting the visible month and year accordingly.

Documentation:
- Update documentation to reflect the latest version of auro-formkit components, changing from beta.4 to beta.6.