### PR TITLE
fix: set unique id and arialabel correctly in input/radio/checkbox #589

### DIFF
--- a/components/checkbox/docs/api.md
+++ b/components/checkbox/docs/api.md
@@ -51,7 +51,7 @@ Custom element for the purpose of allowing users to select one or more options o
 | `checked`  | `checked`  | `boolean` | false   | If set to true, the checkbox will be filled with a checkmark. |
 | `disabled` | `disabled` | `boolean` | false   | If set to true, the checkbox will not be clickable. |
 | `error`    | `error`    | `boolean` | false   | If set to true, the checkbox will be displayed with an error state. |
-| `id`       | `id`       | `string`  |         | Sets the individual `id` per element.            |
+| `id`       | `id`       | `string`  |         | The id global attribute defines an identifier (ID) which must be unique in the whole document. |
 | `name`     | `name`     | `string`  |         | Accepts any string and is used to identify related checkboxes when submitting form data. |
 | `onDark`   | `onDark`   | `boolean` | false   | Sets onDark styles for component.                |
 | `value`    | `value`    | `string`  |         | Sets the element's input value. Must be unique within an auro-checkbox-group element. |

--- a/components/checkbox/src/auro-checkbox.js
+++ b/components/checkbox/src/auro-checkbox.js
@@ -18,6 +18,9 @@ import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/util
 /**
  * Custom element for the purpose of allowing users to select one or more options of a limited number of choices.
  *
+ * @prop {string} id - The id global attribute defines an identifier (ID) which must be unique in the whole document.
+ * @attr id
+ *
  * @csspart checkbox - apply css to a specific checkbox.
  * @csspart checkbox-input - apply css to a specific checkbox's input.
  * @csspart checkbox-label - apply css to a specific checkbox's label.
@@ -85,11 +88,6 @@ export class AuroCheckbox extends LitElement {
       },
 
       /**
-       * Sets the individual `id` per element.
-       */
-      id: { type: String },
-
-      /**
        * Accepts any string and is used to identify related checkboxes when submitting form data.
        */
       name: { type: String },
@@ -118,6 +116,16 @@ export class AuroCheckbox extends LitElement {
       touched: {
         type: Boolean,
         reflect: true,
+        attribute: false
+      },
+
+      /**
+       * @private
+       * id for input node
+       */
+      inputId: {
+        type: String,
+        reflect: false,
         attribute: false
       }
     };
