### PR TITLE
Validate form interactions through test suite

### DIFF
--- a/components/form/demo/registerDemoDeps.js
+++ b/components/form/demo/registerDemoDeps.js
@@ -1,6 +1,19 @@
 import {AuroInput} from "@aurodesignsystem/auro-input";
 import {AuroDatePicker} from "@aurodesignsystem/auro-datepicker";
+import {AuroCounter, AuroCounterGroup} from "@aurodesignsystem/auro-counter";
+import {AuroCheckbox, AuroCheckboxGroup} from "@aurodesignsystem/auro-checkbox";
+import {AuroCombobox} from "@aurodesignsystem/auro-combobox";
+import {AuroMenu, AuroMenuOption} from "@aurodesignsystem/auro-menu";
+import {AuroSelect} from "@aurodesignsystem/auro-select";
 
 AuroInput.register();
 AuroInput.register('auro-input-two');
 AuroDatePicker.register();
+AuroCounter.register();
+AuroCounterGroup.register();
+AuroCheckbox.register();
+AuroCheckboxGroup.register();
+AuroCombobox.register();
+AuroMenu.register();
+AuroMenuOption.register();
+AuroSelect.register();

--- a/components/form/docs/api.md
+++ b/components/form/docs/api.md
@@ -11,16 +11,18 @@ The auro-form element provides users a way to ... (it would be great if you fill
 
 ## Properties
 
-| Property         | Modifiers | Type                                             | Default | Description                                      |
-|------------------|-----------|--------------------------------------------------|---------|--------------------------------------------------|
-| `formState`      |           | `FormState`                                      | {}      |                                                  |
-| `isInitialState` | readonly  | `boolean`                                        |         | Mostly internal way to determine if a form is in the initial state. |
-| `reset`          |           |                                                  |         |                                                  |
-| `resetElements`  | readonly  | `HTMLButtonElement[]`                            |         | Getter for internal _resetElements.              |
-| `submit`         |           |                                                  |         |                                                  |
-| `submitElements` | readonly  | `HTMLButtonElement[]`                            |         | Getter for internal _submitElements.             |
-| `validity`       | readonly  | `"valid" \| "invalid"`                           |         | Current validity state of the form, based on form element events. |
-| `value`          | readonly  | `Record<string, string \| number \| boolean \| string[] \| null>` |         | Reduce the form value into a key-value pair.<br /><br />NOTE: form keys use `name` first, and `id` second if `name` is not available.<br />This follows standard HTML5 form behavior - submission uses `name` by default when creating<br />the FormData object. |
+| Property                   | Modifiers | Type                                             | Default | Description                                      |
+|----------------------------|-----------|--------------------------------------------------|---------|--------------------------------------------------|
+| `formState`                |           | `FormState`                                      | {}      |                                                  |
+| `isInitialState`           | readonly  | `boolean`                                        |         | Mostly internal way to determine if a form is in the initial state. |
+| `reset`                    |           |                                                  |         |                                                  |
+| `resetElements`            | readonly  | `HTMLButtonElement[]`                            |         | Getter for internal _resetElements.              |
+| `sharedInputListener`      |           |                                                  |         |                                                  |
+| `sharedValidationListener` |           |                                                  |         |                                                  |
+| `submit`                   |           |                                                  |         |                                                  |
+| `submitElements`           | readonly  | `HTMLButtonElement[]`                            |         | Getter for internal _submitElements.             |
+| `validity`                 | readonly  | `"valid" \| "invalid"`                           |         | Current validity state of the form, based on form element events. |
+| `value`                    | readonly  | `Record<string, string \| number \| boolean \| string[] \| null>` |         | Reduce the form value into a key-value pair.<br /><br />NOTE: form keys use `name` first, and `id` second if `name` is not available.<br />This follows standard HTML5 form behavior - submission uses `name` by default when creating<br />the FormData object. |
 
 ## Methods
 
@@ -33,6 +35,8 @@ The auro-form element provides users a way to ... (it would be great if you fill
 | `queryAuroElements`         | `(): NodeList`                    | Construct the query strings from elements, append them together, execute, and return the NodeList. |
 | `reset`                     | `(): void`                        | Reset fires an event called `reset` - just as you would expect from a normal form. |
 | `setDisabledStateOnButtons` | `(): void`                        |                                                  |
+| `sharedInputListener`       | `(event: Event): void`            | Shared input listener for all form elements.<br /><br />**event**: The event that is fired from the form element. |
+| `sharedValidationListener`  | `(event: Event): void`            | Shared validation listener for all form elements.<br /><br />**event**: The event that is fired from the form element. |
 | `submit`                    | `(): void`                        | Submit fires an event called `submit` - just as you would expect from a normal form. |
 
 ## Events

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -77,7 +77,11 @@ export class AuroForm extends LitElement {
       'auro-input',
       'auro-select',
       'auro-datepicker',
+      // checkbox and radio are grouped elements
       'auro-checkbox-group',
+      'auro-radio-group',
+      // while counter is groupable, the group is for min/max values and not for grouped values
+      'auro-counter',
     ];
   }
 
@@ -271,7 +275,7 @@ export class AuroForm extends LitElement {
     }
 
     this.formState[targetName] = {
-      value: element.getAttribute('value'),
+      value: element.value || element.getAttribute('value'),
       validity: element.validity || null,
       required: element.hasAttribute('required'),
       // element

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -119,6 +119,18 @@ export class AuroForm extends LitElement {
     return this._isInElementCollection(AuroForm.formElementTags, element);
   }
 
+  /**
+   * Validates if an event is from a valid form element with a name.
+   * @param {Event} event - The event to validate.
+   * @returns {boolean} - True if event is valid for processing.
+   * @private
+   */
+  _eventIsValidFormEvent(event) {
+    const targetName = event.target.getAttribute("name");
+    return this.isFormElement(event.target) && targetName;
+  }
+
+
   static get buttonElementTags() {
     return [
       'button',
@@ -394,7 +406,7 @@ export class AuroForm extends LitElement {
     const targetName = event.target.getAttribute("name");
 
     // This should only happen if some bubble-up event is fired from inside a form element.
-    if (!this.isFormElement(event.target) || !targetName) {
+    if (!this._eventIsValidFormEvent(event)) {
       return;
     }
 
@@ -419,7 +431,7 @@ export class AuroForm extends LitElement {
    */
   sharedValidationListener(event) {
     const targetName = event.target.getAttribute("name");
-    if (!this.isFormElement(event.target) || !targetName) {
+    if (!this._eventIsValidFormEvent(event)) {
       return;
     }
 
@@ -466,7 +478,8 @@ export class AuroForm extends LitElement {
 
   onSlotChange() {
     this.initializeState();
-    // this._attachEventListeners();
+    // Safe to call as we remove and re-add event listeners
+    this._attachEventListeners();
   }
 
   // function that renders the HTML and CSS into the scope of the component

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -77,6 +77,7 @@ export class AuroForm extends LitElement {
       'auro-input',
       'auro-select',
       'auro-datepicker',
+      'auro-combobox',
       // checkbox and radio are grouped elements
       'auro-checkbox-group',
       'auro-radio-group',

--- a/components/form/test/auro-form-interactions.test.js
+++ b/components/form/test/auro-form-interactions.test.js
@@ -189,7 +189,7 @@ describe('auro-form', () => {
 
     useSharedTestBehavior('auro-counter-group', componentTemplate);
 
-    it('should store counter value as a number', async () => {
+    it('should store counter group value as an object', async () => {
       const form = await fixture(componentTemplate);
       const [counterGroup] = form._elements;
       const someNumber = 5;

--- a/components/form/test/auro-form-interactions.test.js
+++ b/components/form/test/auro-form-interactions.test.js
@@ -145,4 +145,34 @@ describe('auro-form', () => {
       await expect(form.value.testGroup).to.equal('yes');
     });
   });
+
+  describe('when an auro-combobox is present', () => {
+    const componentTemplate = html`
+      <auro-form>
+        <auro-combobox name="comboTest">
+          <span slot="label">Name</span>
+          <auro-menu>
+            <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+            <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+            <auro-menuoption value="Peaches" id="option-2">Peaches</auro-menuoption>
+            <auro-menuoption value="Grapes" id="option-3">Grapes</auro-menuoption>
+            <auro-menuoption value="Cherries" id="option-4">Cherries</auro-menuoption>
+            <auro-menuoption static nomatch>No matching option</auro-menuoption>
+          </auro-menu>
+        </auro-combobox>
+      </auro-form>
+    `;
+
+    useSharedTestBehavior('auro-combobox', componentTemplate);
+
+    it('should store combobox value as a string array', async () => {
+      const form = await fixture(componentTemplate);
+      const [combobox] = form._elements;
+
+      combobox.input.value = 'Oranges';
+
+      await elementUpdated(form);
+      await expect(form.value.comboTest).to.deep.equal(['Oranges']);
+    });
+  });
 });

--- a/components/form/test/auro-form-interactions.test.js
+++ b/components/form/test/auro-form-interactions.test.js
@@ -175,4 +175,30 @@ describe('auro-form', () => {
       await expect(form.value.comboTest).to.deep.equal(['Oranges']);
     });
   });
+
+  describe('when an auro-counter-group is present', () => {
+    const componentTemplate = html`
+      <auro-form>
+        <auro-counter-group name="someCounterGroup" isDropdown>
+          <auro-counter name="shortLabel">
+            Short label
+          </auro-counter>
+        </auro-counter-group>
+      </auro-form>
+    `;
+
+    useSharedTestBehavior('auro-counter-group', componentTemplate);
+
+    it('should store counter value as a number', async () => {
+      const form = await fixture(componentTemplate);
+      const [counterGroup] = form._elements;
+      const someNumber = 5;
+
+      counterGroup.counters[0].increment(someNumber);
+
+      await elementUpdated(counterGroup);
+      await elementUpdated(form);
+      await expect(form.value.someCounterGroup).to.deep.equal({ shortLabel: someNumber });
+    });
+  });
 });

--- a/components/form/test/auro-form-interactions.test.js
+++ b/components/form/test/auro-form-interactions.test.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-underscore-dangle,max-lines,array-element-newline */
+
+import {fixture, html, expect, elementUpdated} from '@open-wc/testing';
+
+// !AURO ELEMENT REGISTRATION MUST BE DONE BEFORE AURO FORM REGISTRATION! //
+import '../demo/registerDemoDeps.js';
+import '../src/index.js';
+
+/**
+ * Shared tests to dedupe maintenance effort.
+ * @param {string} name - Identifier for naming tests.
+ * @param {*} markup - The HTML markup, including just one form and one form element.
+ */
+function useSharedTestBehavior(name, markup) {
+  const getElement = () => fixture(markup);
+
+  describe(`${name} automatic form behavior`, () => {
+    it.skip('should be accessible', async () => {
+      const form = await getElement();
+      await expect(form).to.be.accessible();
+    });
+
+    it('should get included as an auro form element', async () => {
+      const form = await getElement();
+      await expect(form._elements).to.have.length(1);
+    });
+
+    it('value should be available on form.value via name attribute', async () => {
+      const form = await getElement();
+      const formMemberName = form._elements[0].getAttribute('name');
+
+      await expect(form._elements).to.have.length(1);
+      await expect(form.value).to.have.key(formMemberName);
+    });
+  });
+}
+
+describe('auro-form', () => {
+  describe('when an auro-input is present', () => {
+    useSharedTestBehavior('auro-input', html`
+      <auro-form>
+        <auro-input name="myInput">
+          <span slot="label">Input</span>
+        </auro-input>
+      </auro-form>
+    `);
+  });
+
+  describe('when an auro-checkbox-group is present', () => {
+    const componentTemplate = html`
+      <auro-form>
+        <auro-checkbox-group name="testGroup">
+          <span slot="legend">Form label goes here</span>
+          <auro-checkbox value="value1" id="checkbox-basic1">Checkbox option</auro-checkbox>
+          <auro-checkbox value="value2" id="checkbox-basic2" checked>Checkbox option</auro-checkbox>
+          <auro-checkbox value="value3" id="checkbox-basic3">Checkbox option</auro-checkbox>
+          <auro-checkbox value="value4" id="checkbox-basic4">Checkbox option</auro-checkbox>
+        </auro-checkbox-group>
+      </auro-form>
+    `;
+
+    useSharedTestBehavior('auro-checkbox-group', componentTemplate);
+
+    it('should surface checkbox group values as an array', async () => {
+      const form = await fixture(componentTemplate);
+      const [checkboxGroup] = form._elements;
+
+      await elementUpdated(checkboxGroup);
+      await expect(form.value.testGroup).to.eql(['value2']);
+    });
+  });
+
+  describe('when an auro-datepicker is present', () => {
+    const template = html`
+      <auro-form>
+        <auro-datepicker id="date-example" name="dateExample" required>
+          <span slot="fromLabel">Choose a date</span>
+          <span slot="mobileDateLabel">Choose a date</span>
+        </auro-datepicker>
+      </auro-form>
+    `;
+
+    useSharedTestBehavior('auro-datepicker', template);
+
+    it ('should surface values from datepicker without `range` attribute as a string', async () => {
+      const form = await fixture(template);
+      const [datePicker] = form._elements;
+      const [input] = datePicker.inputList;
+
+      await expect(form.value.dateExample).to.equal(null);
+
+      input.value = '04/03/2023';
+      await elementUpdated(form);
+      await expect(form.value.dateExample).to.equal('04/03/2023');
+    });
+
+    it ('should surface values from datepicker with `range` attribute as a string array', async () => {
+      const form = await fixture(html`
+        <auro-form>
+          <auro-datepicker id="date-example" name="dateExample" range required>
+            <span slot="fromLabel">Choose a date</span>
+            <span slot="mobileDateLabel">Choose a date</span>
+          </auro-datepicker>
+        </auro-form>
+      `);
+      const [datePicker] = form._elements;
+      const [input, input2] = datePicker.inputList;
+
+      await expect(form.value.dateExample).to.equal(null);
+
+      input.value = '04/03/2023';
+      input2.value = '04/04/2023';
+
+      await elementUpdated(form);
+      await expect(form.value.dateExample).to.deep.equal(['04/03/2023', '04/04/2023']);
+    });
+  });
+
+  describe('when an auro-radio-group is present', () => {
+    const componentTemplate = html`
+      <auro-form>
+        <auro-radio-group name="testGroup">
+          <span slot="legend">Form label goes here</span>
+          <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+          <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+          <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        </auro-radio-group>
+      </auro-form>
+    `;
+
+    useSharedTestBehavior('auro-radio-group', componentTemplate);
+
+    // DOES NOT WORK. radio group needs to emit an input event!
+    it.skip('should surface radio group values as a string array', async () => {
+      const form = await fixture(componentTemplate);
+      const [radioGroup] = form._elements;
+      const [radioOne] = [...form.querySelectorAll('auro-radio')];
+
+      await elementUpdated(radioGroup);
+      await expect(form.value.testGroup).to.equal(null);
+
+      await radioOne.click();
+      await elementUpdated(radioGroup);
+
+      await expect(form.value.testGroup).to.equal('yes');
+    });
+  });
+});


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary by Sourcery

Add support for form interactions with auro-combobox, auro-radio-group, and auro-counter-group.  Update the interaction listener to share a single listener across all form elements.

New Features:
- Added support for auro-combobox, auro-radio-group, and auro-counter-group components within auro-form.

Tests:
- Added interaction tests for auro-form.