### PR TITLE
fix: use versioningTag for `auro-helptext`

### DIFF
--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -96,7 +96,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-checkbox@2.0.0-beta.42/dist/auro-checkbox__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-checkbox@2.0.0-beta.45/dist/auro-checkbox__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-checkbox use cases

--- a/components/checkbox/package.json
+++ b/components/checkbox/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "build": "run-s sass bundler types build:docs",
+    "build:version": "node ./scripts/version.mjs",
     "sass": "run-s build:sass postCss:component sass:render",
     "build:sass": "sass --no-source-map --load-path=../../node_modules \"./src/styles/:./src/styles/\"",
     "build:watch": "nodemon -e scss,js --watch src --ignore \"*.css\" --ignore \"*-css.js\" --exec \"npm run build\"",

--- a/components/checkbox/scripts/version.mjs
+++ b/components/checkbox/scripts/version.mjs
@@ -1,4 +1,3 @@
 import { writeDepVersionFile } from '@auro-formkit/build-tools/formVersionWriter';
 
 await writeDepVersionFile('@aurodesignsystem/auro-helptext');
-await writeDepVersionFile('@aurodesignsystem/auro-icon');

--- a/components/checkbox/src/auro-checkbox-group.js
+++ b/components/checkbox/src/auro-checkbox-group.js
@@ -3,20 +3,23 @@
 
 // ---------------------------------------------------------------------
 
-/* eslint-disable max-lines */
+/* eslint-disable max-lines, lit/binding-positions, lit/no-invalid-html */
 
-import { LitElement, html } from "lit";
+import { LitElement } from "lit";
+import { html } from 'lit/static-html.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import AuroFormValidation from '@auro-formkit/form-validation';
 import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
+import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
 
 // Import the processed CSS file into the scope of the component
 import styleCss from "./styles/auro-checkbox-group-css.js";
 import colorCss from "./styles/colorGroup-css.js";
 import tokensCss from "./styles/tokens-css.js";
 
-import '@aurodesignsystem/auro-helptext';
+import { AuroHelpText } from '@aurodesignsystem/auro-helptext';
+import helpTextVersion from './helptextVersion.js';
 
 /**
  * The auro-checkbox-group element is a wrapper for auro-checkbox element.
@@ -60,6 +63,16 @@ export class AuroCheckboxGroup extends LitElement {
      * @private
      */
     this.runtimeUtils = new AuroLibraryRuntimeUtils();
