### PR TITLE
feat: add autocomplete and name properties to native select element

### DIFF
--- a/components/select/apiExamples/autocomplete.html
+++ b/components/select/apiExamples/autocomplete.html
@@ -1,0 +1,79 @@
+<div class="autofill-example-form">
+  <div class="input-row">
+    <auro-input autocomplete="given-name">
+      <span slot="label">First Name</span>
+      <span slot="bib.fullscreen.headline">First Name</span>
+    </auro-input>
+    <auro-input autocomplete="family-name">
+      <span slot="label">Last Name</span>
+      <span slot="bib.fullscreen.headline">Last Name</span>
+    </auro-input>
+  </div>
+  <div class="input-row">
+    <auro-input autocomplete="address-line1">
+      <span slot="label">Street Address</span>
+      <span slot="bib.fullscreen.headline">Street Address</span>
+    </auro-input>
+    <auro-input autocomplete="address-level2">
+      <span slot="label">City</span>
+      <span slot="bib.fullscreen.headline">City</span>
+    </auro-input>
+    <auro-select autocomplete="address-level1">
+      <span slot="bib.fullscreen.headline">Select Your State</span>
+      <span slot="label">Select Your State</span>
+      <auro-menu>
+        <auro-menuoption value="AL">Alabama</auro-menuoption>
+        <auro-menuoption value="AK">Alaska</auro-menuoption>
+        <auro-menuoption value="AZ">Arizona</auro-menuoption>
+        <auro-menuoption value="AR">Arkansas</auro-menuoption>
+        <auro-menuoption value="CA">California</auro-menuoption>
+        <auro-menuoption value="CO">Colorado</auro-menuoption>
+        <auro-menuoption value="CT">Connecticut</auro-menuoption>
+        <auro-menuoption value="DE">Delaware</auro-menuoption>
+        <auro-menuoption value="DC">District of Columbia</auro-menuoption>
+        <auro-menuoption value="FL">Florida</auro-menuoption>
+        <auro-menuoption value="GA">Georgia</auro-menuoption>
+        <auro-menuoption value="HI">Hawaii</auro-menuoption>
+        <auro-menuoption value="ID">Idaho</auro-menuoption>
+        <auro-menuoption value="IL">Illinois</auro-menuoption>
+        <auro-menuoption value="IN">Indiana</auro-menuoption>
+        <auro-menuoption value="IA">Iowa</auro-menuoption>
+        <auro-menuoption value="KS">Kansas</auro-menuoption>
+        <auro-menuoption value="KY">Kentucky</auro-menuoption>
+        <auro-menuoption value="LA">Louisiana</auro-menuoption>
+        <auro-menuoption value="ME">Maine</auro-menuoption>
+        <auro-menuoption value="MD">Maryland</auro-menuoption>
+        <auro-menuoption value="MA">Massachusetts</auro-menuoption>
+        <auro-menuoption value="MI">Michigan</auro-menuoption>
+        <auro-menuoption value="MN">Minnesota</auro-menuoption>
+        <auro-menuoption value="MS">Mississippi</auro-menuoption>
+        <auro-menuoption value="MO">Missouri</auro-menuoption>
+        <auro-menuoption value="MT">Montana</auro-menuoption>
+        <auro-menuoption value="NE">Nebraska</auro-menuoption>
+        <auro-menuoption value="NV">Nevada</auro-menuoption>
+        <auro-menuoption value="NH">New Hampshire</auro-menuoption>
+        <auro-menuoption value="NJ">New Jersey</auro-menuoption>
+        <auro-menuoption value="NM">New Mexico</auro-menuoption>
+        <auro-menuoption value="NY">New York</auro-menuoption>
+        <auro-menuoption value="NC">North Carolina</auro-menuoption>
+        <auro-menuoption value="ND">North Dakota</auro-menuoption>
+        <auro-menuoption value="OH">Ohio</auro-menuoption>
+        <auro-menuoption value="OK">Oklahoma</auro-menuoption>
+        <auro-menuoption value="OR">Oregon</auro-menuoption>
+        <auro-menuoption value="PA">Pennsylvania</auro-menuoption>
+        <auro-menuoption value="RI">Rhode Island</auro-menuoption>
+        <auro-menuoption value="SC">South Carolina</auro-menuoption>
+        <auro-menuoption value="SD">South Dakota</auro-menuoption>
+        <auro-menuoption value="TN">Tennessee</auro-menuoption>
+        <auro-menuoption value="TX">Texas</auro-menuoption>
+        <auro-menuoption value="UT">Utah</auro-menuoption>
+        <auro-menuoption value="VT">Vermont</auro-menuoption>
+        <auro-menuoption value="VA">Virginia</auro-menuoption>
+        <auro-menuoption value="WA">Washington</auro-menuoption>
+        <auro-menuoption value="WV">West Virginia</auro-menuoption>
+        <auro-menuoption value="WI">Wisconsin</auro-menuoption>
+        <auro-menuoption value="WY">Wyoming</auro-menuoption>
+      </auro-menu>
+    </auro-select>
+  </div>
+</div>

