### PR TITLE
Enable usage of css properties in tests and adjust viewport settings #239

### DIFF
--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines, no-undef, prefer-destructuring, no-use-before-define, no-magic-numbers, no-unused-vars, no-await-in-loop */
 
 import { fixture, html, expect, elementUpdated, nextFrame } from '@open-wc/testing';
+import { setViewport} from '@web/test-runner-commands';
 import '../src/index.js';
 
 describe('auro-datepicker', () => {
@@ -542,20 +543,23 @@ describe('auro-datepicker', () => {
     await expect(calendar.numCalendars).to.be.equal(2);
   });
 
-  it.skip('renders twelve calendars in mobile version', async () => {
-    window.innerWidth = 550;
+  it('renders twelve calendars in mobile version', async () => {
+    await setViewport({
+      width: 500,
+      height: 800
+    });
 
     const el = await fixture(html`
       <auro-datepicker></auro-datepicker>
     `);
 
     const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-    const calendar = dropdown.bibContent.querySelector('auro-calendar');
 
     await dropdown.querySelector('[auro-input]').click();
     await expect(dropdown.isPopoverVisible).to.be.true;
-    await elementUpdated(calendar.shadowRoot);
-    await nextFrame();
+
+    const calendar = dropdown.bibContent.querySelector('auro-calendar');
+    await elementUpdated(calendar);
 
     await expect(calendar.numCalendars).to.be.equal(12);
   });
@@ -586,8 +590,11 @@ describe('auro-datepicker', () => {
     expect(input2.value).to.equal('');
   });
 
-  it.skip('render correct number of calendars with calendarStartDate and calendarEndDate in mobile', async () => {
-    window.innerWidth = 550;
+  it('render correct number of calendars with calendarStartDate and calendarEndDate in mobile', async () => {
+    await setViewport({
+      width: 500,
+      height: 800
+    });
 
     const el = await fixture(html`
       <auro-datepicker range calendarStartDate="03/04/2023" calendarEndDate="05/05/2023"></auro-datepicker>
@@ -598,7 +605,7 @@ describe('auro-datepicker', () => {
 
     await dropdown.querySelector('[auro-input]').click();
     await expect(dropdown.isPopoverVisible).to.be.true;
-    await elementUpdated(calendar.shadowRoot);
+    await elementUpdated(calendar.numCalendars);
     await nextFrame();
 
     await expect(calendar.numCalendars).to.equal(3);
@@ -682,8 +689,11 @@ describe('auro-datepicker', () => {
     await expect(el.dropdown.isPopoverVisible).to.be.true;
   });
 
-  it.skip('closes the mobile bib when clicking the bottom done', async () => {
-    window.innerWidth = 550;
+  it('closes the mobile bib when clicking the bottom done', async () => {
+    await setViewport({
+      width: 500,
+      height: 800
+    });
 
     const el = await fixture(html`
       <auro-datepicker></auro-datepicker>

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -559,7 +559,8 @@ describe('auro-datepicker', () => {
     await expect(dropdown.isPopoverVisible).to.be.true;
 
     const calendar = dropdown.bibContent.querySelector('auro-calendar');
-    await elementUpdated(calendar);
+    await elementUpdated(calendar.shadowRoot);
+    await nextFrame();
 
     await expect(calendar.numCalendars).to.be.equal(12);
   });
@@ -605,7 +606,7 @@ describe('auro-datepicker', () => {
 
     await dropdown.querySelector('[auro-input]').click();
     await expect(dropdown.isPopoverVisible).to.be.true;
-    await elementUpdated(calendar.numCalendars);
+    await elementUpdated(calendar.shadowRoot);
     await nextFrame();
 
     await expect(calendar.numCalendars).to.equal(3);

--- a/packages/config/src/web-test-runner.config.mjs
+++ b/packages/config/src/web-test-runner.config.mjs
@@ -5,8 +5,14 @@ export default {
     '!**/node_modules/**'
   ],
   nodeResolve: {
-    moduleDirectories: ['node_modules', 'components'],
-    extensions: ['.js', '.css']
+    moduleDirectories: [
+      'node_modules',
+      'components'
+    ],
+    extensions: [
+      '.js',
+      '.css'
+    ]
   },
   coverageConfig: {
     include: ['src/**/*.js'],
@@ -17,5 +23,13 @@ export default {
       functions: 70,
       lines: 70
     }
-  }
+  },
+  testRunnerHtml: (testFramework) => `<html>
+      <head>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm//@aurodesignsystem/design-tokens@latest/dist/tokens/CSSCustomProperties.css">
+      </head>
+      <body>
+        <script type="module" src="${testFramework}"></script>
+      </body>
+    </html>`,
 };


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Enable CSS custom properties usage in web test runner and update viewport setting logic in datepicker tests.

Tests:
- Use CSS custom properties in web tests.
- Update viewport setting logic in datepicker tests to use `setViewport` and remove window resize logic.