### PR TITLE
Fix validation not triggering submit button enable

### DIFF
--- a/components/form/docs/api.md
+++ b/components/form/docs/api.md
@@ -41,7 +41,8 @@ The auro-form element provides users a way to ... (it would be great if you fill
 
 ## Events
 
-| Event    | Type                                             |
-|----------|--------------------------------------------------|
-| `reset`  | `CustomEvent<{ previousValue: Record<string, string \| number \| boolean \| string[] \| null>; }>` |
-| `submit` | `CustomEvent<{ value: Record<string, string \| number \| boolean \| string[] \| null>; }>` |
+| Event    | Type                                             | Description                    |
+|----------|--------------------------------------------------|--------------------------------|
+| `change` | `Event`                                          | Fires when form state changes. |
+| `reset`  | `CustomEvent<{ previousValue: Record<string, string \| number \| boolean \| string[] \| null>; }>` |                                |
+| `submit` | `CustomEvent<{ value: Record<string, string \| number \| boolean \| string[] \| null>; }>` |                                |

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -31,6 +31,7 @@ import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/util
  *
  * @attr {Boolean} fixed - Uses fixed pixel values for element shape
  * @attr {String} cssClass - Applies designated CSS class to demo element - you want to delete me!
+ * @event {Event} change - Fires when form state changes.
  */
 
 // build the component class
@@ -330,6 +331,12 @@ export class AuroForm extends LitElement {
       }
     });
 
+    this.dispatchEvent(new Event('change', {
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    }));
+
     // Set enabled/disabled states on buttons
     this.setDisabledStateOnButtons();
   }
@@ -415,13 +422,24 @@ export class AuroForm extends LitElement {
       this._addElementToState(event.target);
     }
 
+    let needsUpdate = false;
     // Check special input types and handle their edge cases
     if (this._isElementTag('auro-datepicker', event.target) && event.target.hasAttribute('range')) {
       this.formState[targetName].value = event.target.values;
-      this.requestUpdate('formState');
+
+      needsUpdate = true;
     } else {
       this.formState[targetName].value = event.target.value;
+      needsUpdate = true;
+    }
+
+    if (needsUpdate) {
       this.requestUpdate('formState');
+      this.dispatchEvent(new CustomEvent('change', {
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      }));
     }
   }
 
@@ -441,6 +459,7 @@ export class AuroForm extends LitElement {
 
     this.formState[targetName].validity = event.detail.validity;
     this._calculateValidity();
+    this.requestUpdate('formState');
   }
 
   _attachEventListeners() {

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -422,25 +422,19 @@ export class AuroForm extends LitElement {
       this._addElementToState(event.target);
     }
 
-    let needsUpdate = false;
     // Check special input types and handle their edge cases
     if (this._isElementTag('auro-datepicker', event.target) && event.target.hasAttribute('range')) {
       this.formState[targetName].value = event.target.values;
-
-      needsUpdate = true;
     } else {
       this.formState[targetName].value = event.target.value;
-      needsUpdate = true;
     }
 
-    if (needsUpdate) {
-      this.requestUpdate('formState');
-      this.dispatchEvent(new CustomEvent('change', {
-        bubbles: true,
-        composed: true,
-        cancelable: true
-      }));
-    }
+    this.requestUpdate('formState');
+    this.dispatchEvent(new CustomEvent('change', {
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    }));
   }
 
   /**


### PR DESCRIPTION
# Alaska Airlines Pull Request

I originally thought this was a datepicker issue, but it's more like combobox was firing events in an order that form didn't explicitly handle (form was brittle).

Form now explicitly requests an update when setting validity state, so we no longer have to worry about input/validation events coming in through unexpected orders. Order doesn't matter :)

Closes #318 

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**