### PR TITLE
docs: add `label` slots to all `auro-select` examples

### DIFF
--- a/components/select/README.md
+++ b/components/select/README.md
@@ -85,6 +85,7 @@ This configuration enables proper module resolution for the component's TypeScri
 ```html
 <auro-select>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>
@@ -110,7 +111,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.1/auro-select/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-select/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/select/apiExamples/basic.html
+++ b/components/select/apiExamples/basic.html
@@ -1,5 +1,6 @@
 <auro-select>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/custom.html
+++ b/components/select/apiExamples/custom.html
@@ -1,6 +1,7 @@
 <custom-select>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/customBibHeight.html
+++ b/components/select/apiExamples/customBibHeight.html
@@ -1,6 +1,7 @@
 <auro-select id="customBibHeightExample">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/customErrorValidity.html
+++ b/components/select/apiExamples/customErrorValidity.html
@@ -1,6 +1,7 @@
 <auro-select id="primaryError">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="1">1</auro-menuoption>
     <auro-menuoption value="2">2</auro-menuoption>

--- a/components/select/apiExamples/disabled.html
+++ b/components/select/apiExamples/disabled.html
@@ -1,6 +1,7 @@
 <auro-select disabled>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">disabled select example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/error.html
+++ b/components/select/apiExamples/error.html
@@ -1,4 +1,5 @@
 <auro-select error="Custom error message">
+  <span slot="label">error select example</span>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
   <auro-menu>

--- a/components/select/apiExamples/errorApi.html
+++ b/components/select/apiExamples/errorApi.html
@@ -4,6 +4,7 @@
 <auro-select id="errorExample" error="Custom error message">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">error Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/flexMenuWidth.html
+++ b/components/select/apiExamples/flexMenuWidth.html
@@ -1,4 +1,5 @@
 <auro-select flexMenuWidth id="flexMenuWidthExample">
+  <span slot="label">flexMenuWidth select example</span>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
   <auro-menu>

--- a/components/select/apiExamples/fullscreenBreakpoint.html
+++ b/components/select/apiExamples/fullscreenBreakpoint.html
@@ -1,4 +1,5 @@
 <auro-select fullscreenBreakpoint="lg">
+  <span slot="label">Select Example</span>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>

--- a/components/select/apiExamples/helpText.html
+++ b/components/select/apiExamples/helpText.html
@@ -2,6 +2,7 @@
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
   <span slot="helpText">Custom help text message.</span>
+  <span slot="label">helpText select example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/multiselect.html
+++ b/components/select/apiExamples/multiselect.html
@@ -1,6 +1,7 @@
 <auro-select multiselect>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Select one or more options</label>
+  <span slot="label">multiselect select example</span>
   <auro-menu>
     <auro-menuoption value="1">Option 1</auro-menuoption>
     <auro-menuoption value="2">Option 2</auro-menuoption>

--- a/components/select/apiExamples/nestedSelect.html
+++ b/components/select/apiExamples/nestedSelect.html
@@ -15,6 +15,7 @@
   <span slot="header">Visible Overflow Dialog</span>
   <div slot="content">
     <auro-select id="nestedSelect">
+      <span slot="label">Nested Select Example</span>
       <auro-menu>
         <auro-menuoption value="stops">Stops</auro-menuoption>
         <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/noCheckmark.html
+++ b/components/select/apiExamples/noCheckmark.html
@@ -1,6 +1,7 @@
 <auro-select nocheckmark>
     <span slot="bib.fullscreen.headline">Bib Headline</span>
     <label slot="placeholder">Placeholder Text</label>
+    <span slot="label">nocheckmark Select Example</span>
     <auro-menu>
         <auro-menuoption value="stops">Stops</auro-menuoption>
         <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/presetOption.html
+++ b/components/select/apiExamples/presetOption.html
@@ -1,6 +1,7 @@
 <auro-select>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="Please select an option" selected>Please select an option</auro-menuoption>
     <hr>

--- a/components/select/apiExamples/required.html
+++ b/components/select/apiExamples/required.html
@@ -1,5 +1,6 @@
 <auro-select required setCustomValidityValueMissing="Custom required validation error message.">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">required field</span>
   <label slot="placeholder">Placeholder Text</label>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>

--- a/components/select/apiExamples/valueAlert.html
+++ b/components/select/apiExamples/valueAlert.html
@@ -1,4 +1,5 @@
 <auro-select id="valueAlert">
+  <span slot="label">Select Example</span>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
   <auro-menu id="valueAlertMenu">

--- a/components/select/apiExamples/valueExtraction.html
+++ b/components/select/apiExamples/valueExtraction.html
@@ -1,6 +1,7 @@
 <auro-select id="valueExtraction">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/components/select/apiExamples/withIcons.html
+++ b/components/select/apiExamples/withIcons.html
@@ -1,6 +1,7 @@
 <auro-select>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="air">
       <auro-icon label customColor category="health" name="air">Air</auro-icon>

--- a/components/select/apiExamples/withSubmenus.html
+++ b/components/select/apiExamples/withSubmenus.html
@@ -1,6 +1,7 @@
 <auro-select>
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <label slot="placeholder">Placeholder Text</label>
+  <span slot="label">Select Example</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
     <auro-menuoption value="price">Price</auro-menuoption>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-formkit",
-  "version": "2.0.3-beta.1",
+  "version": "2.1.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-formkit",
-      "version": "2.0.3-beta.1",
+      "version": "2.1.0-beta.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -14,11 +14,11 @@
         "packages/*"
       ],
       "dependencies": {
+        "@aurodesignsystem/auro-library": "^3.0.13",
         "@lit/reactive-element": "^2.0.4",
         "lit": "^3.2.1"
       },
       "devDependencies": {
-        "@aurodesignsystem/auro-library": "^3.0.13",
         "@aurodesignsystem/eslint-config": "^1.3.3",
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adding `label` slots to all `auro-select` examples except placeholder section to show with/without label slot

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adds the `label` slot to most of the `auro-select` examples.

## Summary by Sourcery

Adds the `label` slot to most of the `auro-select` examples to demonstrate its usage.