+
+    /**
+     * Generate unique names for dependency components.
+     */
+    const versioning = new AuroDependencyVersioning();
+
+    /**
+     * @private
+     */
+    this.helpTextTag = versioning.generateTag('auro-helptext', helpTextVersion, AuroHelpText);
   }
 
   static get styles() {
@@ -357,13 +370,13 @@ export class AuroCheckboxGroup extends LitElement {
 
       ${!this.validity || this.validity === undefined || this.validity === 'valid'
         ? html`
-          <auro-helptext large part="helpText">
+          <${this.helpTextTag} large part="helpText">
             <slot name="helpText"></slot>
-          </auro-helptext>`
+          </${this.helpTextTag}>`
         : html`
-          <auro-helptext error large role="alert" aria-live="assertive" part="helpText">
+          <${this.helpTextTag} error large role="alert" aria-live="assertive" part="helpText">
             ${this.errorMessage}
-          </auro-helptext>`
+          </${this.helpTextTag}>`
       }
     `;
   }

--- a/components/checkbox/src/helptextVersion.js
+++ b/components/checkbox/src/helptextVersion.js
@@ -1,0 +1,1 @@
+export default '1.0.0';

--- a/components/combobox/README.md
+++ b/components/combobox/README.md
@@ -101,10 +101,10 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@6.0.0/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.42/dist/auro-dropdown__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.42/dist/auro-input__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.42/dist/auro-menu__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-combobox@2.0.0-beta.42/dist/auro-combobox__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.45/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.45/dist/auro-input__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.45/dist/auro-menu__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-combobox@2.0.0-beta.45/dist/auro-combobox__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-combobox use cases

--- a/components/counter/README.md
+++ b/components/counter/README.md
@@ -100,7 +100,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-counter@2.0.0-beta.42/dist/auro-counter__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-counter@2.0.0-beta.45/dist/auro-counter__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-counter use cases

--- a/components/datepicker/README.md
+++ b/components/datepicker/README.md
@@ -93,10 +93,10 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@6.0.0/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.42/dist/auro-dropdown__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.42/dist/auro-input__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-popover@2.0.0-beta.42/dist/auro-popover__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-datepicker@2.0.0-beta.42/dist/auro-datepicker__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.45/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.45/dist/auro-input__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-popover@2.0.0-beta.45/dist/auro-popover__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-datepicker@2.0.0-beta.45/dist/auro-datepicker__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-datepicker use cases

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -97,7 +97,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.42/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.45/dist/auro-dropdown__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-dropdown use cases

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -24,7 +24,8 @@ import styleCss from "./styles/style-css.js";
 import colorCss from "./styles/color-css.js";
 import tokensCss from "./styles/tokens-css.js";
 
-import '@aurodesignsystem/auro-helptext';
+import { AuroHelpText } from '@aurodesignsystem/auro-helptext';
+import helpTextVersion from './helptextVersion.js';
 
 /**
  * @attr { Boolean } disableEventShow - If declared, the dropdown will only show by calling the API .show() public method.
@@ -128,6 +129,11 @@ export class AuroDropdown extends LitElement {
      * @private
      */
     this.dropdownBibTag = versioning.generateTag('auro-dropdownbib', dropdownVersion, AuroDropdownBib);
+
+    /**
+     * @private
+     */
+    this.helpTextTag = versioning.generateTag('auro-helptext', helpTextVersion, AuroHelpText);
   }
 
   /**
@@ -565,9 +571,9 @@ export class AuroDropdown extends LitElement {
               </div>
             ` : undefined }
         </div>
-        <auro-helptext part="helpText" ?error="${this.error}">
+        <${this.helpTextTag} part="helpText" ?error="${this.error}">
           <slot name="helpText"></slot>
-        </auro-helptext>
+        </${this.helpTextTag}>
         <div class="slotContent">
           <slot @slotchange="${this.handleDefaultSlot}"></slot>
         </div>

--- a/components/dropdown/src/helptextVersion.js
+++ b/components/dropdown/src/helptextVersion.js
@@ -1,0 +1,1 @@
+export default '1.0.0';

--- a/components/form/README.md
+++ b/components/form/README.md
@@ -98,7 +98,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-form@2.0.0-beta.42/dist/auro-form__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-form@2.0.0-beta.45/dist/auro-form__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-form use cases

--- a/components/form/docs/api.md
+++ b/components/form/docs/api.md
@@ -16,6 +16,7 @@ The auro-form element provides users a way to ... (it would be great if you fill
 | `formState`                |           | `FormState`                                      | {}      |                                                  |
 | `isInitialState`           | readonly  | `boolean`                                        |         | Mostly internal way to determine if a form is in the initial state. |
 | `mutationEventListener`    |           |                                                  |         |                                                  |
+| `mutationObservers`        |           | `MutationObserver[]`                             | []      |                                                  |
 | `reset`                    |           |                                                  |         |                                                  |
 | `resetElements`            | readonly  | `HTMLButtonElement[]`                            |         | Getter for internal _resetElements.              |
 | `sharedInputListener`      |           |                                                  |         |                                                  |
@@ -33,7 +34,7 @@ The auro-form element provides users a way to ... (it would be great if you fill
 | `isButtonElement`           | `(element: HTMLElement): boolean` | Check if the tag name is a button element.<br /><br />**element**: The element to check. |
 | `isFormElement`             | `(element: HTMLElement): boolean` | Check if the tag name is a form element.<br /><br />**element**: The element to check (attr or tag name). |
 | `mutationEventListener`     | `(): void`                        | Mutation observer for form elements. Slot change does not trigger unless<br />root-level elements are added/removed. This is a workaround to ensure<br />nested form elements are also observed. |
-| `onSlotChange`              | `(event: any): void`              |                                                  |
+| `onSlotChange`              | `(event: Event): void`            | Slot change event listener. This is the main entry point for the form element.<br /><br />**event**: The slot change event. |
 | `queryAuroElements`         | `(): NodeList`                    | Construct the query strings from elements, append them together, execute, and return the NodeList. |
 | `reset`                     | `(): void`                        | Reset fires an event called `reset` - just as you would expect from a normal form. |
 | `setDisabledStateOnButtons` | `(): void`                        |                                                  |

--- a/components/helptext/src/auro-helptext.js
+++ b/components/helptext/src/auro-helptext.js
@@ -23,6 +23,8 @@ export class AuroHelpText extends LitElement {
 
     this.error = false;
     this.hasTextContent = false;
+
+    AuroLibraryRuntimeUtils.prototype.handleComponentTagRename(this, 'auro-helptext');
   }
 
   static get styles() {

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -89,7 +89,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.42/dist/auro-input__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-input@2.0.0-beta.45/dist/auro-input__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-input use cases

--- a/components/input/scripts/version.mjs
+++ b/components/input/scripts/version.mjs
@@ -2,3 +2,4 @@ import { writeDepVersionFile } from '@auro-formkit/build-tools/formVersionWriter
 
 await writeDepVersionFile('@aurodesignsystem/auro-icon');
 await writeDepVersionFile('@aurodesignsystem/auro-button');
+await writeDepVersionFile('@aurodesignsystem/auro-helptext');

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -20,7 +20,8 @@ import iconVersion from './iconVersion.js';
 import { AuroButton } from '@aurodesignsystem/auro-button/src/auro-button.js';
 import buttonVersion from './buttonVersion.js';
 
-import '@aurodesignsystem/auro-helptext';
+import { AuroHelpText } from '@aurodesignsystem/auro-helptext';
+import helpTextVersion from './helptextVersion.js';
 
 // build the component class
 export class AuroInput extends BaseInput {
@@ -41,6 +42,11 @@ export class AuroInput extends BaseInput {
      * @private
      */
     this.buttonTag = versioning.generateTag('auro-button', buttonVersion, AuroButton);
+
+    /**
+     * @private
+     */
+    this.helpTextTag = versioning.generateTag('auro-helptext', helpTextVersion, AuroHelpText);
   }
 
   /**
@@ -230,18 +236,18 @@ export class AuroInput extends BaseInput {
       <!-- Help text and error message template -->
         ${!this.validity || this.validity === undefined || this.validity === 'valid'
         ? html`
-        <auro-helptext>
+        <${this.helpTextTag}>
           <p id="${this.uniqueId}" part="helpText">
             <slot name="helptext">${this.getHelpText(this.type)}</slot>
           </p>
-        </auro-helptext>
+        </${this.helpTextTag}>
         `
         : html`
-        <auro-helptext error>
+        <${this.helpTextTag} error>
           <p id="${this.uniqueId}" role="alert" aria-live="assertive" part="helpText">
             ${this.errorMessage}
           </p>
-        </auro-helptext>
+        </${this.helpTextTag}>
         `
         }
     `;

--- a/components/input/src/helptextVersion.js
+++ b/components/input/src/helptextVersion.js
@@ -1,0 +1,1 @@
+export default '1.0.0';

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -100,7 +100,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.42/dist/auro-menu__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.45/dist/auro-menu__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-menu use cases

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -90,7 +90,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-radio@2.0.0-beta.42/dist/auro-radio__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-radio@2.0.0-beta.45/dist/auro-radio__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-radio use cases

--- a/components/radio/package.json
+++ b/components/radio/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "build": "run-s sass bundler types build:docs",
+    "build:version": "node ./scripts/version.mjs",
     "sass": "run-s build:sass postCss:component sass:render",
     "build:sass": "sass --no-source-map --load-path=../../node_modules \"./src/styles/:./src/styles/\"",
     "build:watch": "nodemon -e scss,js --watch src --ignore \"*.css\" --ignore \"*-css.js\" --exec \"npm run build\"",

--- a/components/radio/scripts/version.mjs
+++ b/components/radio/scripts/version.mjs
@@ -1,4 +1,3 @@
 import { writeDepVersionFile } from '@auro-formkit/build-tools/formVersionWriter';
 
 await writeDepVersionFile('@aurodesignsystem/auro-helptext');
-await writeDepVersionFile('@aurodesignsystem/auro-icon');

--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -2,7 +2,8 @@
 // See LICENSE in the project root for license information.
 // ---------------------------------------------------------------------
 
-import { LitElement, html } from "lit";
+import { LitElement } from "lit";
+import { html } from "lit/static-html.js";
 import { classMap } from 'lit/directives/class-map.js';
 
 // Import touch detection lib
@@ -18,11 +19,13 @@ import AuroFormValidation from '@auro-formkit/form-validation';
 
 // Import library runtime utils
 import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
+import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
 
-import '@aurodesignsystem/auro-helptext';
+import { AuroHelpText } from '@aurodesignsystem/auro-helptext';
+import helpTextVersion from './helptextVersion.js';
 
 /* eslint no-magic-numbers: ["error", { "ignore": [0, 1, -1] }] */
-/* eslint-disable max-lines */
+/* eslint-disable max-lines, lit/binding-positions, lit/no-invalid-html */
 
 /**
  * @attr {String} validity - Specifies the `validityState` this element is in.
@@ -70,6 +73,16 @@ export class AuroRadioGroup extends LitElement {
      * @private
      */
     this.runtimeUtils = new AuroLibraryRuntimeUtils();
+
+    /**
+     * Generate unique names for dependency components.
+     */
+    const versioning = new AuroDependencyVersioning();
+
+    /**
+     * @private
+     */
+    this.helpTextTag = versioning.generateTag('auro-helptext', helpTextVersion, AuroHelpText);
   }
 
   static get styles() {
@@ -438,13 +451,13 @@ export class AuroRadioGroup extends LitElement {
 
       ${!this.validity || this.validity === undefined || this.validity === 'valid'
         ? html`
-          <auro-helptext large part="helpText">
+          <${this.helpTextTag} large part="helpText">
             <slot name="helpText"></slot>
-          </auro-helptext>`
+          </${this.helpTextTag}>`
         : html`
-          <auro-helptext large role="alert" error aria-live="assertive" part="helpText">
+          <${this.helpTextTag} large role="alert" error aria-live="assertive" part="helpText">
             ${this.errorMessage}
-          </auro-helptext>`
+          </${this.helpTextTag}>`
       }
     `;
   }

--- a/components/radio/src/helptextVersion.js
+++ b/components/radio/src/helptextVersion.js
@@ -1,0 +1,1 @@
+export default '1.0.0';

--- a/components/select/README.md
+++ b/components/select/README.md
@@ -99,9 +99,9 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <!-- The below content is automatically added from ../../docs/templates/componentBundleUseModBrowsers.md -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@4.13.0/dist/tokens/CSSCustomProperties.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@5.1.2/dist/bundled/essentials.css" />
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.42/dist/auro-dropdown__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.42/dist/auro-menu__bundled.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-select@2.0.0-beta.42/dist/auro-select__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-dropdown@2.0.0-beta.45/dist/auro-dropdown__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-menu@2.0.0-beta.45/dist/auro-menu__bundled.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit/auro-select@2.0.0-beta.45/dist/auro-select__bundled.js" type="module"></script>
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## auro-select use cases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-formkit",
-  "version": "2.0.0-beta.42",
+  "version": "2.0.0-beta.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-formkit",
-      "version": "2.0.0-beta.42",
+      "version": "2.0.0-beta.43",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [


### PR DESCRIPTION
# Alaska Airlines Pull Request


closed #354 

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

This pull request updates the `auro-input`, `auro-checkbox-group`, `auro-radio-group`, and `auro-dropdown` components to use versioning tags for the `auro-helptext` component. This ensures that the correct version of the `auro-helptext` component is used, preventing potential compatibility issues.

Enhancements:
- Use versioning tag for `auro-helptext` in `auro-input`, `auro-checkbox-group`, `auro-radio-group`, and `auro-dropdown` components to ensure consistent component versions.

Build:
- Add `build:version` script to `auro-checkbox` and `auro-radio` package.json files.
- Update component bundle versions in `auro-combobox`, `auro-datepicker`, and `auro-select` README files.

Chores:
- Introduce `helptextVersion.js` files in `auro-checkbox`, `auro-dropdown`, `auro-input`, and `auro-radio` components to manage the version of the `auro-helptext` dependency.