### PR TITLE
test: setup to run a11y check on all test iteration for checkbox 

### DIFF
--- a/components/checkbox/test/auro-checkbox.test.js
+++ b/components/checkbox/test/auro-checkbox.test.js
@@ -4,12 +4,15 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable max-lines */
-import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated } from "@open-wc/testing";
+import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
 
-import '../src/registered.js';
+import "../src/registered.js";
 
-describe('auro-checkbox-group', () => {
-  it('has the expected properties and validity in required state', async () => {
+useAccessibleIt();
+
+describe("auro-checkbox-group", () => {
+  it("has the expected properties and validity in required state", async () => {
     const el = await fixture(html`
       <auro-checkbox-group required>
         <auro-checkbox
@@ -27,24 +30,24 @@ describe('auro-checkbox-group', () => {
     `);
 
     expect(el.required).to.be.true;
-    expect(el.ariaRequired).to.equal('true');
+    expect(el.ariaRequired).to.equal("true");
 
     const alaskaCheckbox = el.querySelector("auro-checkbox[id=alaska]");
 
-    alaskaCheckbox.shadowRoot.querySelector('input').click();
+    alaskaCheckbox.shadowRoot.querySelector("input").click();
 
     await elementUpdated(el);
 
-    expect(el.validity).to.equal('valid');
+    expect(el.validity).to.equal("valid");
 
-    alaskaCheckbox.shadowRoot.querySelector('input').click();
+    alaskaCheckbox.shadowRoot.querySelector("input").click();
 
     await elementUpdated(el);
 
-    expect(el.validity).to.equal('valueMissing');
+    expect(el.validity).to.equal("valueMissing");
   });
 
-  it('has the expected properties and validity in error state', async () => {
+  it("has the expected properties and validity in error state", async () => {
     const el = await fixture(html`
       <auro-checkbox-group error="custom error message">
         <auro-checkbox
@@ -61,20 +64,20 @@ describe('auro-checkbox-group', () => {
       </auro-checkbox-group>
     `);
 
-    expect(el.hasAttribute('error')).to.be.true;
-    expect(el.hasAttribute('aria-invalid')).to.be.true;
-    expect(el.validity).to.equal('customError');
+    expect(el.hasAttribute("error")).to.be.true;
+    expect(el.hasAttribute("aria-invalid")).to.be.true;
+    expect(el.validity).to.equal("customError");
 
-    el.removeAttribute('error');
+    el.removeAttribute("error");
 
     await elementUpdated(el);
 
-    expect(el.hasAttribute('error')).to.be.false;
-    expect(el.hasAttribute('aria-invalid')).to.be.false;
-    expect(el.validity).to.equal('valid');
+    expect(el.hasAttribute("error")).to.be.false;
+    expect(el.hasAttribute("aria-invalid")).to.be.false;
+    expect(el.validity).to.equal("valid");
   });
 
-  it('should fire a input event with correct data', async () => {
+  it("should fire a input event with correct data", async () => {
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -92,11 +95,11 @@ describe('auro-checkbox-group', () => {
     `);
 
     const alaskaCheckbox = el.querySelector("auro-checkbox[id=alaska]"),
-      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector('input');
+      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector("input");
 
     let result = false;
 
-    el.addEventListener('input', (event) => {
+    el.addEventListener("input", (event) => {
       result = event.target.checked;
     });
 
@@ -105,7 +108,7 @@ describe('auro-checkbox-group', () => {
     expect(result).to.be.true;
   });
 
-  it('can uncheck a checkbox after selection', async () => {
+  it("can uncheck a checkbox after selection", async () => {
     const el = await fixture(html`
       <auro-checkbox
         id="alaska"
@@ -115,19 +118,20 @@ describe('auro-checkbox-group', () => {
     `);
 
     const alaskaCheckbox = el,
-      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector('input');
+      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector("input");
 
     alaskaCheckboxInput.click();
-    alaskaCheckboxInput.dispatchEvent(new Event('input'));
+    alaskaCheckboxInput.dispatchEvent(new Event("input"));
     await alaskaCheckbox.updateComplete;
     expect(alaskaCheckboxInput.checked).to.be.true;
 
     alaskaCheckbox.checked = false;
     await alaskaCheckbox.updateComplete;
-    expect(alaskaCheckboxInput.checked, 'the shadow input was not unchecked').to.be.false;
+    expect(alaskaCheckboxInput.checked, "the shadow input was not unchecked").to
+      .be.false;
   });
 
-  it('can select multiple checkboxes', async () => {
+  it("can select multiple checkboxes", async () => {
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -145,9 +149,10 @@ describe('auro-checkbox-group', () => {
     `);
 
     const alaskaCheckbox = el.querySelector("auro-checkbox[id=alaska]"),
-      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector('input'),
+      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector("input"),
       washingtonCheckbox = el.querySelector("auro-checkbox[id=washington]"),
-      washingtonCheckboxInput = washingtonCheckbox.shadowRoot.querySelector('input');
+      washingtonCheckboxInput =
+        washingtonCheckbox.shadowRoot.querySelector("input");
 
     expect(alaskaCheckbox.checked).to.not.be.true;
     expect(washingtonCheckbox.checked).to.not.be.true;
@@ -161,7 +166,7 @@ describe('auro-checkbox-group', () => {
     expect(washingtonCheckbox.checked).to.be.true;
   });
 
-  it('controls child state after slot change', async () => {
+  it("controls child state after slot change", async () => {
     const el = await fixture(html`
       <auro-checkbox-group disabled required error="Test message">
         <auro-checkbox
@@ -177,7 +182,7 @@ describe('auro-checkbox-group', () => {
       </auro-checkbox-group>
     `);
 
-    const checkboxes = el.querySelectorAll('auro-checkbox');
+    const checkboxes = el.querySelectorAll("auro-checkbox");
 
     checkboxes.forEach((checkbox) => {
       expect(checkbox.disabled).to.be.true;
@@ -185,29 +190,7 @@ describe('auro-checkbox-group', () => {
     });
   });
 
-  it('is accessible', async () => {
-    const el = await fixture(html`
-      <auro-checkbox-group>
-        <auro-checkbox
-          id="alaska"
-          name="states"
-          value="alaska"
-          checked
-        ></auro-checkbox>
-
-        <auro-checkbox
-          id="washington"
-          name="states"
-          type="radio"
-          value="washington"
-        ></auro-checkbox>
-      </auro-checkbox-group>
-    `);
-
-    expect(el).to.be.accessible();
-  });
-
-  it('updates states on children', async () => {
+  it("updates states on children", async () => {
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -231,15 +214,16 @@ describe('auro-checkbox-group', () => {
 
     await elementUpdated(el);
 
-    const checkboxes = el.querySelectorAll('auro-checkbox');
+    const checkboxes = el.querySelectorAll("auro-checkbox");
 
     checkboxes.forEach((checkbox) => {
-      expect(checkbox.disabled, "child disabled state was not updated").to.be.true;
+      expect(checkbox.disabled, "child disabled state was not updated").to.be
+        .true;
       expect(checkbox.error, "child error state was not updated").to.be.true;
     });
   });
 
-  it('disabled state on checkboxes updates correctly', async () => {
+  it("disabled state on checkboxes updates correctly", async () => {
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -257,8 +241,8 @@ describe('auro-checkbox-group', () => {
       </auro-checkbox-group>
     `);
 
-    const alaskaCheckbox = document.getElementById('alaska');
-    const washingtonCheckbox = document.getElementById('washington');
+    const alaskaCheckbox = document.getElementById("alaska");
+    const washingtonCheckbox = document.getElementById("washington");
 
     expect(alaskaCheckbox.disabled).to.be.true;
     expect(washingtonCheckbox.disabled).to.be.false;
@@ -278,7 +262,7 @@ describe('auro-checkbox-group', () => {
     expect(washingtonCheckbox.disabled).to.be.false;
   });
 
-  it('exposes .value as an array of strings', async () => {
+  it("exposes .value as an array of strings", async () => {
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -295,15 +279,15 @@ describe('auro-checkbox-group', () => {
     `);
 
     const alaskaCheckbox = el.querySelector("auro-checkbox[id=alaska]"),
-      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector('input');
+      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector("input");
 
     // Click the first checkbox
     alaskaCheckboxInput.click();
 
-    await expect(el.value).to.eql(['alaska']);
+    await expect(el.value).to.eql(["alaska"]);
   });
 
-  it('resets value to empty array when calling reset()', async () => {
+  it("resets value to empty array when calling reset()", async () => {
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -321,9 +305,9 @@ describe('auro-checkbox-group', () => {
     `);
 
     const alaskaCheckbox = el.querySelector("auro-checkbox[id=alaska]"),
-      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector('input');
+      alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector("input");
 
-    const group = document.querySelector('auro-checkbox-group');
+    const group = document.querySelector("auro-checkbox-group");
 
     // Click the first checkbox
     alaskaCheckboxInput.click();
@@ -331,7 +315,7 @@ describe('auro-checkbox-group', () => {
     await elementUpdated(el);
 
     expect(alaskaCheckbox.checked).to.be.true;
-    expect(group.value).to.eql(['alaska']);
+    expect(group.value).to.eql(["alaska"]);
 
     group.reset();
 
@@ -341,8 +325,8 @@ describe('auro-checkbox-group', () => {
   });
 });
 
-describe('auro-checkbox', () => {
-  it('has the expected properties', async () => {
+describe("auro-checkbox", () => {
+  it("has the expected properties", async () => {
     const expectedId = "testId",
       expectedName = "testName",
       expectedValue = "testValue";
@@ -355,18 +339,19 @@ describe('auro-checkbox', () => {
         checked
         disabled
         error
-      >Checkbox option</auro-checkbox>
+        >Checkbox option</auro-checkbox
+      >
     `);
 
     const root = el.shadowRoot;
-    const input = root.querySelector('input');
-    const errorBorder = root.querySelector('.errorBorder');
+    const input = root.querySelector("input");
+    const errorBorder = root.querySelector(".errorBorder");
 
     expect(input.checked).to.be.true;
     expect(input.disabled).to.be.true;
     expect(input.value).to.equal(expectedValue);
     expect(input.name).to.equal(expectedName);
-    expect(input.type).to.equal('checkbox');
+    expect(input.type).to.equal("checkbox");
     expect(errorBorder).to.not.be.undefined;
     expect(el).dom.to.equal(`
       <auro-checkbox id="${expectedId}" name="${expectedName}" value="${expectedValue}" error checked disabled>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-formkit",
-  "version": "3.2.8",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-formkit",
-      "version": "3.2.8",
+      "version": "0.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -14,7 +14,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@aurodesignsystem/auro-library": "^4.4.1",
+        "@aurodesignsystem/auro-library": "^4.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit": "^3.2.1"
       },
@@ -1392,9 +1392,9 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-4.4.1.tgz",
-      "integrity": "sha512-5/zK52RfrH7zDKlAhgBkLRyXlRsZsnelnLZuBlRGd7wclmyw3FRuaul+1dpgCulgtZWKiZv8TlE8YdBrwnlC+w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-4.5.0.tgz",
+      "integrity": "sha512-yy1pKRQjYQ808e2hh87BxWwbV/Vweb9IpISm2SnqJ3K0mUKHZ7Zn1BFPWO8hc0Zf5RvHPDa0FqzeXaySytkWaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "lit": "^3.2.1",
     "@lit/reactive-element": "^2.1.0",
-    "@aurodesignsystem/auro-library": "^4.4.1"
+    "@aurodesignsystem/auro-library": "^4.5.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "*"


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #450
bump auro-library version for checkbox's test to run a11y check on every iteration.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Upgrade checkbox tests to leverage automatic per-iteration accessibility checks by bumping the library version and standardize test code formatting

Enhancements:
- Standardize auro-checkbox tests to use double quotes for string literals
- Remove the standalone accessibility test as a11y checks now run on every iteration

Build:
- Bump @aurodesignsystem/auro-library dependency to ^4.5.0