### PR TITLE
Move host styles to div to prevent tailwindcss from overriding the padding

### DIFF
--- a/components/bibtemplate/src/iconVersion.js
+++ b/components/bibtemplate/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '6.1.2';
+export default '7.0.1';

--- a/components/combobox/README.md
+++ b/components/combobox/README.md
@@ -111,7 +111,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-combobox/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-combobox/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/counter/README.md
+++ b/components/counter/README.md
@@ -110,7 +110,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-counter/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-counter/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/counter/src/auro-counter-wrapper.js
+++ b/components/counter/src/auro-counter-wrapper.js
@@ -42,7 +42,7 @@ export class AuroCounterWrapper extends LitElement {
 
   // function that renders the HTML and CSS into the scope of the component
   render() {
-    return html`<slot></slot>`;
+    return html`<div class="wrapper"><slot></slot></div>`;
   }
 }
 

--- a/components/counter/src/iconVersion.js
+++ b/components/counter/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '6.1.2';
+export default '7.0.1';

--- a/components/counter/src/styles/counter-wrapper.scss
+++ b/components/counter/src/styles/counter-wrapper.scss
@@ -12,7 +12,7 @@
 
 /* stylelint-disable no-descending-specificity, selector-max-attribute, selector-nest-combinators */
 
-:host {
+.wrapper {
   display: flex;
   flex-direction: column;
   gap: var(--ds-size-300, $ds-size-300);
@@ -25,5 +25,7 @@
 }
 
 :host([isindropdown]) {
-  padding: var(--ds-size-300, $ds-size-300);
+  .wrapper {
+    padding: var(--ds-size-300, $ds-size-300);
+  }
 }

--- a/components/datepicker/README.md
+++ b/components/datepicker/README.md
@@ -104,7 +104,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-datepicker/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-datepicker/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -107,7 +107,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-dropdown/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-dropdown/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/form/README.md
+++ b/components/form/README.md
@@ -109,7 +109,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-form/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-form/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -99,7 +99,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-input/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-input/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -110,7 +110,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-menu/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-menu/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/menu/src/iconVersion.js
+++ b/components/menu/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '6.1.2';
+export default '7.0.1';

--- a/components/select/README.md
+++ b/components/select/README.md
@@ -111,7 +111,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.3/auro-select/+esm"></script>
+<script type="module "src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@2.1.0-beta.4/auro-select/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Modify counter component styling and update package version references to prevent Tailwind CSS from overriding padding

Bug Fixes:
- Prevent Tailwind CSS from overriding component padding by moving styles from :host to a wrapper div

Enhancements:
- Refactor counter component to use a wrapper div for more predictable styling

Chores:
- Update package version references from 2.1.0-beta.3 to 2.1.0-beta.4 across multiple components