--- a/components/select/demo/api.html
+++ b/components/select/demo/api.html
@@ -52,5 +52,20 @@
     <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-button@latest/dist/auro-button__bundled.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-dialog@latest/dist/auro-dialog__bundled.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-loader@latest/dist/auro-loader__bundled.js" type="module"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.4/auro-input/+esm"></script>
+
+    <style>
+      .autofill-example-form .input-row {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+        gap: 15px;
+      }
+      .autofill-example-form .input-row auro-input,
+      .autofill-example-form .input-row auro-select {
+        flex: 1 0 auto;
+      }
+    </style>
   </body>
 </html>

--- a/components/select/demo/index.html
+++ b/components/select/demo/index.html
@@ -47,5 +47,20 @@
     <!-- If additional elements are needed for the demo, add them here. -->
     <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-accordion@latest/dist/auro-accordion__bundled.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-button@latest/dist/auro-button__bundled.js" type="module"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.4/auro-input/+esm"></script>
+
+    <style>
+      .autofill-example-form .input-row {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+        gap: 15px;
+      }
+      .autofill-example-form .input-row auro-input,
+      .autofill-example-form .input-row auro-select {
+        flex: 1 0 auto;
+      }
+    </style>
   </body>
 </html>

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -7,12 +7,14 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | Property                        | Attribute                       | Type      | Default        | Description                                      |
 |---------------------------------|---------------------------------|-----------|----------------|--------------------------------------------------|
 | `autoPlacement`                 | `autoPlacement`                 | `boolean` | "false"        | If declared, bib's position will be automatically calculated where to appear. |
+| `autocomplete`                  | `autocomplete`                  | `string`  |                | If declared, sets the autocomplete attribute for the select element. |
 | `disabled`                      | `disabled`                      | `boolean` |                | When attribute is present, element shows disabled state. |
 | `error`                         | `error`                         | `string`  |                | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
 | `flexMenuWidth`                 | `flexMenuWidth`                 | `boolean` |                | If set, makes dropdown width match the size of the content, rather than the width of the trigger. |
 | `fullscreenBreakpoint`          | `fullscreenBreakpoint`          | `string`  | "sm"           | Defines the screen size breakpoint (`xs`, `sm`, `md`, `lg`, `xl`, `disabled`)<br />at which the dropdown switches to fullscreen mode on mobile. `disabled` indicates a dropdown should _never_ enter fullscreen.<br /><br />When expanded, the dropdown will automatically display in fullscreen mode<br />if the screen size is equal to or smaller than the selected breakpoint. |
 | `largeFullscreenHeadline`       | `largeFullscreenHeadline`       | `boolean` |                | If declared, make bib.fullscreen.headline in HeadingDisplay.<br />Otherwise, Heading 600 |
 | `multiSelect`                   | `multiselect`                   | `boolean` |                | Sets multi-select mode, allowing multiple options to be selected at once. |
+| `name`                          | `name`                          | `string`  |                | The name for the select element.                 |
 | `noCheckmark`                   | `noCheckmark`                   | `boolean` |                | When true, checkmark on selected option will no longer be present. |
 | `noFlip`                        | `noFlip`                        | `boolean` | "false"        | If declared, the bib will NOT flip to an alternate position<br />when there isn't enough space in the specified `placement`. |
 | `noValidate`                    | `noValidate`                    | `boolean` |                | If set, disables auto-validation on blur.        |

