### PR TITLE
fix: bubble focusable element's focusevent up to `#trigger`

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -635,20 +635,6 @@ export class AuroDatePicker extends LitElement {
       }
     });
 
-    document.activeElement.addEventListener('focusin', () => {
-      // if dropdown is not ready, exit
-      if (!this.dropdown || !this.dropdown.bibContent) {
-        return;
-      }
-
-      if (document.activeElement !== document.querySelector('body') &&
-      !this.contains(document.activeElement) &&
-      !this.dropdown.bibContent.contains(document.activeElement) &&
-      this.dropdown.isPopoverVisible) {
-        this.dropdown.hide();
-      }
-    });
-
     if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
       this.calendar.dateFrom = new Date(this.formattedValue).getTime();
     }

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1004,7 +1004,6 @@ export class AuroDatePicker extends LitElement {
           ?disabled="${this.disabled}"
           ?error="${this.validity !== undefined && this.validity !== 'valid'}"
           disableEventShow
-          noHideOnThisFocusLoss
           fullscreenBreakpoint="sm"
           part="dropdown">
           <div slot="trigger" class="dpTriggerContent" part="trigger">

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines, no-undef, prefer-destructuring, no-use-before-define, no-magic-numbers, no-unused-vars, no-await-in-loop */
 
-import { fixture, html, expect, elementUpdated, nextFrame } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated, nextFrame, oneEvent } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import '../src/registered.js';
 
