### PR TITLE
fix: make datepicker's height the same as other components' height #271

### DIFF
--- a/components/input/src/styles/input.scss
+++ b/components/input/src/styles/input.scss
@@ -10,8 +10,8 @@ input {
 
   position: relative;
   overflow: hidden;
-  min-height: calc(var(--ds-size-700, $ds-size-700) + var(--ds-size-25, $ds-size-25));
-  max-height: calc(var(--ds-size-700, $ds-size-700) + var(--ds-size-25, $ds-size-25));
+  min-height: var(--ds-size-700, $ds-size-700);
+  max-height: var(--ds-size-700, $ds-size-700);
   flex: 1;
   padding: var(--ds-size-400, $ds-size-400) 0 var(--ds-size-50, $ds-size-50);
   margin: 0;


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Set date picker's input size(min-height, max-height) correct

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Bug Fixes:
- Fix the date picker's height to match other components.