### PR TITLE
fix: remove border and box-shadow on radio and use outline

### DIFF
--- a/components/radio/src/styles/color.scss
+++ b/components/radio/src/styles/color.scss
@@ -25,8 +25,6 @@
 
   &:after {
     background-color: var(--ds-auro-radio-btn-fill-color);
-    border-color: var(--ds-auro-radio-btn-border-color);
-    box-shadow: inset 0 0 0 3px var(--ds-auro-radio-btn-inset-color);
     outline-color: var(--ds-auro-radio-btn-border-color);
     
     -webkit-tap-highlight-color: var(--ds-auro-radio-tap-color);

--- a/components/radio/src/styles/style.scss
+++ b/components/radio/src/styles/style.scss
@@ -6,6 +6,8 @@
 /* stylelint-disable
    no-duplicate-selectors,
    declaration-empty-line-before,
+   declaration-property-value-no-unknown,
+   scss/dollar-variable-first-in-block,
    selector-max-class,
    scss/selector-nest-combinators,
    order/properties-order,
@@ -23,6 +25,8 @@
 @import '@aurodesignsystem/webcorestylesheets/src/breakpoints';
 @import '@aurodesignsystem/webcorestylesheets/src/core';
 @import '@aurodesignsystem/webcorestylesheets/src/utilityClasses/displayProperties';
+
+$bullet-to-border-distance: 3px;
 
 :host {
   display: block;
@@ -80,16 +84,23 @@
     position: absolute;
     z-index: 1;
     top: 50%;
-    left: var(--ds-size-50, $ds-size-50);
+    left: var(--ds-size-100, $ds-size-100);
 
-    width: calc(var(--ds-size-200, $ds-size-200) + var(--ds-size-50, $ds-size-50));
-    height: calc(var(--ds-size-200, $ds-size-200) + var(--ds-size-50, $ds-size-50));
-    transform: translateY(-50%);
+    width: var(--ds-size-250, $ds-size-250);
+    height: var(--ds-size-250, $ds-size-250);
+
+    // When the size is too small, the circle looks like an oval on safari.
+    // To avoid that, scale down the bigger circle to the proper size.
+    $scale: $ds-size-250 / ($ds-size-250 + $ds-size-100);
+    transform: translateY(-50%) scale($scale, $scale);
+    transform-origin: center left;
 
     content: '';
 
-    border-radius: 50%;
-    border: 1px solid;
+    // Use outline becasue box-shadow has a coord misalignment on safari.
+    border-radius: 9999px;
+    outline: 1px / $scale solid;
+    outline-offset: $bullet-to-border-distance / $scale;
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

fixes #522 


The issue was caused by GL and CPU calculation mismatch. 
- While border and background were painted by CPU, box-shadow gets painted by GL. 
- This happens ONLY on Safari on a second monitor because Safari is optimized for Retina displays but does not well optimized on non-Retina displays. 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update radio button styling to use outline instead of border and box-shadow, improving visual appearance and accessibility

Bug Fixes:
- Replaced border and box-shadow with a more accessible outline styling for radio buttons

Enhancements:
- Adjusted radio button visual styling to use outline with offset
- Refined positioning and sizing of radio button indicator