### PR TITLE
feat: add public `validate` function in each components #246

### DIFF
--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -96,7 +96,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-checkbox@2.0.0-beta.14/dist/auro-checkbox__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-checkbox@2.0.0-beta.18/dist/auro-checkbox__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-checkbox use cases

--- a/components/checkbox/docs/api.md
+++ b/components/checkbox/docs/api.md
@@ -18,9 +18,10 @@ The auro-checkbox-group element is a wrapper for auro-checkbox element.
 
 ## Methods
 
-| Method  | Type       | Description                        |
-|---------|------------|------------------------------------|
-| `reset` | `(): void` | Resets component to initial state. |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| `reset`    | `(): void`                             | Resets component to initial state.               |
+| `validate` | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/checkbox/src/auro-checkbox-group.js
+++ b/components/checkbox/src/auro-checkbox-group.js
@@ -185,7 +185,7 @@ export class AuroCheckboxGroup extends LitElement {
       composed: true,
     }));
 
-    this.validation.validate(this, true);
+    this.validate(true);
   }
 
   firstUpdated() {
@@ -271,7 +271,7 @@ export class AuroCheckboxGroup extends LitElement {
 
     this.handlePreselectedItems();
 
-    this.validation.validate(this);
+    this.validate();
   }
 
   /**
@@ -327,8 +327,16 @@ export class AuroCheckboxGroup extends LitElement {
         this.removeAttribute('aria-invalid');
       }
 
-      this.validation.validate(this, true);
+      this.validate(true);
     }
+  }
+
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
   }
 
   render() {

--- a/components/combobox/README.md
+++ b/components/combobox/README.md
@@ -100,10 +100,10 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.14/dist/auro-dropdown__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.14/dist/auro-input__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.14/dist/auro-menu__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-combobox@2.0.0-beta.14/dist/auro-combobox__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.18/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.18/dist/auro-input__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.18/dist/auro-menu__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-combobox@2.0.0-beta.18/dist/auro-combobox__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-combobox use cases

--- a/components/combobox/demo/api.md
+++ b/components/combobox/demo/api.md
@@ -25,10 +25,11 @@
 
 ## Methods
 
-| Method  | Type       | Description                         |
-|---------|------------|-------------------------------------|
-| [focus](#focus) | `(): void` | Focuses the combobox trigger input. |
-| [reset](#reset) | `(): void` | Resets component to initial state.  |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| [focus](#focus)    | `(): void`                             | Focuses the combobox trigger input.              |
+| [reset](#reset)    | `(): void`                             | Resets component to initial state.               |
+| [validate](#validate) | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -22,10 +22,11 @@
 
 ## Methods
 
-| Method  | Type       | Description                         |
-|---------|------------|-------------------------------------|
-| `focus` | `(): void` | Focuses the combobox trigger input. |
-| `reset` | `(): void` | Resets component to initial state.  |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| `focus`    | `(): void`                             | Focuses the combobox trigger input.              |
+| `reset`    | `(): void`                             | Resets component to initial state.               |
+| `validate` | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -458,7 +458,7 @@ export class AuroCombobox extends LitElement {
      */
     this.addEventListener('focusout', () => {
       if (document.activeElement !== this) {
-        this.validation.validate(this);
+        this.validate(this);
       }
 
       // Set to undefined if empty
@@ -536,7 +536,7 @@ export class AuroCombobox extends LitElement {
 
     // Validate only if the value was set programmatically
     if (document.activeElement !== this) {
-      this.validation.validate(this);
+      this.validate(this);
     }
 
     // Hide menu if value is empty, otherwise show if there are available suggestions
@@ -665,6 +665,14 @@ export class AuroCombobox extends LitElement {
     this.menu.value = undefined;
   }
 
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
+  }
+
   updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
     if (changedProperties.has('value')) {
@@ -693,7 +701,7 @@ export class AuroCombobox extends LitElement {
 
     if (changedProperties.has('error')) {
       this.input.setAttribute('error', this.getAttribute('error'));
-      this.validation.validate(this);
+      this.validate();
     }
   }
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -458,7 +458,7 @@ export class AuroCombobox extends LitElement {
      */
     this.addEventListener('focusout', () => {
       if (document.activeElement !== this) {
-        this.validate(this);
+        this.validate();
       }
 
       // Set to undefined if empty
@@ -536,7 +536,7 @@ export class AuroCombobox extends LitElement {
 
     // Validate only if the value was set programmatically
     if (document.activeElement !== this) {
-      this.validate(this);
+      this.validate();
     }
 
     // Hide menu if value is empty, otherwise show if there are available suggestions

--- a/components/counter/README.md
+++ b/components/counter/README.md
@@ -100,7 +100,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-counter@2.0.0-beta.16/dist/auro-counter__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-counter@2.0.0-beta.18/dist/auro-counter__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-counter use cases

--- a/components/counter/docs/api.md
+++ b/components/counter/docs/api.md
@@ -12,10 +12,11 @@
 
 ## Methods
 
-| Method      | Type                                  | Description                                      |
-|-------------|---------------------------------------|--------------------------------------------------|
-| `decrement` | `(value?: number \| undefined): void` | Decrements the value of the counter by 1. If a value is provided, it decrements by that amount.<br /><br />**value**: The amount to decrement by. |
-| `increment` | `(value?: number \| undefined): void` | Increments the counter value by 1. If a value is provided, it increments by that amount.<br /><br />**value**: The amount to increment by. |
+| Method      | Type                                   | Description                                      |
+|-------------|----------------------------------------|--------------------------------------------------|
+| `decrement` | `(value?: number \| undefined): void`  | Decrements the value of the counter by 1. If a value is provided, it decrements by that amount.<br /><br />**value**: The amount to decrement by. |
+| `increment` | `(value?: number \| undefined): void`  | Increments the counter value by 1. If a value is provided, it increments by that amount.<br /><br />**value**: The amount to increment by. |
+| `validate`  | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 
@@ -43,6 +44,12 @@
 | `total`      | `total`      | `number`  | "undefined" | The total value of the counters.                 |
 | `validity`   | `validity`   | `string`  | "undefined" | Reflects the validity state.                     |
 | `value`      | `value`      | `object`  | "undefined" | The current individual values of the nested counters. |
+
+## Methods
+
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| `validate` | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -205,9 +205,17 @@ export class AuroCounterGroup extends LitElement {
     });
   }
 
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
+  }
+
   updated(changedProperties) {
     if (changedProperties.has("value")) {
-      this.validation.validate(this);
+      this.validate(this);
       this.dispatchEvent(
         new CustomEvent("input", {
           detail: {

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -215,7 +215,7 @@ export class AuroCounterGroup extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has("value")) {
-      this.validate(this);
+      this.validate();
       this.dispatchEvent(
         new CustomEvent("input", {
           detail: {

--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -1,4 +1,4 @@
-/* eslint-disable lit/binding-positions, lit/no-invalid-html */
+/* eslint-disable lit/binding-positions, lit/no-invalid-html, max-lines */
 // Copyright (c) 2025 Alaska Airlines. All right reserved. Licensed under the Apache-2.0 license
 // See LICENSE in the project root for license information.
 
@@ -220,13 +220,22 @@ export class AuroCounter extends LitElement {
     this.checkSlots();
   }
 
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
+  }
+
+
   firstUpdated() {
     this.initValue();
   }
 
   updated(changedProperties) {
     if (changedProperties.has("value")) {
-      this.validation.validate(this);
+      this.validate(this);
       this.dispatchEvent(
         new CustomEvent("input", {
           detail: {

--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -235,7 +235,7 @@ export class AuroCounter extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has("value")) {
-      this.validate(this);
+      this.validate();
       this.dispatchEvent(
         new CustomEvent("input", {
           detail: {

--- a/components/datepicker/README.md
+++ b/components/datepicker/README.md
@@ -93,10 +93,10 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.14/dist/auro-dropdown__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.14/dist/auro-input__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-popover@2.0.0-beta.14/dist/auro-popover__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-datepicker@2.0.0-beta.14/dist/auro-datepicker__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.18/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.18/dist/auro-input__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-popover@2.0.0-beta.18/dist/auro-popover__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-datepicker@2.0.0-beta.18/dist/auro-datepicker__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-datepicker use cases

--- a/components/datepicker/docs/api.md
+++ b/components/datepicker/docs/api.md
@@ -27,10 +27,11 @@
 
 ## Methods
 
-| Method  | Type                         | Description                                      |
-|---------|------------------------------|--------------------------------------------------|
-| `focus` | `(focusInput: string): void` | Focuses the datepicker trigger input.<br /><br />**focusInput**: Pass in `endDate` to focus on the return input. No parameter is needed to focus on the depart input. |
-| `reset` | `(): void`                   | Resets component to initial state.               |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| `focus`    | `(focusInput: string): void`           | Focuses the datepicker trigger input.<br /><br />**focusInput**: Pass in `endDate` to focus on the return input. No parameter is needed to focus on the depart input. |
+| `reset`    | `(): void`                             | Resets component to initial state.               |
+| `validate` | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -719,6 +719,14 @@ export class AuroDatePicker extends LitElement {
     this.validation.reset(this);
   }
 
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
+  }
+
   updated(changedProperties) {
     if (changedProperties.has('calendarFocusDate')) {
       this.handleFocusDateChange();
@@ -784,7 +792,7 @@ export class AuroDatePicker extends LitElement {
         }
       }
 
-      this.validation.validate(this);
+      this.validate(this);
     }
 
     if (changedProperties.has('valueEnd') && this.inputList[1]) {
@@ -814,7 +822,7 @@ export class AuroDatePicker extends LitElement {
         }
       }
 
-      this.validation.validate(this);
+      this.validate(this);
     }
 
     if (changedProperties.has('error')) {

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -792,7 +792,7 @@ export class AuroDatePicker extends LitElement {
         }
       }
 
-      this.validate(this);
+      this.validate();
     }
 
     if (changedProperties.has('valueEnd') && this.inputList[1]) {
@@ -822,7 +822,7 @@ export class AuroDatePicker extends LitElement {
         }
       }
 
-      this.validate(this);
+      this.validate();
     }
 
     if (changedProperties.has('error')) {

--- a/components/form/README.md
+++ b/components/form/README.md
@@ -98,7 +98,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-form@2.0.0-beta.14/dist/auro-form__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-form@2.0.0-beta.18/dist/auro-form__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-form use cases

--- a/components/form/docs/api.md
+++ b/components/form/docs/api.md
@@ -11,17 +11,30 @@ The auro-form element provides users a way to ... (it would be great if you fill
 
 ## Properties
 
-| Property       | Modifiers | Type                                             | Default | Description                                      |
-|----------------|-----------|--------------------------------------------------|---------|--------------------------------------------------|
-| `formElements` |           | `HTMLInputElement[]`                             | []      |                                                  |
-| `formState`    |           | `FormState`                                      | {}      |                                                  |
-| `value`        | readonly  | `Record<string, string \| number \| boolean \| string[] \| null>` |         | Reduce the form value into a key-value pair.<br /><br />NOTE: form keys use `name` first, and `id` second if `name` is not available.<br />This follows standard HTML5 form behavior - submission uses `name` by default when creating<br />the FormData object. |
+| Property         | Modifiers | Type                                             | Default | Description                                      |
+|------------------|-----------|--------------------------------------------------|---------|--------------------------------------------------|
+| `formState`      |           | `FormState`                                      | {}      |                                                  |
+| `isInitialState` | readonly  | `boolean`                                        |         | Mostly internal way to determine if a form is in the initial state. |
+| `reset`          |           |                                                  |         |                                                  |
+| `submit`         |           |                                                  |         |                                                  |
+| `validity`       | readonly  | `"valid" \| "invalid"`                           |         | Current validity state of the form, based on form element events. |
+| `value`          | readonly  | `Record<string, string \| number \| boolean \| string[] \| null>` |         | Reduce the form value into a key-value pair.<br /><br />NOTE: form keys use `name` first, and `id` second if `name` is not available.<br />This follows standard HTML5 form behavior - submission uses `name` by default when creating<br />the FormData object. |
 
 ## Methods
 
-| Method              | Type                         | Description                                      |
-|---------------------|------------------------------|--------------------------------------------------|
-| `getSubmitFunction` | `(): (event: any) => void`   |                                                  |
-| `isFormElement`     | `(tagName: string): boolean` | Check if the tag name is a form element.<br /><br />**tagName**: The tag name to check. |
-| `isSubmitElement`   | `(tagName: string): boolean` | Check if the tag name is a submit element.<br /><br />**tagName**: The tag name to check. |
-| `onSlotChange`      | `(event: any): void`         |                                                  |
+| Method                      | Type                              | Description                                      |
+|-----------------------------|-----------------------------------|--------------------------------------------------|
+| `initializeState`           | `(): void`                        | Initialize (or reinitialize) the form state.     |
+| `isButtonElement`           | `(element: HTMLElement): boolean` | Check if the tag name is a button element.<br /><br />**element**: The element to check. |
+| `isFormElement`             | `(element: HTMLElement): boolean` | Check if the tag name is a form element.<br /><br />**element**: The element to check (attr or tag name). |
+| `onSlotChange`              | `(): void`                        |                                                  |
+| `queryAuroElements`         | `(): NodeList`                    | Construct the query strings from elements, append them together, execute, and return the NodeList. |
+| `reset`                     | `(): void`                        |                                                  |
+| `setDisabledStateOnButtons` | `(): void`                        |                                                  |
+| `submit`                    | `(): void`                        | Submit fires an event called `submit` - just as you would expect from a normal form. |
+
+## Events
+
+| Event    | Type                                             |
+|----------|--------------------------------------------------|
+| `submit` | `CustomEvent<{ value: Record<string, string \| number \| boolean \| string[] \| null>; }>` |

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -89,7 +89,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.14/dist/auro-input__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.18/dist/auro-input__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-input use cases

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -51,11 +51,11 @@ Generate unique names for dependency components.
 
 ## Methods
 
-| Method       | Type          | Description                              |
-|--------------|---------------|------------------------------------------|
-| `isDateType` | `(): boolean` |                                          |
-| `reset`      | `(): void`    | Resets component to initial state.       |
-| `validate`   | `(): void`    | Public method force validation of input. |
+| Method       | Type                                   | Description                                      |
+|--------------|----------------------------------------|--------------------------------------------------|
+| `isDateType` | `(): boolean`                          |                                                  |
+| `reset`      | `(): void`                             | Resets component to initial state.               |
+| `validate`   | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -651,7 +651,7 @@ export default class BaseInput extends LitElement {
     }
 
     if (changedProperties.has('error')) {
-      this.validation.validate(this, true);
+      this.validate(this, true);
     }
 
     if (changedProperties.has('validity')) {
@@ -843,11 +843,11 @@ export default class BaseInput extends LitElement {
   }
 
   /**
-   * Public method force validation of input.
-   * @returns {void}
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
    */
-  validate() {
-    this.validation.validate(this);
+  validate(force = false) {
+    this.validation.validate(this, force);
   }
 
   /**

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -651,7 +651,7 @@ export default class BaseInput extends LitElement {
     }
 
     if (changedProperties.has('error')) {
-      this.validate(this, true);
+      this.validate(true);
     }
 
     if (changedProperties.has('validity')) {

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -90,7 +90,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.9.2/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-radio@2.0.0-beta.14/dist/auro-radio__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-radio@2.0.0-beta.18/dist/auro-radio__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-radio use cases

--- a/components/radio/docs/api.md
+++ b/components/radio/docs/api.md
@@ -18,9 +18,10 @@
 
 ## Methods
 
-| Method  | Type       | Description                        |
-|---------|------------|------------------------------------|
-| `reset` | `(): void` | Resets component to initial state. |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| `reset`    | `(): void`                             | Resets component to initial state.               |
+| `validate` | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -199,7 +199,7 @@ export class AuroRadioGroup extends LitElement {
     }
 
     if (changedProperties.has('error')) {
-      this.validate(this, true);
+      this.validate(true);
     }
 
     if (changedProperties.has('validity')) {

--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -199,7 +199,7 @@ export class AuroRadioGroup extends LitElement {
     }
 
     if (changedProperties.has('error')) {
-      this.validation.validate(this, true);
+      this.validate(this, true);
     }
 
     if (changedProperties.has('validity')) {
@@ -230,6 +230,14 @@ export class AuroRadioGroup extends LitElement {
     });
 
     this.validation.reset(this);
+  }
+
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
   }
 
   /**

--- a/components/select/README.md
+++ b/components/select/README.md
@@ -99,9 +99,9 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.12.1/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.14/dist/auro-dropdown__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.14/dist/auro-menu__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-select@2.0.0-beta.14/dist/auro-select__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.18/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.18/dist/auro-menu__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-select@2.0.0-beta.18/dist/auro-select__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-select use cases

--- a/components/select/demo/api.md
+++ b/components/select/demo/api.md
@@ -32,9 +32,10 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 
 ## Methods
 
-| Method  | Type       | Description                        |
-|---------|------------|------------------------------------|
-| [reset](#reset) | `(): void` | Resets component to initial state. |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| [reset](#reset)    | `(): void`                             | Resets component to initial state.               |
+| [validate](#validate) | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -22,9 +22,10 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 
 ## Methods
 
-| Method  | Type       | Description                        |
-|---------|------------|------------------------------------|
-| `reset` | `(): void` | Resets component to initial state. |
+| Method     | Type                                   | Description                                      |
+|------------|----------------------------------------|--------------------------------------------------|
+| `reset`    | `(): void`                             | Resets component to initial state.               |
+| `validate` | `(force?: boolean \| undefined): void` | Validates value<br /><br />**force**: Whether to force validation. |
 
 ## Events
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -516,7 +516,7 @@ export class AuroSelect extends LitElement {
     }
 
     if (changedProperties.has('error')) {
-      this.validation.validate(this, true);
+      this.validate(this, true);
     }
   }
 
@@ -526,6 +526,14 @@ export class AuroSelect extends LitElement {
    */
   reset() {
     this.validation.reset(this);
+  }
+
+  /**
+   * Validates value
+   * @param {boolean} [force=false] - Whether to force validation.
+   */
+  validate(force = false) {
+    this.validation.validate(this, force);
   }
 
   // When using auroElement, use the following attribute and function when hiding content from screen readers.

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -516,7 +516,7 @@ export class AuroSelect extends LitElement {
     }
 
     if (changedProperties.has('error')) {
-      this.validate(this, true);
+      this.validate(true);
     }
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Add a public `validate` method to several components: auro-checkbox-group, auro-combobox, auro-counter, auro-datepicker, auro-counter-group, auro-input, auro-radio-group, and auro-select.

New Features:
- Introduce a public `validate` method to programmatically trigger validation for the following components: auro-checkbox-group, auro-combobox, auro-counter, auro-datepicker, auro-counter-group, auro-input, auro-radio-group, and auro-select.

Enhancements:
- Update the version of auro-checkbox, auro-combobox, auro-counter, auro-datepicker, auro-form, auro-input, auro-radio, and auro-select used in the documentation examples to 2.0.0-beta.18.

Documentation:
- Document the new public `validate` method in the API documentation for the affected components.