### PR TITLE
fix: move children to cloned node for fullscreen slots to preserve event listener actions

### DIFF
--- a/components/bibtemplate/src/headerVersion.js
+++ b/components/bibtemplate/src/headerVersion.js
@@ -1,1 +1,1 @@
-export default '3.0.0';
+export default '4.0.0';

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -318,7 +318,10 @@ export class AuroCounterGroup extends LitElement {
       this.bibtemplate.querySelectorAll(`[slot="${targetSlot}"]`).forEach((old) => old.remove());
 
       event.target.assignedNodes().forEach((node) => {
-        const clone = node.cloneNode(true);
+        const clone = node.cloneNode();
+        [...node.childNodes].forEach((child) => {
+          clone.append(child);
+        });
         clone.setAttribute('slot', targetSlot);
         this.bibtemplate.append(clone);
       });

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -138,15 +138,7 @@ Running the `dev` command will open a `localhost` development server for all com
 
 To only develop a single component, use the `--filter` flag:
 
+```shell
+npx turbo dev --filter=@aurodesignsystem/auro-input
 ```
-turbo dev --filter=@aurodesignsystem/auro-input
-```
-<!-- AURO-GENERATED-CONTENT:END -->
-
-### Start formkit development environment
-
-<!-- AURO-GENERATED-CONTENT:START (FILE:src=../../docs/partials/localhost.md) -->
-<!-- The below content is automatically added from ../../docs/partials/localhost.md -->
-
-## Local Development
 <!-- AURO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Problem
any event listener to footer element does not get called because the **cloned** element of footer is displaying

## Solution
clone only the root of footer slot and move its children under cloned element so that attached listener can get property called

## Before Submitting this pull request:
- Link all tickets in this repository related to this PR in the `Development` section
_note: all pull requests require at least one linked ticket_
- If this PR is `Ready For Review`, all ticket's linked under `Development` must have their status changed to `Ready For Review` as well

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Fixes an issue where a click event on a cloned node in the auro-counter-group component would not trigger the original node's click method. The fix adds an event listener to the cloned node that calls the original node's click method when the cloned node is clicked.

Bug Fixes:
- Fixes an issue where a click event on a cloned node in the auro-counter-group component would not trigger the original node's click method.

Chores:
- Updates the version of auro-formkit dependencies in several components.