### PR TITLE
fix: not to bubble up keydown event when the input is not in bibtemplate

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -610,7 +610,7 @@ export class AuroCombobox extends LitElement {
    */
   bubbleUpInputKeyEvent(event) {
     if (event.currentTarget.parentNode !== this.dropdown) {
-      if (event.key.includes("Arrow")) {
+      if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
         event.preventDefault();
       }
 
@@ -759,7 +759,7 @@ export class AuroCombobox extends LitElement {
       }));
     }
 
-    if (this.optionSelected && this.input.value !== this.optionSelected.textContent) {
+    if (this.optionSelected && this.optionSelected[0] && this.input.value !== this.optionSelected[0].textContent) {
       this.optionSelected = undefined;
       hasChange = true;
     }

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -607,10 +607,7 @@ export class AuroCombobox extends LitElement {
    * @param {KeyboardEvent} event - The keyboard event.
    */
   bubbleUpInputKeyEvent(event) {
-    if (event.currentTarget.parentNode === this.dropdown) {
-      if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-        event.preventDefault();
-      }
+    if (event.currentTarget.parentNode !== this.dropdown) {
       const ke = new KeyboardEvent(event.type, {
         key: event.key,
         code: event.code,

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -490,7 +490,9 @@ export class AuroCombobox extends LitElement {
 
     // this.dropdown.addEventListener('auroDropdown-show', () => {
     this.menuWrapper = this.dropdown.querySelector('.menuWrapper');
-    this.menuWrapper.append(this.menu);
+    if (this.menu) {
+      this.menuWrapper.append(this.menu);
+    }
 
     // setting up bibtemplate
     this.bibtemplate = this.dropdown.querySelector(this.bibtemplateTag._$litStatic$); // eslint-disable-line no-underscore-dangle
@@ -526,7 +528,6 @@ export class AuroCombobox extends LitElement {
    */
   configureMenu() {
     this.menu = this.querySelector('auro-menu, [auro-menu]');
-    this.menu.addEventListener('auroMenu-loadingChange', (event) => this.handleMenuLoadingChange(event));
 
     // a racing condition on custom-combobox with custom-menu
     if (!this.menu) {
@@ -537,6 +538,7 @@ export class AuroCombobox extends LitElement {
       return;
     }
 
+    this.menu.addEventListener('auroMenu-loadingChange', (event) => this.handleMenuLoadingChange(event));
     this.menu.shadowRoot.addEventListener('slotchange', (event) => this.handleSlotChange(event));
 
     if (this.checkmark) {
@@ -608,6 +610,10 @@ export class AuroCombobox extends LitElement {
    */
   bubbleUpInputKeyEvent(event) {
     if (event.currentTarget.parentNode !== this.dropdown) {
+      if (event.key.includes("Arrow")) {
+        event.preventDefault();
+      }
+
       const ke = new KeyboardEvent(event.type, {
         key: event.key,
         code: event.code,

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -652,7 +652,7 @@ function setInputValue(el, value) {
   input.value = value;
   input.dispatchEvent(new InputEvent('input'));
   auroInput.dispatchEvent(new Event('input', {bubbles:true}));
-  auroInput.dispatchEvent(new KeyboardEvent('keyup', {
+  el.dispatchEvent(new KeyboardEvent('keyup', {
     key: value.slice(value.length - 1),
     repeat: false
   }));

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -492,6 +492,12 @@ export class AuroSelect extends LitElement {
     });
   }
 
+  /**
+   * @private
+   * Updates the active option in the menu based on keyboard input.
+   * @param {string} _key - The key pressed by the user.
+   * @returns {void}
+   */
   updateActiveOptionBasedOnKey(_key) {
 
     // Get a lowercase version of the key pressed

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -493,8 +493,8 @@ export class AuroSelect extends LitElement {
   }
 
   /**
-   * @private
    * Updates the active option in the menu based on keyboard input.
+   * @private
    * @param {string} _key - The key pressed by the user.
    * @returns {void}
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-formkit",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-formkit",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [


### PR DESCRIPTION
# Alaska Airlines Pull Request

fixing keyevent to be bubbled up correctly (only when it is in fullscreen bib) - it was coded in the opposite condition.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Modify event handling in combobox and select components to prevent unintended key event bubbling

Bug Fixes:
- Prevent unnecessary key event propagation in combobox input handling
- Adjust event dispatching in test utilities to correctly trigger keyboard events

Enhancements:
- Refine input event management in combobox and select components

## Summary by Sourcery

Fix event handling in combobox component to correctly manage key event bubbling and prevent unintended propagation

Bug Fixes:
- Corrected key event bubbling logic in combobox input handling
- Fixed condition for preventing arrow key default behavior

Enhancements:
- Improved event management in combobox component
- Refined input event handling logic

Chores:
- Updated auro-library dependency to version 4.4.1