### PR TITLE
Add `autocomplete="off"` functionality to combobox and force focus into HTML5 input

### DIFF
--- a/components/combobox/demo/api.md
+++ b/components/combobox/demo/api.md
@@ -7,6 +7,7 @@
 
 | Property                        | Attribute                       | Type      | Default     | Description                                      |
 |---------------------------------|---------------------------------|-----------|-------------|--------------------------------------------------|
+| [autocomplete](#autocomplete)                  | `autocomplete`                  | `string`  |             | An enumerated attribute that defines what the user agent can suggest for autofill. At this time, only `autocomplete="off"` is supported. |
 | [checkmark](#checkmark)                     | `checkmark`                     | `boolean` |             | When attribute is present auro-menu will apply checkmarks to selected options. |
 | [disabled](#disabled)                      | `disabled`                      | `boolean` |             | If set, disables the combobox.                   |
 | [error](#error)                         | `error`                         | `string`  |             | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |

--- a/components/combobox/demo/api.md
+++ b/components/combobox/demo/api.md
@@ -7,20 +7,20 @@
 
 | Property                        | Attribute                       | Type      | Default     | Description                                      |
 |---------------------------------|---------------------------------|-----------|-------------|--------------------------------------------------|
-| [checkmark](#checkmark)                     | `checkmark`                     | `Boolean` |             | When attribute is present auro-menu will apply checkmarks to selected options. |
-| [disabled](#disabled)                      | `disabled`                      | `Boolean` |             | If set, disables the combobox.                   |
-| [error](#error)                         | `error`                         | `String`  |             | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |
-| [noFilter](#noFilter)                      | `noFilter`                      | `Boolean` | false       | If set, combobox will not filter menuoptions based in input. |
-| [noValidate](#noValidate)                    | `noValidate`                    | `Boolean` |             | If set, disables auto-validation on blur.        |
-| [optionSelected](#optionSelected)                | `optionSelected`                | `Object`  | "undefined" | Specifies the current selected option.           |
-| [required](#required)                      | `required`                      | `Boolean` |             | Populates the `required` attribute on the input. Used for client-side validation. |
-| [setCustomValidity](#setCustomValidity)             | `setCustomValidity`             | `String`  |             | Sets a custom help text message to display for all validityStates. |
-| [setCustomValidityCustomError](#setCustomValidityCustomError)  | `setCustomValidityCustomError`  | `String`  |             | Custom help text message to display when validity = `customError`. |
-| [setCustomValidityValueMissing](#setCustomValidityValueMissing) | `setCustomValidityValueMissing` | `String`  |             | Custom help text message to display when validity = `valueMissing`. |
-| [triggerIcon](#triggerIcon)                   | `triggerIcon`                   | `Boolean` |             | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
-| [type](#type)                          | `type`                          | `String`  |             | Applies the defined value as the type attribute on auro-input. |
-| [validity](#validity)                      | `validity`                      | `String`  | "undefined" | Specifies the `validityState` this element is in. |
-| [value](#value)                         | `value`                         | `String`  | "undefined" | Value selected for the dropdown menu.            |
+| [checkmark](#checkmark)                     | `checkmark`                     | `boolean` |             | When attribute is present auro-menu will apply checkmarks to selected options. |
+| [disabled](#disabled)                      | `disabled`                      | `boolean` |             | If set, disables the combobox.                   |
+| [error](#error)                         | `error`                         | `string`  |             | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |
+| [noFilter](#noFilter)                      | `noFilter`                      | `boolean` | false       | If set, combobox will not filter menuoptions based in input. |
+| [noValidate](#noValidate)                    | `noValidate`                    | `boolean` |             | If set, disables auto-validation on blur.        |
+| [optionSelected](#optionSelected)                | `optionSelected`                | `object`  | "undefined" | Specifies the current selected option.           |
+| [required](#required)                      | `required`                      | `boolean` |             | Populates the `required` attribute on the input. Used for client-side validation. |
+| [setCustomValidity](#setCustomValidity)             | `setCustomValidity`             | `string`  |             | Sets a custom help text message to display for all validityStates. |
+| [setCustomValidityCustomError](#setCustomValidityCustomError)  | `setCustomValidityCustomError`  | `string`  |             | Custom help text message to display when validity = `customError`. |
+| [setCustomValidityValueMissing](#setCustomValidityValueMissing) | `setCustomValidityValueMissing` | `string`  |             | Custom help text message to display when validity = `valueMissing`. |
+| [triggerIcon](#triggerIcon)                   | `triggerIcon`                   | `boolean` |             | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
+| [type](#type)                          | `type`                          | `string`  |             | Applies the defined value as the type attribute on auro-input. |
+| [validity](#validity)                      | `validity`                      | `string`  | "undefined" | Specifies the `validityState` this element is in. |
+| [value](#value)                         | `value`                         |           | "undefined" | Value selected for the dropdown menu.            |
 
 ## Methods
 

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -4,6 +4,7 @@
 
 | Property                        | Attribute                       | Type      | Default     | Description                                      |
 |---------------------------------|---------------------------------|-----------|-------------|--------------------------------------------------|
+| `autocomplete`                  | `autocomplete`                  | `string`  |             | An enumerated attribute that defines what the user agent can suggest for autofill. At this time, only `autocomplete="off"` is supported. |
 | `checkmark`                     | `checkmark`                     | `boolean` |             | When attribute is present auro-menu will apply checkmarks to selected options. |
 | `disabled`                      | `disabled`                      | `boolean` |             | If set, disables the combobox.                   |
 | `error`                         | `error`                         | `string`  |             | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -4,20 +4,20 @@
 
 | Property                        | Attribute                       | Type      | Default     | Description                                      |
 |---------------------------------|---------------------------------|-----------|-------------|--------------------------------------------------|
-| `checkmark`                     | `checkmark`                     | `Boolean` |             | When attribute is present auro-menu will apply checkmarks to selected options. |
-| `disabled`                      | `disabled`                      | `Boolean` |             | If set, disables the combobox.                   |
-| `error`                         | `error`                         | `String`  |             | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |
-| `noFilter`                      | `noFilter`                      | `Boolean` | false       | If set, combobox will not filter menuoptions based in input. |
-| `noValidate`                    | `noValidate`                    | `Boolean` |             | If set, disables auto-validation on blur.        |
-| `optionSelected`                | `optionSelected`                | `Object`  | "undefined" | Specifies the current selected option.           |
-| `required`                      | `required`                      | `Boolean` |             | Populates the `required` attribute on the input. Used for client-side validation. |
-| `setCustomValidity`             | `setCustomValidity`             | `String`  |             | Sets a custom help text message to display for all validityStates. |
-| `setCustomValidityCustomError`  | `setCustomValidityCustomError`  | `String`  |             | Custom help text message to display when validity = `customError`. |
-| `setCustomValidityValueMissing` | `setCustomValidityValueMissing` | `String`  |             | Custom help text message to display when validity = `valueMissing`. |
-| `triggerIcon`                   | `triggerIcon`                   | `Boolean` |             | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
-| `type`                          | `type`                          | `String`  |             | Applies the defined value as the type attribute on auro-input. |
-| `validity`                      | `validity`                      | `String`  | "undefined" | Specifies the `validityState` this element is in. |
-| `value`                         | `value`                         | `String`  | "undefined" | Value selected for the dropdown menu.            |
+| `checkmark`                     | `checkmark`                     | `boolean` |             | When attribute is present auro-menu will apply checkmarks to selected options. |
+| `disabled`                      | `disabled`                      | `boolean` |             | If set, disables the combobox.                   |
+| `error`                         | `error`                         | `string`  |             | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |
+| `noFilter`                      | `noFilter`                      | `boolean` | false       | If set, combobox will not filter menuoptions based in input. |
+| `noValidate`                    | `noValidate`                    | `boolean` |             | If set, disables auto-validation on blur.        |
+| `optionSelected`                | `optionSelected`                | `object`  | "undefined" | Specifies the current selected option.           |
+| `required`                      | `required`                      | `boolean` |             | Populates the `required` attribute on the input. Used for client-side validation. |
+| `setCustomValidity`             | `setCustomValidity`             | `string`  |             | Sets a custom help text message to display for all validityStates. |
+| `setCustomValidityCustomError`  | `setCustomValidityCustomError`  | `string`  |             | Custom help text message to display when validity = `customError`. |
+| `setCustomValidityValueMissing` | `setCustomValidityValueMissing` | `string`  |             | Custom help text message to display when validity = `valueMissing`. |
+| `triggerIcon`                   | `triggerIcon`                   | `boolean` |             | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
+| `type`                          | `type`                          | `string`  |             | Applies the defined value as the type attribute on auro-input. |
+| `validity`                      | `validity`                      | `string`  | "undefined" | Specifies the `validityState` this element is in. |
+| `value`                         | `value`                         |           | "undefined" | Value selected for the dropdown menu.            |
 
 ## Methods
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -603,6 +603,10 @@ export class AuroCombobox extends LitElement {
         }
       }
     });
+
+    this.addEventListener('focusin', () => {
+      this.focus();
+    });
   }
 
   /**

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -29,20 +29,6 @@ import styleCss from "./styles/style-css.js";
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
- * @prop {Object} optionSelected - Specifies the current selected option.
- * @prop {String} value - Value selected for the dropdown menu.
- * @prop {Boolean} checkmark - When attribute is present auro-menu will apply checkmarks to selected options.
- * @attr {String} error - When defined, sets persistent validity to `customError` and sets the validation message to the attribute value.
- * @attr {String} validity - Specifies the `validityState` this element is in.
- * @attr {String} setCustomValidity - Sets a custom help text message to display for all validityStates.
- * @attr {String} setCustomValidityCustomError - Custom help text message to display when validity = `customError`.
- * @attr {String} setCustomValidityValueMissing - Custom help text message to display when validity = `valueMissing`.
- * @attr {Boolean} disabled - If set, disables the combobox.
- * @attr {Boolean} noFilter - If set, combobox will not filter menuoptions based in input.
- * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
- * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
- * @attr {Boolean} triggerIcon - If set, the `icon` attribute will be applied to the trigger `auro-input` element.
- * @attr {String} type - Applies the defined value as the type attribute on auro-input.
  * @slot - Default slot for the menu content.
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
@@ -61,28 +47,6 @@ export class AuroCombobox extends LitElement {
     this.optionSelected = undefined;
 
     this.privateDefaults();
-
-    /**
-     * @private
-     */
-    this.validation = new AuroFormValidation();
-
-    /**
-     * @private
-     */
-    this.runtimeUtils = new AuroLibraryRuntimeUtils();
-
-    /**
-     * @private
-     */
-    this.isHiddenWhileLoading = false;
-
-    /**
-     * Generate unique names for dependency components.
-     */
-    const versioning = new AuroDependencyVersioning();
-    this.dropdownTag = versioning.generateTag('auro-dropdown', dropdownVersion, AuroDropdown);
-    this.inputTag = versioning.generateTag('auro-input', inputVersion, AuroInput);
   }
 
   /**
@@ -93,6 +57,17 @@ export class AuroCombobox extends LitElement {
     this.availableOptions = [];
     this.optionActive = null;
     this.msgSelectionMissing = 'Please select an option.';
+
+    this.validation = new AuroFormValidation();
+
+    this.runtimeUtils = new AuroLibraryRuntimeUtils();
+
+    this.isHiddenWhileLoading = false;
+
+    const versioning = new AuroDependencyVersioning();
+
+    this.dropdownTag = versioning.generateTag('auro-dropdown', dropdownVersion, AuroDropdown);
+    this.inputTag = versioning.generateTag('auro-input', inputVersion, AuroInput);
   }
 
   // This function is to define props used within the scope of this component
@@ -101,92 +76,115 @@ export class AuroCombobox extends LitElement {
   static get properties() {
     return {
       // ...super.properties,
-      error: {
-        type: String,
-        reflect: true
-      },
-      setCustomValidity: {
-        type: String
-      },
-      setCustomValidityCustomError: {
-        type: String
-      },
-      setCustomValidityValueMissing: {
-        type: String
-      },
-      validity: {
-        type: String,
-        reflect: true
-      },
-      disabled: {
-        type: Boolean,
-        reflect: true
-      },
-      noFilter: {
-        type: Boolean,
-        reflect: true
-      },
-      optionSelected: {
-        type: Object,
-        converter: arrayConverter,
-        hasChanged: arrayOrUndefinedHasChanged
-      },
-      noValidate: { type: Boolean },
-      required: {
-        type: Boolean,
-        reflect: true
-      },
-      triggerIcon: {
-        type: Boolean,
-        reflect: true
-      },
-      type: {
-        type: String,
-        reflect: true
-      },
-      value: {
-        converter: arrayConverter,
-        hasChanged: arrayOrUndefinedHasChanged
-      },
+
+      /**
+       * When attribute is present auro-menu will apply checkmarks to selected options.
+       */
       checkmark: {
         type: Boolean,
         reflect: true
       },
 
       /**
-       * @private
+       * If set, disables the combobox.
        */
-      availableOptions: { type: Array },
+      disabled: {
+        type: Boolean,
+        reflect: true
+      },
 
       /**
-       * @private
+       * When defined, sets persistent validity to `customError` and sets the validation message to the attribute value.
        */
-      optionActive: { type: Object },
+      error: {
+        type: String,
+        reflect: true
+      },
 
       /**
-       * @private
+       * If set, combobox will not filter menuoptions based in input.
        */
-      msgSelectionMissing: { type: String },
+      noFilter: {
+        type: Boolean,
+        reflect: true
+      },
 
       /**
-       * @private
+       * If set, disables auto-validation on blur.
        */
-      dropdownElementName: { type: String },
+      noValidate: {
+        type: Boolean
+      },
 
       /**
-       * @private
+       * Specifies the current selected option.
        */
-      dropdownTag: { type: Object },
+      optionSelected: {
+        type: Object,
+        converter: arrayConverter,
+        hasChanged: arrayOrUndefinedHasChanged
+      },
 
       /**
-       * @private
+       * Populates the `required` attribute on the input. Used for client-side validation.
        */
-      inputElementName: { type: String },
+      required: {
+        type: Boolean,
+        reflect: true
+      },
 
       /**
-       * @private
+       * Sets a custom help text message to display for all validityStates.
        */
-      inputTag: { type: Object }
+      setCustomValidity: {
+        type: String
+      },
+
+      /**
+       * Custom help text message to display when validity = `customError`.
+       */
+      setCustomValidityCustomError: {
+        type: String
+      },
+
+      /**
+       * Custom help text message to display when validity = `valueMissing`.
+       */
+      setCustomValidityValueMissing: {
+        type: String
+      },
+
+      /**
+       * If set, the `icon` attribute will be applied to the trigger `auro-input` element.
+       */
+      triggerIcon: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * Applies the defined value as the type attribute on auro-input.
+       */
+      type: {
+        type: String,
+        reflect: true
+      },
+
+      /**
+       * Specifies the `validityState` this element is in.
+       */
+      validity: {
+        type: String,
+        reflect: true
+      },
+
+      /**
+       * Value selected for the dropdown menu.
+       */
+      value: {
+        converter: arrayConverter,
+        hasChanged: arrayOrUndefinedHasChanged
+      },
     };
   }
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -78,6 +78,14 @@ export class AuroCombobox extends LitElement {
       // ...super.properties,
 
       /**
+       * An enumerated attribute that defines what the user agent can suggest for autofill. At this time, only `autocomplete="off"` is supported.
+       */
+      autocomplete: {
+        type: String,
+        reflect: true
+      },
+
+      /**
        * When attribute is present auro-menu will apply checkmarks to selected options.
        */
       checkmark: {
@@ -739,6 +747,7 @@ export class AuroCombobox extends LitElement {
             setCustomValidity="${this.setCustomValidity}"
             setCustomValidityValueMissing="${this.setCustomValidityValueMissing}"
             setCustomValidityCustomError="${this.setCustomValidityCustomError}"
+            .autocomplete="${this.autocomplete}"
             .type="${this.type}"
             @input="${this.handleInputValueChange}">
             <slot name="label" slot="label"></slot>


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

New Features:
- Allow users to disable autocomplete functionality on combobox components via the `autocomplete` attribute.