--- a/components/select/docs/partials/api.md
+++ b/components/select/docs/partials/api.md
@@ -59,6 +59,21 @@ To pre-set the value of auro-select on load, use the `value` property. The `sele
 
 </auro-accordion>
 
+#### Autocomplete
+
+Use the `autocomplete` attribute to let browser's know what information to use to fill out the form.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/autocomplete.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/autocomplete.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
 #### required <a name="required"></a>
 
 When present, the `required` attribute specifies that a select field must be filled out before submitting the form.

--- a/components/select/docs/partials/api.md
+++ b/components/select/docs/partials/api.md
@@ -59,7 +59,7 @@ To pre-set the value of auro-select on load, use the `value` property. The `sele
 
 </auro-accordion>
 
-#### Autocomplete
+#### Autocomplete <a name="autocomplete"></a>
 
 Use the `autocomplete` attribute to let browser's know what information to use to fill out the form.
 

--- a/components/select/docs/partials/index.md
+++ b/components/select/docs/partials/index.md
@@ -69,6 +69,23 @@ The following example illustrates the use of the `label`, `placeholder` and `hel
 
 </auro-accordion>
 
+
+## Autofill/Autocomplete Support
+
+Use the `autocomplete` attribute to let browser's know what information to use to fill out the form.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/autocomplete.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/autocomplete.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 ## Example with auro-icons in options
 
 Displays an `<auro-select>` element with `<auro-icon>` elements in each option.

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -831,6 +831,7 @@ export class AuroSelect extends LitElement {
         </${this.dropdownTag}>
         <div class="nativeSelectWrapper">
           <select 
+            tabindex="-1"
             id="${`native-select-${this.id || this.uniqueId}`}"
             name="${this.name || ''}"
             ?disabled="${this.disabled}"

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -27,6 +27,7 @@ import {
 } from '@aurodesignsystem/auro-menu';
 
 import styleCss from "./styles/style-css.js";
+import { ifDefined } from "lit-html/directives/if-defined.js";
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
@@ -118,6 +119,14 @@ export class AuroSelect extends LitElement {
     return {
 
       /**
+       * If declared, sets the autocomplete attribute for the select element.
+       */
+      autocomplete: {
+        type: String,
+        reflect: true
+      },
+
+      /**
        * If declared, bib's position will be automatically calculated where to appear.
        * @default false
        */
@@ -131,6 +140,14 @@ export class AuroSelect extends LitElement {
        */
       disabled: {
         type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * The name for the select element.
+       */
+      name: {
+        type: String,
         reflect: true
       },
 
@@ -677,6 +694,7 @@ export class AuroSelect extends LitElement {
         this.menu.value = undefined;
       }
 
+      this._updateNativeSelect();
       this.validation.validate(this);
 
       // LEGACY EVENT
@@ -727,6 +745,23 @@ export class AuroSelect extends LitElement {
   validate(force = false) {
     this.validation.validate(this, force);
   }
+
+  _handleNativeSelectChange(event) {
+    const selectedOption = event.target.options[event.target.selectedIndex];
+    const selectedValue = selectedOption.value;
+    const [currentValue] = this.value || [];
+    this.value = !currentValue || currentValue !== selectedValue ? [selectedValue] : this.value;
+  }
+
+  _updateNativeSelect() {
+    const nativeSelect = this.shadowRoot.querySelector('select');
+    if (!nativeSelect) {
+      return;
+    }
+    const [value] = this.value || [];
+    nativeSelect.value = value || '';
+  }
+
 
   // When using auroElement, use the following attribute and function when hiding content from screen readers.
   // aria-hidden="${this.hideAudible(this.hiddenAudible)}"
@@ -794,6 +829,28 @@ export class AuroSelect extends LitElement {
             }
           </p>
         </${this.dropdownTag}>
+        <div class="nativeSelectWrapper">
+          <select 
+            id="${`native-select-${this.id || this.uniqueId}`}"
+            name="${this.name || ''}"
+            ?disabled="${this.disabled}"
+            ?required="${this.required}"
+            aria-hidden="true"
+            autocomplete="${ifDefined(this.autocomplete)}"
+            @change="${this._handleNativeSelectChange}">
+            <option value="" ?selected="${!this.value}"></option>
+            ${this.options.map((option) => {
+              const optionValue = option.value || option.textContent;
+              return html`
+                <option 
+                  value="${optionValue}" 
+                  ?selected="${this.value === optionValue}">
+                  ${option.textContent}
+                </option>
+              `;
+            })}
+          </select>
+        </div>
         <!-- Help text and error message template -->
       </div>
     `;

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -746,6 +746,12 @@ export class AuroSelect extends LitElement {
     this.validation.validate(this, force);
   }
 
