### PR TITLE
Remove version from cdn link in readme

### DIFF
--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -106,7 +106,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-checkbox/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-checkbox/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/combobox/README.md
+++ b/components/combobox/README.md
@@ -111,7 +111,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-combobox/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-combobox/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -2,31 +2,31 @@
 
 ## Properties
 
-| Property                        | Attribute                       | Type      | Default        | Description                                      |
-|---------------------------------|---------------------------------|-----------|----------------|--------------------------------------------------|
-| `autoPlacement`                 | `autoPlacement`                 | `boolean` |                | If declared, bib's position will be automatically calculated where to appear. |
-| `autocomplete`                  | `autocomplete`                  | `string`  | "false"        | An enumerated attribute that defines what the user agent can suggest for autofill. At this time, only `autocomplete="off"` is supported. |
-| `checkmark`                     | `checkmark`                     | `boolean` |                | When attribute is present auro-menu will apply checkmarks to selected options. |
-| `disabled`                      | `disabled`                      | `boolean` |                | If set, disables the combobox.                   |
-| `error`                         | `error`                         | `string`  |                | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |
-| `fullscreenBreakpoint`          | `fullscreenBreakpoint`          | `string`  | "sm"           | Defines the screen size breakpoint (`xs`, `sm`, `md`, `lg`, `xl`, `disabled`)<br />at which the dropdown switches to fullscreen mode on mobile. `disabled` indicates a dropdown should _never_ enter fullscreen.<br /><br />When expanded, the dropdown will automatically display in fullscreen mode<br />if the screen size is equal to or smaller than the selected breakpoint. |
-| `inputmode`                     | `inputmode`                     | `string`  |                | Exposes inputmode attribute for input.           |
-| `largeFullscreenHeadline`       | `largeFullscreenHeadline`       | `boolean` |                | If declared, make bib.fullscreen.headline in HeadingDisplay.<br />Otherwise, Heading 600 |
-| `noFilter`                      | `noFilter`                      | `boolean` |                | If set, combobox will not filter menuoptions based in input. |
-| `noFlip`                        | `noFlip`                        | `boolean` | "false"        | If declared, the bib will NOT flip to an alternate position<br />when there isn't enough space in the specified `placement`. |
-| `noValidate`                    | `noValidate`                    | `boolean` |                | If set, disables auto-validation on blur.        |
-| `offset`                        | `offset`                        | `number`  | "0"            | Gap between the trigger element and bib.         |
-| `onDark`                        | `onDark`                        | `boolean` |                | If declared, onDark styles will be applied to the trigger. |
-| `optionSelected`                | `optionSelected`                | `object`  |                | Specifies the current selected option.           |
-| `placement`                     | `placement`                     | `string`  | "bottom-start" | Position where the bib should appear relative to the trigger.<br />Accepted values:<br />"top" \| "right" \| "bottom" \| "left" \|<br />"bottom-start" \| "top-start" \| "top-end" \|<br />"right-start" \| "right-end" \| "bottom-end" \|<br />"left-start" \| "left-end" |
-| `required`                      | `required`                      | `boolean` |                | Populates the `required` attribute on the input. Used for client-side validation. |
-| `setCustomValidity`             | `setCustomValidity`             | `string`  |                | Sets a custom help text message to display for all validityStates. |
-| `setCustomValidityCustomError`  | `setCustomValidityCustomError`  | `string`  |                | Custom help text message to display when validity = `customError`. |
-| `setCustomValidityValueMissing` | `setCustomValidityValueMissing` | `string`  |                | Custom help text message to display when validity = `valueMissing`. |
-| `triggerIcon`                   | `triggerIcon`                   | `boolean` |                | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
-| `type`                          | `type`                          | `string`  |                | Applies the defined value as the type attribute on auro-input. |
-| `validity`                      | `validity`                      | `string`  |                | Specifies the `validityState` this element is in. |
-| `value`                         | `value`                         |           |                | Value selected for the dropdown menu.            |
+| Property                        | Attribute                       | Type                   | Default        | Description                                      |
+|---------------------------------|---------------------------------|------------------------|----------------|--------------------------------------------------|
+| `autoPlacement`                 | `autoPlacement`                 | `boolean`              |                | If declared, bib's position will be automatically calculated where to appear. |
+| `autocomplete`                  | `autocomplete`                  | `string`               | "false"        | An enumerated attribute that defines what the user agent can suggest for autofill. At this time, only `autocomplete="off"` is supported. |
+| `checkmark`                     | `checkmark`                     | `boolean`              |                | When attribute is present auro-menu will apply checkmarks to selected options. |
+| `disabled`                      | `disabled`                      | `boolean`              |                | If set, disables the combobox.                   |
+| `error`                         | `error`                         | `string`               |                | When defined, sets persistent validity to `customError` and sets the validation message to the attribute value. |
+| `fullscreenBreakpoint`          | `fullscreenBreakpoint`          | `string`               | "sm"           | Defines the screen size breakpoint (`xs`, `sm`, `md`, `lg`, `xl`, `disabled`)<br />at which the dropdown switches to fullscreen mode on mobile. `disabled` indicates a dropdown should _never_ enter fullscreen.<br /><br />When expanded, the dropdown will automatically display in fullscreen mode<br />if the screen size is equal to or smaller than the selected breakpoint. |
+| `inputmode`                     | `inputmode`                     | `string`               |                | Exposes inputmode attribute for input.           |
+| `largeFullscreenHeadline`       | `largeFullscreenHeadline`       | `boolean`              |                | If declared, make bib.fullscreen.headline in HeadingDisplay.<br />Otherwise, Heading 600 |
+| `noFilter`                      | `noFilter`                      | `boolean`              |                | If set, combobox will not filter menuoptions based in input. |
+| `noFlip`                        | `noFlip`                        | `boolean`              | "false"        | If declared, the bib will NOT flip to an alternate position<br />when there isn't enough space in the specified `placement`. |
+| `noValidate`                    | `noValidate`                    | `boolean`              |                | If set, disables auto-validation on blur.        |
+| `offset`                        | `offset`                        | `number`               | "0"            | Gap between the trigger element and bib.         |
+| `onDark`                        | `onDark`                        | `boolean`              |                | If declared, onDark styles will be applied to the trigger. |
+| `optionSelected`                | `optionSelected`                | `object`               |                | Specifies the current selected option.           |
+| `placement`                     | `placement`                     | `string`               | "bottom-start" | Position where the bib should appear relative to the trigger.<br />Accepted values:<br />"top" \| "right" \| "bottom" \| "left" \|<br />"bottom-start" \| "top-start" \| "top-end" \|<br />"right-start" \| "right-end" \| "bottom-end" \|<br />"left-start" \| "left-end" |
+| `required`                      | `required`                      | `boolean`              |                | Populates the `required` attribute on the input. Used for client-side validation. |
+| `setCustomValidity`             | `setCustomValidity`             | `string`               |                | Sets a custom help text message to display for all validityStates. |
+| `setCustomValidityCustomError`  | `setCustomValidityCustomError`  | `string`               |                | Custom help text message to display when validity = `customError`. |
+| `setCustomValidityValueMissing` | `setCustomValidityValueMissing` | `string`               |                | Custom help text message to display when validity = `valueMissing`. |
+| `triggerIcon`                   | `triggerIcon`                   | `boolean`              |                | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
+| `type`                          | `type`                          | `string`               |                | Applies the defined value as the type attribute on auro-input. |
+| `validity`                      | `validity`                      | `string`               |                | Specifies the `validityState` this element is in. |
+| `value`                         | `value`                         | `Array\|String<Array>` |                | Value selected for the dropdown menu.            |
 
 ## Methods
 

