### PR TITLE
fix: make `focus` function to focus `input` node

### DIFF
--- a/components/checkbox/docs/api.md
+++ b/components/checkbox/docs/api.md
@@ -58,11 +58,9 @@ Custom element for the purpose of allowing users to select one or more options o
 
 ## Methods
 
-| Method         | Type                 | Description                        |
-|----------------|----------------------|------------------------------------|
-| `handleChange` | `(event: any): void` |                                    |
-| `handleInput`  | `(event: any): void` |                                    |
-| `reset`        | `(): void`           | Resets component to initial state. |
+| Method  | Type       | Description                        |
+|---------|------------|------------------------------------|
+| `reset` | `(): void` | Resets component to initial state. |
 
 ## Events
 

--- a/components/checkbox/src/auro-checkbox.js
+++ b/components/checkbox/src/auro-checkbox.js
@@ -36,6 +36,15 @@ export class AuroCheckbox extends LitElement {
      * @private
      */
     this.runtimeUtils = new AuroLibraryRuntimeUtils();
+
+    /**
+     * @private
+     * @property {boolean} delegatesFocus - Whether the shadow root delegates focus.
+     */
+    this.constructor.shadowRootOptions = {
+      ...LitElement.shadowRootOptions,
+      delegatesFocus: true,
+    };
   }
 
   static get styles() {
@@ -114,8 +123,14 @@ export class AuroCheckbox extends LitElement {
     AuroLibraryRuntimeUtils.prototype.registerComponent(name, AuroCheckbox);
   }
 
-  // This custom event is only for the purpose of supporting IE
-  // .addEventListener('change', function() { })
+  /**
+   * Handles the change event for the checkbox input.
+   * Updates the checked state and dispatches a corresponding custom event.
+   * This custom event is only for the purpose of supporting IE
+   * @private
+   * @param {Event} event - The change event from the checkbox input.
+   * @returns {void}
+   */
   handleChange(event) {
     this.checked = event.target.checked;
     const customEvent = new CustomEvent(event.type, event);
@@ -123,6 +138,13 @@ export class AuroCheckbox extends LitElement {
     this.dispatchEvent(customEvent);
   }
 
+  /**
+   * Handles the input event for the checkbox input.
+   * Updates the checked state and dispatches a custom 'auroCheckbox-input' event.
+   * @private
+   * @param {Event} event - The input event from the checkbox input.
+   * @returns {void}
+   */
   handleInput(event) {
     this.checked = event.target.checked;
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Implement a `focus()` method for the Auro Checkbox component to directly focus the input element

New Features:
- Added a `focus()` method to programmatically focus the checkbox input

Enhancements:
- Stored a reference to the input element in the component
- Added detailed JSDoc comments for methods

Documentation:
- Updated API documentation to remove unnecessary method descriptions