### PR TITLE
Radio group now only queries for radio elements

### DIFF
--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -100,7 +100,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.0.1/auro-radio/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.3.0-beta.1/auro-radio/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/radio/apiExamples/accordionExample.html
+++ b/components/radio/apiExamples/accordionExample.html
@@ -1,13 +1,13 @@
 <auro-radio-group>
   <span slot="legend">Accordion Test</span>
-  <auro-radio id="basicGroupRadio1" label="Credit or debit card" name="radioDemo" value="yes"></auro-radio>
-  <auro-radio id="basicGroupRadio2" label="Apple Pay" name="radioDemo" value="no"></auro-radio>
-  <auro-radio id="basicGroupRadio2" label="Alaska Airlines Commercial Account" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="basicGroupRadio1" label="Credit or debit card" name="creditordebit" value="yes"></auro-radio>
+  <auro-radio id="basicGroupRadio2" label="Apple Pay" name="applePay" value="no"></auro-radio>
+  <auro-radio id="basicGroupRadio3" label="Alaska Airlines Commercial Account" name="alaskaCommercial" value="no"></auro-radio>
   <div>
     <auro-accordion>
       <span slot="trigger">More payment options</span>
-      <auro-radio id="basicGroupRadio4" label="Click to pay" name="radioDemoA" value="testinga"></auro-radio>
-      <auro-radio id="basicGroupRadio4" label="Google Pay" name="radioDemoA" value="testingb"></auro-radio>
+      <auro-radio id="basicGroupRadio4" label="Click to pay" name="radioDemoA" value="manualCredit"></auro-radio>
+      <auro-radio id="basicGroupRadio5" label="Google Pay" name="radioDemoA" value="googlePay"></auro-radio>
     </auro-accordion>
   </div>
 </auro-radio-group>

--- a/components/radio/apiExamples/accordionExample.html
+++ b/components/radio/apiExamples/accordionExample.html
@@ -1,0 +1,13 @@
+<auro-radio-group>
+  <span slot="legend">Accordion Test</span>
+  <auro-radio id="basicGroupRadio1" label="Credit or debit card" name="radioDemo" value="yes"></auro-radio>
+  <auro-radio id="basicGroupRadio2" label="Apple Pay" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="basicGroupRadio2" label="Alaska Airlines Commercial Account" name="radioDemo" value="no"></auro-radio>
+  <div>
+    <auro-accordion>
+      <span slot="trigger">More payment options</span>
+      <auro-radio id="basicGroupRadio4" label="Click to pay" name="radioDemoA" value="testinga"></auro-radio>
+      <auro-radio id="basicGroupRadio4" label="Google Pay" name="radioDemoA" value="testingb"></auro-radio>
+    </auro-accordion>
+  </div>
+</auro-radio-group>

--- a/components/radio/apiExamples/accordionExample.html
+++ b/components/radio/apiExamples/accordionExample.html
@@ -1,13 +1,11 @@
 <auro-radio-group>
   <span slot="legend">Accordion Test</span>
-  <auro-radio id="basicGroupRadio1" label="Credit or debit card" name="creditordebit" value="yes"></auro-radio>
-  <auro-radio id="basicGroupRadio2" label="Apple Pay" name="applePay" value="no"></auro-radio>
-  <auro-radio id="basicGroupRadio3" label="Alaska Airlines Commercial Account" name="alaskaCommercial" value="no"></auro-radio>
-  <div>
-    <auro-accordion>
-      <span slot="trigger">More payment options</span>
-      <auro-radio id="basicGroupRadio4" label="Click to pay" name="radioDemoA" value="manualCredit"></auro-radio>
-      <auro-radio id="basicGroupRadio5" label="Google Pay" name="radioDemoA" value="googlePay"></auro-radio>
-    </auro-accordion>
-  </div>
+  <auro-radio id="basicGroupRadio1" label="Credit or debit card" name="creditordebit" value="credit"></auro-radio>
+  <auro-radio id="basicGroupRadio2" label="Apple Pay" name="applePay" value="applePay"></auro-radio>
+  <auro-radio id="basicGroupRadio3" label="Alaska Airlines Commercial Account" name="alaskaCommercial" value="alaskaCommercial"></auro-radio>
+  <auro-accordion>
+    <span slot="trigger">More payment options</span>
+    <auro-radio id="basicGroupRadio4" label="Click to pay" name="manualCredit" value="manualCredit"></auro-radio>
+    <auro-radio id="basicGroupRadio5" label="Google Pay" name="googlePay" value="googlePay"></auro-radio>
+  </auro-accordion>
 </auro-radio-group>

