### PR TITLE
fix: set correct margin on helpText in select, combobox and datepicker #272, #275

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -768,7 +768,7 @@ export class AuroCombobox extends LitElement {
               ? html`
                 <slot name="helpText"></slot>
               ` : html`
-                <p role="alert" aria-live="assertive" part="helpText">
+                <p role="alert" class="comboboxElement-helpText" aria-live="assertive" part="helpText">
                   ${this.errorMessage}
                 </p>`
             }

--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Alaska Airlines. All right reserved. Licensed under the Apache-2.0 license
 // See LICENSE in the project root for license information.
 
-/* stylelint-disable max-nesting-depth */
+/* stylelint-disable max-nesting-depth, selector-class-pattern */
 
 @import '@aurodesignsystem/design-tokens/dist/tokens/SCSSVariables';
 @import '@aurodesignsystem/webcorestylesheets/src/utilityClasses/displayProperties';
@@ -35,6 +35,13 @@
     --ds-auro-input-border-color: transparent;
     --ds-auro-input-container-color: transparent;
   }
+}
+
+.comboboxElement-helpText {
+  margin-top: var(--ds-size-50, $ds-size-50);
+  margin-bottom: 0;
+  font-size: var(--ds-text-body-size-xs, $ds-text-body-size-xs);
+  line-height: 1rem;
 }
 
 :host {

--- a/components/datepicker/src/styles/style.scss
+++ b/components/datepicker/src/styles/style.scss
@@ -36,7 +36,8 @@
 }
 
 .datepickerElement-helpText {
-  margin: var(--ds-size-50, $ds-size-50) 0;
+  margin-top: var(--ds-size-50, $ds-size-50);
+  margin-bottom: 0;
   font-size: var(--ds-text-body-size-xs, $ds-text-body-size-xs);
   line-height: 1rem;
 }

--- a/components/dropdown/src/styles/style.scss
+++ b/components/dropdown/src/styles/style.scss
@@ -86,7 +86,6 @@
 /* stylelint-enable selector-id-pattern */
 
 .helpText {
-  margin-top: var(--ds-size-50, $ds-size-50);
   font-size: var(--ds-text-body-size-xs, $ds-text-body-size-xs);
   line-height: var(--ds-text-body-size-default, $ds-text-body-size-default);
 }

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -70,7 +70,8 @@ auro-menuoption {
 }
 
 .selectElement-helpText {
-  margin: var(--ds-size-50, $ds-size-50) 0;
+  margin-top: var(--ds-size-50, $ds-size-50);
+  margin-bottom: 0;
   font-size: var(--ds-text-body-size-xs, $ds-text-body-size-xs);
   line-height: 1rem;
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

- remove margin on help text in dropdown #275
- set correct margin on help text in select, combobox, datepicker #272

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Fix the margin on help text in select, combobox, and datepicker components.

Bug Fixes:
- Remove margin on help text in dropdown.
- Set correct margin on help text in select, combobox, and datepicker.