### PR TITLE
feat: fix clear button accessibility

### DIFF
--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -188,8 +188,7 @@ export class AuroInput extends BaseInput {
                 <${this.buttonTag}
                   variant="flat"
                   class="notificationBtn clearBtn"
-                  aria-hidden="true"
-                  tabindex="-1"
+                  aria-label="${i18n(this.lang, 'clearInput')}"
                   @click="${this.handleClickClear}">
                   <${this.iconTag}
                     customColor

--- a/components/input/src/i18n.js
+++ b/components/input/src/i18n.js
@@ -57,7 +57,8 @@ const stringsES = {
   'dateYYMM': 'Ingrese una fecha completa en el formato AA/MM',
   'dateYY': 'Ingrese una fecha completa en el formato AA',
   'dateMM': 'Ingrese una fecha completa en el formato MM',
-  'dateDD': 'Ingrese una fecha completa en el formato DD'
+  'dateDD': 'Ingrese una fecha completa en el formato DD',
+  'clearInput': 'Borrar campo de entrada',
 };
 
 const stringsEN = {
@@ -80,7 +81,8 @@ const stringsEN = {
   'dateYYMM': 'Please enter a complete date in the format YY/MM',
   'dateYY': 'Please enter a complete date in the format YY',
   'dateMM': 'Please enter a complete date in the format MM',
-  'dateDD': 'Please enter a complete date in the format DD'
+  'dateDD': 'Please enter a complete date in the format DD',
+  'clearInput': 'Clear input field',
 };
 
 /**


### PR DESCRIPTION
When clicking the `x` button to clear the values, this error appeared:

> Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users.

The clear button had `aria-hidden="true"` and `tabindex="-1"` set to hide it.

When clicked, the `x` button still gets focus, which was conflicting with being hidden from assistive technology.

**Fix**

Instead of hiding the button, added an `aria-label` with `i18n` translation.

![Screenshot 2025-02-25 at 2 04 13 PM](https://github.com/user-attachments/assets/1d98d941-4561-48d5-8ad9-f2880e3ba809)

## Summary by Sourcery

Bug Fixes:
- Fixes an accessibility issue where the clear button in the input component was causing an error with assistive technologies.