@@ -209,6 +217,8 @@ export class AuroCheckbox extends LitElement {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-checkbox');
 
+    this.inputId = this.id ? `${this.id}-input` : window.crypto.randomUUID();
+
     this.addEventListener('click', () => {
       this.handleFocusin();
     });
@@ -243,13 +253,13 @@ export class AuroCheckbox extends LitElement {
           @input="${this.handleInput}"
           ?disabled="${this.disabled}"
           .checked="${this.checked}"
-          id="${ifDefined(this.id)}"
+          id="${this.inputId}"
           name="${ifDefined(this.name)}"
           type="checkbox"
           .value="${this.value}"
         />
 
-        <label for="${ifDefined(this.id)}" class="${classMap(labelClasses)}" part="checkbox-label">
+        <label for="${this.inputId}" class="${classMap(labelClasses)}" part="checkbox-label">
           ${this.checked ? this.generateIconHtml() : undefined}
           <slot></slot>
         </label>

--- a/components/checkbox/test/auro-checkbox.test.js
+++ b/components/checkbox/test/auro-checkbox.test.js
@@ -16,13 +16,13 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
 
         <auro-checkbox
           id="washington"
           name="states"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -51,13 +51,13 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
 
         <auro-checkbox
           id="washington"
           name="states"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -81,13 +81,13 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
 
         <auro-checkbox
           id="washington"
           name="states"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -111,7 +111,7 @@ describe('auro-checkbox-group', () => {
         id="alaska"
         name="states-unchecking"
         value="alaska"
-      ></auro-checkbox>
+      >Alaska</auro-checkbox>
     `);
 
     const alaskaCheckbox = el,
@@ -134,13 +134,13 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
 
         <auro-checkbox
           id="washington"
           name="states"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -168,12 +168,12 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
         <auro-checkbox
           id="washington"
           name="states"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -215,14 +215,13 @@ describe('auro-checkbox-group', () => {
           name="states"
           value="alaska"
           checked
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
 
         <auro-checkbox
           id="washington"
           name="states"
-          type="radio"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -248,14 +247,13 @@ describe('auro-checkbox-group', () => {
           name="states"
           value="alaska"
           disabled
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
 
         <auro-checkbox
           id="washington"
           name="states"
-          type="radio"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -287,13 +285,12 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
         <auro-checkbox
           id="washington"
           name="states"
-          type="radio"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 
@@ -313,13 +310,13 @@ describe('auro-checkbox-group', () => {
           id="alaska"
           name="states"
           value="alaska"
-        ></auro-checkbox>
+        >Alaska</auro-checkbox>
         <auro-checkbox
           id="washington"
           name="states"
           type="radio"
           value="washington"
-        ></auro-checkbox>
+        >Washington</auro-checkbox>
       </auro-checkbox-group>
     `);
 

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -26,7 +26,7 @@ Generate unique names for dependency components.
 | `errorMessage`                    | `errorMessage`                    | `string`  |             | Contains the help text message for the current validity error. |
 | `format`                          | `format`                          | `string`  |             | Specifies the input mask format.                 |
 | `icon`                            | `icon`                            | `boolean` | false       | If set, will render an icon inside the input to the left of the value. Support is limited to auro-input instances with credit card format. |
-| `id`                              | `id`                              | `string`  |             | Sets the unique ID of the element.               |
+| `id`                              | `id`                              | `string`  |             | The id global attribute defines an identifier (ID) which must be unique in the whole document. |
 | `inputmode`                       | `inputmode`                       | `string`  |             | Exposes inputmode attribute for input.           |
 | `lang`                            | `lang`                            | `string`  |             | Defines the language of an element.              |
 | `max`                             | `max`                             | `string`  | "undefined" | The maximum value allowed. This only applies for inputs with a type of `number` and all date formats. |

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -118,7 +118,7 @@ export class AuroInput extends BaseInput {
             : undefined
             }
           </div>
-          <label for=${this.id} class="${classMap(labelClasses)}" part="label">
+          <label for=${this.inputId} class="${classMap(labelClasses)}" part="label">
             <slot name="label">
               ${this.label}
             </slot>
@@ -128,7 +128,7 @@ export class AuroInput extends BaseInput {
             @input="${this.handleInput}"
             @focusin="${this.handleFocusin}"
             @blur="${this.handleBlur}"
-            id="${this.id}"
+            id="${this.inputId}"
             name="${ifDefined(this.name)}"
             type="${this.type === 'password' && this.showPassword ? 'text' : this.getInputType(this.type)}"
             pattern="${ifDefined(this.definePattern())}"
@@ -196,7 +196,7 @@ export class AuroInput extends BaseInput {
                   variant="flat"
                   ?onDark="${this.onDark}"
                   class="notificationBtn clearBtn"
-                  aria-label="${i18n(this.lang, 'clearInput')}"
+                  arialabel="${i18n(this.lang, 'clearInput')}"
                   @click="${this.handleClickClear}">
                   <${this.iconTag}
                     customColor

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -25,6 +25,9 @@ import AuroFormValidation from '@auro-formkit/form-validation';
  * @attr {Boolean} bordered - Applies bordered UI variant.
  * @attr {Boolean} borderless - Applies borderless UI variant.
  *
+ * @prop {string} id - The id global attribute defines an identifier (ID) which must be unique in the whole document.
+ * @attr id
+ *
  * @slot helptext - Sets the help text displayed below the input.
  * @slot label - Sets the label text for the input.
  *
@@ -213,13 +216,6 @@ export default class BaseInput extends LitElement {
       icon: {
         type: Boolean,
         reflect: true
-      },
-
-      /**
-       * Sets the unique ID of the element.
-       */
-      id: {
-        type: String
       },
 
       /** Exposes inputmode attribute for input.  */
@@ -442,6 +438,16 @@ export default class BaseInput extends LitElement {
         type: Boolean,
         reflect: true,
         attribute: false
+      },
+
+      /**
+       * @private
+       * id for input node
+       */
+      inputId: {
+        type: String,
+        reflect: false,
+        attribute: false
       }
     };
   }
@@ -473,6 +479,7 @@ export default class BaseInput extends LitElement {
     if (this.tagName.toLowerCase() !== 'auro-input') {
       this.setAttribute('auro-input', true);
     }
+    this.inputId = this.id ? `${this.id}-input` : window.crypto.randomUUID();
 
     this.inputElement = this.renderRoot.querySelector('input');
     this.labelElement = this.shadowRoot.querySelector('label');

--- a/components/input/test/auro-input.test.js
+++ b/components/input/test/auro-input.test.js
@@ -594,9 +594,9 @@ describe('auro-input', () => {
       <auro-input id="checkSpellCheck" type="text" required spellcheck="false"></auro-input>
     `);
 
-    expect(el.shadowRoot.querySelector('#checkSpellCheck')).to.have.attribute('spellcheck', 'false');
-    expect(el.shadowRoot.querySelector('#checkSpellCheck')).to.have.attribute('autocorrect', 'off');
-    expect(el.shadowRoot.querySelector('#checkSpellCheck')).to.have.attribute('autocapitalize', 'none');
+    expect(el.shadowRoot.querySelector('input')).to.have.attribute('spellcheck', 'false');
+    expect(el.shadowRoot.querySelector('input')).to.have.attribute('autocorrect', 'off');
+    expect(el.shadowRoot.querySelector('input')).to.have.attribute('autocapitalize', 'none');
   });
 
   it('Does not set spellcheck and autocapitalize values', async () => {
@@ -604,9 +604,9 @@ describe('auro-input', () => {
       <auro-input id="checkSpellCheck" type="text" required spellcheck="true"></auro-input>
     `);
 
-    expect(el.shadowRoot.querySelector('#checkSpellCheck')).to.have.attribute('spellcheck', 'true');
-    expect(el.shadowRoot.querySelector('#checkSpellCheck')).to.not.have.attribute('autocorrect');
-    expect(el.shadowRoot.querySelector('#checkSpellCheck')).to.not.have.attribute('autocapitalize');
+    expect(el.shadowRoot.querySelector('input')).to.have.attribute('spellcheck', 'true');
+    expect(el.shadowRoot.querySelector('input')).to.not.have.attribute('autocorrect');
+    expect(el.shadowRoot.querySelector('input')).to.not.have.attribute('autocapitalize');
   });
 
   it('reset method clears the value and validity state', async () => {
@@ -805,7 +805,7 @@ describe('auro-input', () => {
 
       expect(content).to.not.contain(`Por favor`);
       expect(eli18nContent).to.contain(`Por favor`);
-      expect(eli18n.shadowRoot.querySelector('#input01')).to.have.attribute('lang', 'es');
+      expect(eli18n.shadowRoot.querySelector('input')).to.have.attribute('lang', 'es');
     });
   });
 

--- a/components/radio/docs/api.md
+++ b/components/radio/docs/api.md
@@ -55,7 +55,7 @@
 | `checked`  | `checked`  | `Boolean` | false   | If set to true, the radio button will be filled. |
 | `disabled` | `disabled` | `Boolean` | false   | If set to true, the radio button will be non-clickable. |
 | `error`    | `error`    | `Boolean` | false   | If set to true, sets an error state on the radio button. |
-| `id`       | `id`       | `string`  |         |                                                  |
+| `id`       | `id`       | `string`  |         | The id global attribute defines an identifier (ID) which must be unique in the whole document. |
 | `label`    | `label`    | `string`  |         |                                                  |
 | `name`     | `name`     | `string`  |         |                                                  |
 | `onDark`   | `onDark`   | `Boolean` | false   | If set to true, the component will render with a dark theme. |

--- a/components/radio/src/auro-radio.js
+++ b/components/radio/src/auro-radio.js
@@ -24,6 +24,10 @@ import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/util
  * @attr {Boolean} error - If set to true, sets an error state on the radio button.
  * @attr {Boolean} onDark - If set to true, the component will render with a dark theme.
  * @event toggleSelected - Notifies that the component has toggled the checked/selected state.
+ *
+ * @prop {string} id - The id global attribute defines an identifier (ID) which must be unique in the whole document.
+ * @attr id
+ *
  * @event focusSelected - Notifies that the component has gained focus.
  * @event auroRadio-blur - Notifies that the component has lost focus.
  * @event resetRadio - Notifies that the component has reset the checked/selected state.
@@ -79,7 +83,6 @@ export class AuroRadio extends LitElement {
         type: Boolean,
         reflect: true
       },
-      id:       { type: String },
       label:    { type: String },
       name:     { type: String },
       value:    { type: String },
@@ -95,6 +98,16 @@ export class AuroRadio extends LitElement {
       touched: {
         type: Boolean,
         reflect: true,
+        attribute: false
+      },
+
+      /**
+       * @private
+       * id for input node
+       */
+      inputId: {
+        type: String,
+        reflect: false,
         attribute: false
       }
     };
@@ -231,6 +244,8 @@ export class AuroRadio extends LitElement {
 
     this.input = this.shadowRoot.querySelector('input');
 
+    this.inputId = this.id ? `${this.id}-input` : window.crypto.randomUUID();
+
     this.addEventListener('click', () => {
       this.input.click();
     });
@@ -257,14 +272,14 @@ export class AuroRadio extends LitElement {
           aria-invalid="${this.invalid(this.error)}"
           aria-required="${this.isRequired(this.required)}"
           .checked="${this.checked}"
-          id="${ifDefined(this.id)}"
+          id="${this.inputId}"
           name="${ifDefined(this.name)}"
           type="radio"
           .value="${this.value}"
           tabIndex="-1"
         />
 
-        <label for="${ifDefined(this.id)}" class="${classMap(labelClasses)}">
+        <label for="${this.inputId}" class="${classMap(labelClasses)}">
           <slot>${this.label}</slot>
         </label>
 

--- a/components/radio/test/auro-radio.test.js
+++ b/components/radio/test/auro-radio.test.js
@@ -4,7 +4,7 @@ import '../src/registered.js';
 describe('auro-radio', () => {
   it('auro-radio is accessible', async () => {
     const el = await fixture(html`
-      <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+      <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">Yes</auro-radio>
     `);
 
     await expect(el).to.be.accessible();
@@ -29,9 +29,9 @@ describe('auro-radio', () => {
     const el = await fixture(html`
       <auro-radio-group>
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">Yes</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">No</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe">Maybe</auro-radio>
       </auro-radio-group>
     `);
 
@@ -53,9 +53,9 @@ describe('auro-radio', () => {
     const el = await fixture(html`
       <auro-radio-group error="customError">
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">Yes</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">No</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe">Maybe</auro-radio>
       </auro-radio-group>
     `);
 
@@ -66,8 +66,8 @@ describe('auro-radio', () => {
     const el = await fixture(html`
       <auro-radio-group disabled>
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">Yes</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">No</auro-radio>
       </auro-radio-group>
     `);
 
@@ -82,8 +82,8 @@ describe('auro-radio', () => {
     const el = await fixture(html`
       <auro-radio-group id="resetGroupTest" required>
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes" checked></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no" checked></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes" checked>Yes</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no" checked>No</auro-radio>
       </auro-radio-group>
     `);
 
@@ -106,9 +106,9 @@ describe('auro-radio', () => {
     const el = await fixture(html`
       <auro-radio-group error="customError">
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">Y</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">N</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe">?</auro-radio>
       </auro-radio-group>
     `);
 
@@ -143,9 +143,9 @@ describe('auro-radio', () => {
     const el = await fixture(html`
       <auro-radio-group>
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">Y</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">N</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe">?</auro-radio>
       </auro-radio-group>
     `);
 
@@ -169,9 +169,9 @@ describe('auro-radio-group', () => {
     const el = await fixture(html`
       <auro-radio-group name="group">
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">T</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">N</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe">?</auro-radio>
       </auro-radio-group>
     `);
 
@@ -205,21 +205,21 @@ describe('auro-radio-group', () => {
     const radioGroup = await fixture(html`
       <auro-radio-group name="group">
         <span slot="legend">Form label goes here</span>
-        <auro-radio id="radio1" label="Yes" name="radioDemo1" value="yes"></auro-radio>
-        <auro-radio id="radio2" label="No" name="radioDemo2" value="no"></auro-radio>
-        <auro-radio id="radio3" label="Maybe" name="radioDemo3" value="maybe"></auro-radio>
+        <auro-radio id="radio1" label="Yes" name="radioDemo1" value="yes">Y</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo2" value="no">N</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo3" value="maybe">?</auro-radio>
 
         <div>
-          <auro-radio id="radio4" label="Yes 2" name="radioDemo4" value="yes2"></auro-radio>
+          <auro-radio id="radio4" label="Yes 2" name="radioDemo4" value="yes2">Y</auro-radio>
         </div>
 
         <div>
           <div>
-            <auro-radio id="radio5" label="No 2" name="radioDemo5" value="no2"></auro-radio>
+            <auro-radio id="radio5" label="No 2" name="radioDemo5" value="no2">N</auro-radio>
           </div>
         </div>
 
-        <auro-radio id="radio6" label="Maybe 2" name="radioDemo6" value="maybe2"></auro-radio>
+        <auro-radio id="radio6" label="Maybe 2" name="radioDemo6" value="maybe2">?</auro-radio>
       </auro-radio-group>
     `);
 
@@ -264,9 +264,9 @@ async function errorFixture() {
   return await fixture(html`
   <auro-radio-group error="There is an error with this form entry">
     <span slot="legend">Form label goes here</span>
-    <auro-radio label="Yes" name="radioDemo" value="yes"></auro-radio>
-    <auro-radio label="No" name="radioDemo" value="no"></auro-radio>
-    <auro-radio label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+    <auro-radio label="Yes" name="radioDemo" value="yes">Y</auro-radio>
+    <auro-radio label="No" name="radioDemo" value="no">N</auro-radio>
+    <auro-radio label="Maybe" name="radioDemo" value="maybe">?</auro-radio>
   </auro-radio-group>
   `);
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request


1. make input node under shadowRoot to have a unique id (not the dupId from its parent)
2. set `arialabel` on auro-button instead of `aria-label`

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix input element id handling and accessibility attributes in `auro-input`. Introduce a dedicated `inputId` for the input and update the label’s `for` and the input’s `id` to use it, correct the clear-button attribute name, and adjust tests to select the input element accordingly.

Bug Fixes:
- Generate and use a unique `inputId` for the input element and link the label’s `for` attribute to it instead of using the host’s `id`.
- Correct the clear-button attribute from `aria-label` to `arialabel` to match expected markup.

Tests:
- Update tests to query the `<input>` element directly instead of selecting by the host `id`.