@@ -90,6 +90,23 @@ describe('auro-datepicker', () => {
 
     await elementUpdated(datepicker);
     await expect(datepicker.dropdown.isPopoverVisible).to.be.false;
+  });
+
+
+  it('hides dropdown the dropdown on blur', async () => {
+    const el = await fixture(html`
+        <auro-datepicker></auro-datepicker>
+    `);
+    
+    el.focus();
+    el.shadowRoot.activeElement.click();
+    await elementUpdated(el);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+    el.blur();
+
+    await oneEvent(el, 'auroDatePicker-toggled');
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
   });
 
   it('handles the required state being set', async () => {

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -134,6 +134,11 @@ export class AuroDropdown extends LitElement {
      * @private
      */
     this.helpTextTag = versioning.generateTag('auro-formkit-dropdown-helptext', helpTextVersion, AuroHelpText);
+
+    /**
+     * @private
+     */
+    this.bubbleUpFocusEvent = this.bubbleUpFocusEvent.bind(this);
   }
 
   /**
@@ -463,6 +468,37 @@ export class AuroDropdown extends LitElement {
   }
 
   /**
+   * @private
+   * Creates and dispatches a duplicate focus event on the trigger element.
+   * @param {Event} event - The original focus event.
+   */
+  bubbleUpFocusEvent(event) {
+    const dupEvent = new FocusEvent(event.type, {
+      bubbles: false,
+      cancelable: false,
+      composed: true,
+    });
+    this.trigger.dispatchEvent(dupEvent);
+  }
+
+  /**
+   * @private
+   * Sets up event listeners to bubble up focus and blur events from nested Auro components within the trigger slot.
+   * This ensures that focus/blur events originating from within these components are propagated to the trigger element itself.
+   */
+  setupTriggerFocusEventBubbleUp() {
+    this.triggerContentSlot.forEach((node) => {
+      if (node.querySelectorAll) {
+        const auroElements = node.querySelectorAll('auro-input, [auro-input], auro-button, [auro-button], button, input');
+        auroElements.forEach((auroEl) => {
+          auroEl.addEventListener('focus', this.bubbleUpFocusEvent);
+          auroEl.addEventListener('blur', this.bubbleUpFocusEvent);
+        });
+      }
+    });
+  }
+
+  /**
    * Handles changes to the trigger content slot and updates related properties.
    *
    * It first updates the floater settings
@@ -501,6 +537,7 @@ export class AuroDropdown extends LitElement {
     }
 
     if (this.triggerContentSlot) {
+      this.setupTriggerFocusEventBubbleUp();
       this.hasTriggerContent = this.triggerContentSlot.some((slot) => {
         if (slot.textContent.trim()) {
           return true;

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -351,6 +351,7 @@ export class AuroDropdown extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.floater.disconnect();
+    this.clearTriggerFocusEventBinding();
   }
 
   updated(changedProperties) {
@@ -493,6 +494,23 @@ export class AuroDropdown extends LitElement {
         auroElements.forEach((auroEl) => {
           auroEl.addEventListener('focus', this.bindFocusEventToTrigger);
           auroEl.addEventListener('blur', this.bindFocusEventToTrigger);
+        });
+      }
+    });
+  }
+
+  /**
+   * Clears focus and blur event listeners from nested Auro components within the trigger slot.
+   * @private
+   * @returns {void}
+   */
+  clearTriggerFocusEventBinding() {
+    this.triggerContentSlot.forEach((node) => {
+      if (node.querySelectorAll) {
+        const auroElements = node.querySelectorAll('auro-input, [auro-input], auro-button, [auro-button], button, input');
+        auroElements.forEach((auroEl) => {
+          auroEl.removeEventListener('focus', this.bindFocusEventToTrigger);
+          auroEl.removeEventListener('blur', this.bindFocusEventToTrigger);
         });
       }
     });

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -138,7 +138,7 @@ export class AuroDropdown extends LitElement {
     /**
      * @private
      */
-    this.bubbleUpFocusEvent = this.bubbleUpFocusEvent.bind(this);
+    this.bindFocusEventToTrigger = this.bindFocusEventToTrigger.bind(this);
   }
 
   /**
@@ -472,7 +472,7 @@ export class AuroDropdown extends LitElement {
    * Creates and dispatches a duplicate focus event on the trigger element.
    * @param {Event} event - The original focus event.
    */
-  bubbleUpFocusEvent(event) {
+  bindFocusEventToTrigger(event) {
     const dupEvent = new FocusEvent(event.type, {
       bubbles: false,
       cancelable: false,
@@ -483,16 +483,16 @@ export class AuroDropdown extends LitElement {
 
   /**
    * @private
-   * Sets up event listeners to bubble up focus and blur events from nested Auro components within the trigger slot.
+   * Sets up event listeners to deliver focus and blur events from nested Auro components within the trigger slot to trigger.
    * This ensures that focus/blur events originating from within these components are propagated to the trigger element itself.
    */
-  setupTriggerFocusEventBubbleUp() {
+  setupTriggerFocusEventBinding() {
     this.triggerContentSlot.forEach((node) => {
       if (node.querySelectorAll) {
         const auroElements = node.querySelectorAll('auro-input, [auro-input], auro-button, [auro-button], button, input');
         auroElements.forEach((auroEl) => {
-          auroEl.addEventListener('focus', this.bubbleUpFocusEvent);
-          auroEl.addEventListener('blur', this.bubbleUpFocusEvent);
+          auroEl.addEventListener('focus', this.bindFocusEventToTrigger);
+          auroEl.addEventListener('blur', this.bindFocusEventToTrigger);
         });
       }
     });
@@ -537,7 +537,7 @@ export class AuroDropdown extends LitElement {
     }
 
     if (this.triggerContentSlot) {
-      this.setupTriggerFocusEventBubbleUp();
+      this.setupTriggerFocusEventBinding();
       this.hasTriggerContent = this.triggerContentSlot.some((slot) => {
         if (slot.textContent.trim()) {
           return true;


### PR DESCRIPTION
# Alaska Airlines Pull Request

- bubble up focusable element in #trigger upto #trigger 
- adding test to check datepicker gets closed on `blur` action
- remove `noHideOnThisFocusLoss` attr on datepicker

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve focus event handling for dropdown and datepicker components by bubbling up focus events and enhancing blur behavior

New Features:
- Create method to duplicate and dispatch focus events on trigger element

Bug Fixes:
- Fix focus event propagation for nested focusable elements within dropdown trigger

Enhancements:
- Implement event listener to bubble up focus and blur events from nested Auro components
- Modify datepicker dropdown close behavior on blur

Tests:
- Add test to verify dropdown closes on blur action