--- a/components/counter/README.md
+++ b/components/counter/README.md
@@ -110,7 +110,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-counter/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-counter/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/datepicker/README.md
+++ b/components/datepicker/README.md
@@ -104,7 +104,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-datepicker/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-datepicker/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -107,7 +107,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-dropdown/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-dropdown/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/form/README.md
+++ b/components/form/README.md
@@ -109,7 +109,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-form/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-form/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/form/docs/api.md
+++ b/components/form/docs/api.md
@@ -16,9 +16,8 @@ The auro-form element provides users a way to ... (it would be great if you fill
 | `formState`                |           | `FormState`                                      | {}      |                                                  |
 | `isInitialState`           | readonly  | `boolean`                                        |         | Mostly internal way to determine if a form is in the initial state. |
 | `mutationEventListener`    |           |                                                  |         |                                                  |
-| `mutationObservers`        |           | `MutationObserver[]`                             | []      |                                                  |
 | `reset`                    |           |                                                  |         |                                                  |
-| `resetElements`            | readonly  | `HTMLButtonElement[]`                            |         | Getter for internal _resetElements.              |
+| `resetElements`            | readonly  | `HTMLButtonElement[]`                            |         | Returns a collection of elements that will reset the form |
 | `sharedInputListener`      |           |                                                  |         |                                                  |
 | `sharedValidationListener` |           |                                                  |         |                                                  |
 | `submit`                   |           |                                                  |         |                                                  |
@@ -33,13 +32,10 @@ The auro-form element provides users a way to ... (it would be great if you fill
 | `initializeState`           | `(): void`                        | Initialize (or reinitialize) the form state.     |
 | `isButtonElement`           | `(element: HTMLElement): boolean` | Check if the tag name is a button element.<br /><br />**element**: The element to check. |
 | `isFormElement`             | `(element: HTMLElement): boolean` | Check if the tag name is a form element.<br /><br />**element**: The element to check (attr or tag name). |
-| `mutationEventListener`     | `(): void`                        | Mutation observer for form elements. Slot change does not trigger unless<br />root-level elements are added/removed. This is a workaround to ensure<br />nested form elements are also observed. |
 | `onSlotChange`              | `(event: Event): void`            | Slot change event listener. This is the main entry point for the form element.<br /><br />**event**: The slot change event. |
 | `queryAuroElements`         | `(): NodeList`                    | Construct the query strings from elements, append them together, execute, and return the NodeList. |
 | `reset`                     | `(): void`                        | Reset fires an event called `reset` - just as you would expect from a normal form. |
 | `setDisabledStateOnButtons` | `(): void`                        |                                                  |
-| `sharedInputListener`       | `(event: Event): void`            | Shared input listener for all form elements.<br /><br />**event**: The event that is fired from the form element. |
-| `sharedValidationListener`  | `(event: Event): void`            | Shared validation listener for all form elements.<br /><br />**event**: The event that is fired from the form element. |
 | `submit`                    | `(): void`                        | Submit fires an event called `submit` - just as you would expect from a normal form. |
 
 ## Events

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -110,7 +110,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-menu/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-menu/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -2,25 +2,19 @@
 
 The auro-menu element provides users a way to select from a list of options.
 
-## Attributes
-
-| Attribute        | Type                            | Description                                      |
-|------------------|---------------------------------|--------------------------------------------------|
-| `optionselected` | `Array<HTMLElement>\|undefined` | An array of currently selected menu options. In single-select mode, the array will contain only one HTMLElement. `undefined` when no options are selected. |
-
 ## Properties
 
-| Property                | Attribute        | Type                       | Default     | Description                                      |
-|-------------------------|------------------|----------------------------|-------------|--------------------------------------------------|
-| `disabled`              | `disabled`       | `boolean`                  |             | When true, the entire menu and all options are disabled; |
-| `hasLoadingPlaceholder` |                  | `boolean`                  |             | Indicates whether the menu has a loadingIcon or loadingText to render when in a loading state. |
-| `loading`               | `loading`        | `boolean`                  | false       | When true, displays a loading state using the loadingIcon and loadingText slots if provided. |
-| `matchWord`             | `matchword`      | `string`                   | "undefined" | Specifies a string used to highlight matched string parts in options. |
-| `multiSelect`           | `multiselect`    | `boolean`                  | false       | When true, the selected option can be multiple options. |
-| `noCheckmark`           | `nocheckmark`    | `boolean`                  | false       | When true, selected option will not show the checkmark. |
-| `optionActive`          | `optionactive`   | `object`                   | "undefined" | Specifies the current active menuOption.         |
-| `optionSelected`        | `optionSelected` |                            | "undefined" |                                                  |
-| `value`                 | `value`          | `Array<string>\|undefined` | "undefined" | Value selected for the menu. `undefined` when no selection has been made, otherwise an array of strings. In single-select mode, the array will contain only one value. |
+| Property                | Attribute        | Type                            | Default     | Description                                      |
+|-------------------------|------------------|---------------------------------|-------------|--------------------------------------------------|
+| `disabled`              | `disabled`       | `boolean`                       |             | When true, the entire menu and all options are disabled; |
+| `hasLoadingPlaceholder` |                  | `boolean`                       |             | Indicates whether the menu has a loadingIcon or loadingText to render when in a loading state. |
+| `loading`               | `loading`        | `boolean`                       | false       | When true, displays a loading state using the loadingIcon and loadingText slots if provided. |
+| `matchWord`             | `matchword`      | `string`                        | "undefined" | Specifies a string used to highlight matched string parts in options. |
+| `multiSelect`           | `multiselect`    | `boolean`                       | false       | When true, the selected option can be multiple options. |
+| `noCheckmark`           | `nocheckmark`    | `boolean`                       | false       | When true, selected option will not show the checkmark. |
+| `optionActive`          | `optionactive`   | `object`                        | "undefined" | Specifies the current active menuOption.         |
+| `optionSelected`        | `optionSelected` | `Array<HTMLElement>\|undefined` | "undefined" | An array of currently selected menu options. In single-select mode, the array will contain only one HTMLElement. `undefined` when no options are selected. |
+| `value`                 | `value`          | `Array<string>\|undefined`      | "undefined" | Value selected for the menu. `undefined` when no selection has been made, otherwise an array of strings. In single-select mode, the array will contain only one value. |
 
 ## Methods
 

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -100,7 +100,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-radio/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-radio/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/components/select/README.md
+++ b/components/select/README.md
@@ -111,7 +111,7 @@ The use of any Auro custom element has a dependency on the [Auro Design Tokens](
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@3.2.8/auro-select/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-select/+esm"></script>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 

--- a/docs/templates/bundleInstallDescription.md
+++ b/docs/templates/bundleInstallDescription.md
@@ -1,5 +1,5 @@
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/{{ monorepoName }}@{{ formkitVersion }}/{{ namespace }}-{{ name }}/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/{{ monorepoName }}@latest/{{ namespace }}-{{ name }}/+esm"></script>
 ```


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Use unpinned `@latest` tag for CDN links across READMEs and bundle templates, and clean up API documentation tables and descriptions for combobox, menu, and and form components

Enhancements:
- Standardize API table formatting for combobox, menu, and form components
- Streamline form API docs by removing obsolete properties and clarifying method descriptions

Documentation:
- Update all component README CDN links and bundle install template to use `@latest` tag instead of specific versions