--- a/components/radio/docs/partials/index.md
+++ b/components/radio/docs/partials/index.md
@@ -69,3 +69,21 @@ This is a default configuration using the `<auro-radio-group>` and `<auro-radio>
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/onDarkGroup.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
+
+### Accordion Nested Group
+
+This example shows how to use `<auro-accordion>` with the `<auro-radio-group>` and `<auro-radio>` elements for
+nested/optional groups (such as a "More Options" section in a payment processor).
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/accordionExample.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/accordionExample.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>

--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -301,7 +301,7 @@ export class AuroRadioGroup extends LitElement {
    * @returns {void}
    */
   handleItems() {
-    this.items = [...this.querySelectorAll(':scope > *:not([slot])')];
+    this.items = [...this.querySelectorAll(':scope auro-radio, :scope [auro-radio]')];
     this.initializeIndex();
 
     if (this.disabled) {

--- a/components/radio/test/auro-radio.test.js
+++ b/components/radio/test/auro-radio.test.js
@@ -202,31 +202,60 @@ describe('auro-radio-group', () => {
   });
 
   it('expect radio group to pick up nested elements', async () => {
-    const el = await fixture(html`
+    const radioGroup = await fixture(html`
       <auro-radio-group name="group">
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo1" value="yes"></auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo2" value="no"></auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo3" value="maybe"></auro-radio>
 
         <div>
-          <auro-radio id="radio4" label="Yes" name="radioDemo" value="yes"></auro-radio>
+          <auro-radio id="radio4" label="Yes 2" name="radioDemo4" value="yes2"></auro-radio>
         </div>
 
         <div>
           <div>
-            <auro-radio id="radio5" label="No" name="radioDemo" value="no"></auro-radio>
+            <auro-radio id="radio5" label="No 2" name="radioDemo5" value="no2"></auro-radio>
           </div>
         </div>
 
-        <auro-radio id="radio6" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio6" label="Maybe 2" name="radioDemo6" value="maybe2"></auro-radio>
       </auro-radio-group>
     `);
 
-    const radioGroup = el;
+    // setup
     const expectedCount = 6;
+    const radio1 = radioGroup.querySelector('#radio1');
+    const radio5 = radioGroup.querySelector('#radio5');
+    const radio4 = radioGroup.querySelector('#radio4');
+    const radio6 = radioGroup.querySelector('#radio6');
 
+    // check that the radio group has the correct number of items
     await expect(radioGroup.items.length).to.equal(expectedCount);
+
+    // no nesting
+    radio1.shadowRoot.querySelector('input').click();
+    await elementUpdated(radioGroup);
+    await expect(radioGroup.value).to.equal('yes');
+    await expect(radioGroup.optionSelected).to.equal(radio1);
+
+    // double nested
+    radio5.shadowRoot.querySelector('input').click();
+    await elementUpdated(radioGroup);
+    await expect(radioGroup.value).to.equal('no2');
+    await expect(radioGroup.optionSelected).to.equal(radio5);
+
+    // single nested
+    radio4.shadowRoot.querySelector('input').click();
+    await elementUpdated(radioGroup);
+    await expect(radioGroup.value).to.equal('yes2');
+    await expect(radioGroup.optionSelected).to.equal(radio4);
+
+    // no nesting, comes after nested elements
+    radio6.shadowRoot.querySelector('input').click();
+    await elementUpdated(radioGroup);
+    await expect(radioGroup.value).to.equal('maybe2');
+    await expect(radioGroup.optionSelected).to.equal(radio6);
   });
 
 });

--- a/components/radio/test/auro-radio.test.js
+++ b/components/radio/test/auro-radio.test.js
@@ -1,4 +1,4 @@
-import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
+import {elementUpdated, expect, fixture, html} from '@open-wc/testing';
 import '../src/registered.js';
 
 describe('auro-radio', () => {
@@ -200,6 +200,35 @@ describe('auro-radio-group', () => {
     await expect(event.target).to.equal(radioGroup);
     await expect(event.target.value).to.equal('yes');
   });
+
+  it('expect radio group to pick up nested elements', async () => {
+    const el = await fixture(html`
+      <auro-radio-group name="group">
+        <span slot="legend">Form label goes here</span>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+
+        <div>
+          <auro-radio id="radio4" label="Yes" name="radioDemo" value="yes"></auro-radio>
+        </div>
+
+        <div>
+          <div>
+            <auro-radio id="radio5" label="No" name="radioDemo" value="no"></auro-radio>
+          </div>
+        </div>
+
+        <auro-radio id="radio6" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+      </auro-radio-group>
+    `);
+
+    const radioGroup = el;
+    const expectedCount = 6;
+
+    await expect(radioGroup.items.length).to.equal(expectedCount);
+  });
+
 });
 
 async function errorFixture() {


### PR DESCRIPTION
Previously, radio-group would pick up ANY non-slot element inside, now, we explicitly query `auro-radio` and `[auro-radio]`.

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Modify radio group to explicitly query for radio elements, improving element selection and nested radio support

New Features:
- Add support for nested radio elements within radio groups

Enhancements:
- Update radio group element selection to only target radio elements

Documentation:
- Update documentation to demonstrate nested radio group usage with accordion

Tests:
- Add test case to verify radio group can handle nested radio elements