### PR TITLE
feat: move start date when the 2nd click is before start date in datepicker #218

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -682,10 +682,11 @@ export class AuroDatePicker extends LitElement {
         if (!this.value || !this.util.validDateStr(this.value)) {
           this.value = newDate;
         } else if (!this.valueEnd || !this.util.validDateStr(this.valueEnd)) {
-
           // verify the date is after this.value to insure we are setting a proper range
           if (new Date(newDate) >= new Date(this.value)) {
             this.valueEnd = newDate;
+          } else {
+            this.value = newDate;
           }
         } else {
           this.value = newDate;


### PR DESCRIPTION
closes #218 

# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Bug Fixes:
- Fix an issue where the datepicker wouldn't correctly set the start date when the second click was before the start date.