+  /**
+   * Syncs the value from the native select element to the component's value.
+   * @param {Event} event // The change event from the native select element.
+   * @returns {void}
+   * @private
+   */
   _handleNativeSelectChange(event) {
     const selectedOption = event.target.options[event.target.selectedIndex];
     const selectedValue = selectedOption.value;
@@ -753,6 +759,11 @@ export class AuroSelect extends LitElement {
     this.value = !currentValue || currentValue !== selectedValue ? [selectedValue] : this.value;
   }
 
+  /**
+   * Updates the native select element's value based on the component's value.
+   * @returns {void}
+   * @private
+   */
   _updateNativeSelect() {
     const nativeSelect = this.shadowRoot.querySelector('select');
     if (!nativeSelect) {

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -36,6 +36,18 @@
 } 
 
 :host {
+  .nativeSelectWrapper {
+    position: absolute;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    border: 0;
+    margin: -1px;
+    clip: rect(0, 0, 0, 0);
+    opacity: 0.01;
+  }
+
   [auro-dropdown] {
     position: relative;
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1,4 +1,4 @@
-import { fixture, html, expect, waitUntil, elementUpdated } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
 import '@aurodesignsystem/auro-dropdown';
 import '../../menu/src/registered.js';
 import '../src/registered.js';
@@ -15,6 +15,47 @@ describe('auro-select', () => {
     const el = document.createElement('auro-select');
 
     await expect(el.localName).to.equal('auro-select');
+  });
+
+  it('should have a native select element for autofill', async () => {
+    const element = await defaultFixture();
+    const nativeSelect = element.shadowRoot.querySelector('.nativeSelectWrapper select');
+    expect(nativeSelect).to.exist;
+  });
+
+  it('should pass the name to the native select', async () => {
+    const element = await defaultFixture();
+    const testName = 'test-name';
+    element.name = testName;
+    await elementUpdated(element);
+    const nativeSelect = element.shadowRoot.querySelector('.nativeSelectWrapper select');
+    expect(nativeSelect.name).to.equal(testName);
+  });
+
+  it('should sync value changes from native select to component', async () => {
+    const element = await defaultFixture();
+    const nativeSelect = element.shadowRoot.querySelector('.nativeSelectWrapper select');
+    nativeSelect.value = 'Apples';
+    nativeSelect.dispatchEvent(new Event('change'));
+
+    await elementUpdated(element);
+
+    const [elValue] = element.value;
+    expect(elValue).to.equal('Apples');
+
+    // Also check that the visible selection matches
+    const triggerText = element.shadowRoot.querySelector('[slot="trigger"]').textContent.trim();
+    expect(triggerText).to.equal('Apples');
+  });
+
+  it('should sync value changes from component to native select', async () => {
+    const element = await defaultFixture();
+    element.value = ['Apples'];
+
+    await elementUpdated(element);
+
+    const nativeSelect = element.shadowRoot.querySelector('.nativeSelectWrapper select');
+    expect(nativeSelect.value).to.equal('Apples');
   });
 
   it('toggles the bib on click', async () => {

--- a/packages/config/src/internal.rollup.config.mjs
+++ b/packages/config/src/internal.rollup.config.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable require-unicode-regexp */
+
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 const createConfig = (input, output) => ({
@@ -8,14 +10,11 @@ const createConfig = (input, output) => ({
     entryFileNames: '[name].js'
   },
   external: [
-    'lit',
-    '@lit/reactive-element',
-    'lit-html',
-    'lit/decorators.js',
-    'lit/static-html.js',
-    'lit/directives/repeat.js',
-    'lit/directives/class-map.js',
-    'lit/directives/if-defined.js',
+    /node_modules\/lit/,
+    /node_modules\/lit-element/,
+    /node_modules\/lit-html/,
+    /node_modules\/@lit/,
+    /node_modules\/@lit-labs/,
   ],
   plugins: [
     nodeResolve({


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add browser autofill support to the auro-select component by embedding a hidden native select element and exposing `autocomplete` and `name` properties with bidirectional value synchronization.

New Features:
- Expose an `autocomplete` property to set the native select's autocomplete attribute
- Expose a `name` property to set the native select's name attribute

Enhancements:
- Embed a hidden native `<select>` element for browser autofill and synchronize its value with the component

Documentation:
- Update API documentation to include the new `autocomplete` and `name` properties

Tests:
- Add tests to verify native select presence, attribute propagation, and bidirectional value synchronization