### PR TITLE
`auro-form` datepicker range support

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -320,6 +320,28 @@ export class AuroDatePicker extends LitElement {
   }
 
   /**
+   * A convenience wrapper for `value` and `valueEnd`, uses the new Auro "array value pattern".
+   * @returns {string[]}
+   */
+  get values() {
+    // If range, and both populated, return both values in an array
+    // - NOTE: both are required here, so we don't have something like `['10/22/25', undefined]`
+    if (this.range && this.value && this.valueEnd) {
+      return [
+        this.value,
+        this.valueEnd
+      ];
+    }
+
+    // This if block catches instances where `value` is present, no matter if valueEnd is selected yet
+    if (this.value) {
+      return [this.value];
+    }
+
+    return [];
+  }
+
+  /**
    * Force the calendar view to the focus date when it changes.
    * @private
    * @returns {void}

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -325,6 +325,9 @@ describe('auro-datepicker', () => {
     await elementUpdated(el);
 
     await expect(el.value).to.equal(dateSelected);
+    await expect(el.value).to.equal(dateSelected);
+    await expect(el.values).to.have.length(1);
+    await expect(el.values[0]).to.equal(dateSelected);
   });
 
   it('selecting a dateTo date by clicking on the calendar sets the correct value', async () => {
@@ -365,6 +368,9 @@ describe('auro-datepicker', () => {
     await elementUpdated(el);
 
     await expect(el.valueEnd).to.equal(dateToSelected);
+    await expect(el.values).to.have.length(2);
+    await expect(el.values[0]).to.equal(dateSelected);
+    await expect(el.values[1]).to.equal(dateFromSelected);
   });
 
   it('attempting to set the dateTo to a date earlier than dateFrom by clicking on the calendar does not set the valueFrom', async () => {

--- a/components/form/demo/working.html
+++ b/components/form/demo/working.html
@@ -80,6 +80,15 @@
       </auro-datepicker>
     </div>
 
+    <div class="datepickerBlock">
+      <h4>Pick a date range</h4>
+      <auro-datepicker id="date-range" name="dateRange" required range>
+        <span slot="fromLabel">Start</span>
+        <span slot="toLabel">End</span>
+        <span slot="mobileDateLabel">Choose a range</span>
+      </auro-datepicker>
+    </div>
+
     <div class="submitBlock">
       <auro-button type="reset">Reset</auro-button>
       <auro-button type="submit">Submit</auro-button>

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -352,15 +352,7 @@ export class AuroForm extends LitElement {
 
       // Check special input types and handle their edge cases
       if (this._isElementTag('auro-datepicker', event.target) && event.target.hasAttribute('range')) {
-        // Value is populated first, check for valueEnd after
-        this.formState[targetName].value = [event.target.value];
-
-        if (event.target.valueEnd) {
-          this.formState[targetName].value = [
-            event.target.value,
-            event.target.valueEnd
-          ];
-        }
+        this.formState[targetName].value = event.target.values;
 
         this.requestUpdate('formState');
       } else {


### PR DESCRIPTION
Form is now aware of datepicker's value and valueEnd keys and will automatically pick up the `range` attribute.

When no `range` attribute is present, a string value is used. When the `range` value IS present, an array of strings is used instead.

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

New Features:
- Added support for date range selection in the `auro-datepicker` component.