### PR TITLE
feat: carryover `displayValue` slot from selected menuoption to `auro-select`

### DIFF
--- a/components/dropdown/src/styles/emphasized/style.scss
+++ b/components/dropdown/src/styles/emphasized/style.scss
@@ -24,8 +24,8 @@
 .layout-emphasized-left,
 .layout-emphasized-right {
   .chevron {
-    margin-left: 8px;
-    margin-right: 24px;
+    margin-left: var(--ds-size-100, $ds-size-100);
+    margin-right: var(--ds-size-300, $ds-size-300);
   }
 }
 
@@ -65,142 +65,21 @@
 
 :host([layout*='emphasized'][shape*='pill']:not([layout*='right'])) {
   .leftIndent {
-    margin-left: 24px;
-    width: calc(100% - 24px);
+    margin-left: var(--ds-size-300, $ds-size-300);
+    width: calc(100% - var(--ds-size-300, $ds-size-300));
   }
 }
 
 :host([layout*='emphasized'][shape*='pill']:not([layout*='left'])) {
   .rightIndent {
-    margin-right: 24px;
-    width: calc(100% - 24px);
+    margin-right: var(--ds-size-300, $ds-size-300);
+    width: calc(100% - var(--ds-size-300, $ds-size-300));
   }
 }
 
 :host([layout*='emphasized'][shape*='pill']:not([layout*='left']):not([layout*='right'])) {
   .rightIndent {
-    margin-right: 24px;
-    width: calc(100% - 48px);
+    margin-right: var(--ds-size-300, $ds-size-300);
+    width: calc(100% - var(--ds-size-600, $ds-size-600));
   }
 }
-
-// .layout-emphasized,
-// .layout-emphasized-left,
-// .layout-emphasized-right {
-//   //
-// }
-
-// :host {
-//   position: relative;
-//   display: inline-block; 
-//   max-width: 100%;
-// }
-
-// :host([fluid]) {
-//   display: block;
-// }
-
-// #bibSizer {
-//   position: absolute;
-//   z-index: -1;
-//   opacity: 0;
-//   pointer-events: none;
-// }
-
-// .label {
-//   font-size: var(--ds-text-body-size-xs, $ds-text-body-size-xs);
-//   line-height: var(--ds-text-body-size-default, $ds-text-body-size-default);
-//   transition: font-size .3s cubic-bezier(.215, .61, .355, 1);
-//   white-space: normal;
-
-//   &[hasTrigger='false'] {
-//     font-size: var(--ds-text-body-size-default, $ds-text-body-size-default);
-//   }
-// }
-
-// .trigger {
-//   position: relative;
-//   display: flex;
-//   align-items: center;
-
-//   &[showBorder] {
-//     border-width: 1px;
-//     border-style: solid;
-//     cursor: pointer;
-//     outline-style: solid;
-//     outline-width: 1px;
-//   }
-// }
-
-// @media (hover: hover) {
-//   .trigger {
-//     &:hover {
-//       cursor: pointer;
-//     }
-//   }
-// }
-
-// .triggerContentWrapper {
-//   overflow: hidden;
-//   flex: 1;
-//   text-overflow: ellipsis;
-//   white-space: nowrap;
-// }
-
-
-// /* stylelint-disable selector-id-pattern */
-// #showStateIcon {
-//   display: flex;
-//   overflow: hidden;
-//   height: 100%;
-//   align-items: center;
-//   margin-left: var(--ds-size-100, $ds-size-100);
-
-//   [auro-icon] {
-//     height: var(--ds-size-300, $ds-size-300);
-//     line-height: var(--ds-size-300, $ds-size-300);
-//   }
-
-//   &[data-expanded='true'] {
-//     [auro-icon] {
-//       transform: rotate(-180deg);
-//     }
-//   }
-// }
-// /* stylelint-enable selector-id-pattern */
-
-// :host([matchwidth]) {
-//   #bibSizer {
-//     width: 100%;
-//   }
-// }
-
-// :host([disabled]) {
-//   pointer-events: none;
-// }
-
-// :host([inset]) {
-//   .trigger {
-//     padding: var(--ds-size-150, $ds-size-150) var(--ds-size-200, $ds-size-200);
-//   }
-// }
-
-// :host([common]),
-// :host([inset][bordered]) {
-//   .trigger {
-//     padding: var(--ds-size-200, $ds-size-200) var(--ds-size-150, $ds-size-150);
-//   }
-// }
-
-// :host([inset][bordered][labeled]) {
-//   .trigger {
-//     padding: var(--ds-size-100, $ds-size-100) var(--ds-size-150, $ds-size-150);
-//   }
-// }
-
-// :host([common]),
-// :host([rounded]) {
-//   .trigger {
-//     border-radius: var(--ds-border-radius, $ds-border-radius);
-//   }
-// }

--- a/components/dropdown/src/styles/snowflake/style.scss
+++ b/components/dropdown/src/styles/snowflake/style.scss
@@ -56,13 +56,13 @@
 
 :host([layout*='snowflake']) {
   .leftIndent {
-    margin-left: 24px;
-    width: calc(100% - 48px);
+    margin-left: var(--ds-size-300, $ds-size-300);
+    width: calc(100% - var(--ds-size-600, $ds-size-600));
   }
 
   .rightIndent {
-    margin-right: 24px;
-    width: calc(100% - 48px);
+    margin-right: var(--ds-size-300, $ds-size-300);
+    width: calc(100% - var(--ds-size-600, $ds-size-600));
   }
 }
 
@@ -70,122 +70,7 @@
 .layout-snowflake-left,
 .layout-snowflake-right {
   .chevron {
-    margin-left: 8px;
-    margin-right: 24px;
+    margin-left: var(--ds-size-100, $ds-size-100);
+    margin-right: var(--ds-size-300, $ds-size-300);
   }
 }
-
-// :host {
-//   position: relative;
-//   display: inline-block; 
-//   max-width: 100%;
-// }
-
-// :host([fluid]) {
-//   display: block;
-// }
-
-// #bibSizer {
-//   position: absolute;
-//   z-index: -1;
-//   opacity: 0;
-//   pointer-events: none;
-// }
-
-// .label {
-//   font-size: var(--ds-text-body-size-xs, $ds-text-body-size-xs);
-//   line-height: var(--ds-text-body-size-default, $ds-text-body-size-default);
-//   transition: font-size .3s cubic-bezier(.215, .61, .355, 1);
-//   white-space: normal;
-
-//   &[hasTrigger='false'] {
-//     font-size: var(--ds-text-body-size-default, $ds-text-body-size-default);
-//   }
-// }
-
-// .trigger {
-//   position: relative;
-//   display: flex;
-//   align-items: center;
-
-//   &[showBorder] {
-//     border-width: 1px;
-//     border-style: solid;
-//     cursor: pointer;
-//     outline-style: solid;
-//     outline-width: 1px;
-//   }
-// }
-
-// @media (hover: hover) {
-//   .trigger {
-//     &:hover {
-//       cursor: pointer;
-//     }
-//   }
-// }
-
-// .triggerContentWrapper {
-//   overflow: hidden;
-//   flex: 1;
-//   text-overflow: ellipsis;
-//   white-space: nowrap;
-// }
-
-
-// /* stylelint-disable selector-id-pattern */
-// #showStateIcon {
-//   display: flex;
-//   overflow: hidden;
-//   height: 100%;
-//   align-items: center;
-//   margin-left: var(--ds-size-100, $ds-size-100);
-
-//   [auro-icon] {
-//     height: var(--ds-size-300, $ds-size-300);
-//     line-height: var(--ds-size-300, $ds-size-300);
-//   }
-
-//   &[data-expanded='true'] {
-//     [auro-icon] {
-//       transform: rotate(-180deg);
-//     }
-//   }
-// }
-// /* stylelint-enable selector-id-pattern */
-
-// :host([matchwidth]) {
-//   #bibSizer {
-//     width: 100%;
-//   }
-// }
-
-// :host([disabled]) {
-//   pointer-events: none;
-// }
-
-// :host([inset]) {
-//   .trigger {
-//     padding: var(--ds-size-150, $ds-size-150) var(--ds-size-200, $ds-size-200);
-//   }
-// }
-
-// :host([common]),
-// :host([inset][bordered]) {
-//   .trigger {
-//     padding: var(--ds-size-200, $ds-size-200) var(--ds-size-150, $ds-size-150);
-//   }
-// }
-
-// :host([inset][bordered][labeled]) {
-//   .trigger {
-//     padding: var(--ds-size-100, $ds-size-100) var(--ds-size-150, $ds-size-150);
-//   }
-// }
-
-// :host([common]),
-// :host([rounded]) {
-//   .trigger {
-//     border-radius: var(--ds-border-radius, $ds-border-radius);
-//   }
-// }

--- a/components/select/README.md
+++ b/components/select/README.md
@@ -17,128 +17,44 @@ The following sections are editable by making changes to the following files:
 | Component Example Code | HTML sample code of the components use            | `./apiExamples/basic.html`          |
 -->
 
-# Select
+# {{ capitalize name }}
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/description.md) -->
-<!-- The below content is automatically added from ./docs/partials/description.md -->
-`<auro-select>` is a combination <auro-hyperlink href="https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements">HTML custom element</auro-hyperlink> that consists of a pre-defined trigger element, `<auro-menu>` for the panel content. The `<auro-select>` element presents a menu of options. The options within the menu are represented by `<auro-menu>` and `<auro-menuoption>` elements. You can pre-select options for the user with the `selected` attribute as part of the `<auro-menuoption>` API.
 <!-- AURO-GENERATED-CONTENT:END -->
+
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/readmeAddlInfo.md) -->
-<!-- The below content is automatically added from ./docs/partials/readmeAddlInfo.md -->
-<!-- AURO-GENERATED-CONTENT This file is to be used for any additional content that should be included in the README.md which is specific to this component. -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## Getting Started
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=../../docs/templates/componentInstall.md) -->
-<!-- The below content is automatically added from ../../docs/templates/componentInstall.md -->
-
-#### NPM Installation
-
-```shell
-$ npm i @aurodesignsystem/auro-formkit
-```
 <!-- AURO-GENERATED-CONTENT:END -->
+
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=../../docs/templates/gettingStarted.md) -->
-<!-- The below content is automatically added from ../../docs/templates/gettingStarted.md -->
-
-### Import Options
-
-#### Automatic Registration
-
-For automatic registration, simply import the component:
-
-```javascript
-// Registers <auro-select> automatically
-import '@aurodesignsystem/auro-formkit/auro-select';
-```
-
-#### Custom Registration
-
-To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our static `AuroSelect.register('custom-select')` method on the component class and pass in a unique name.
-
-```javascript
-// Import the class only
-import { AuroSelect } from '@aurodesignsystem/auro-formkit/auro-select/class';
-
-// Register with a custom name if desired
-AuroSelect.register('custom-select');
-```
-
-#### TypeScript Module Resolution
-
-When using TypeScript set `moduleResolution` to `bundler`, add the following to your `tsconfig.json`:
-
-```json
-{
-    "compilerOptions": {
-        "moduleResolution": "bundler"
-    }
-}
-```
-
-This configuration enables proper module resolution for the component's TypeScript files.
 <!-- AURO-GENERATED-CONTENT:END -->
+
 **Reference component in HTML**
 
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=./apiExamples/basic.html) -->
-<!-- The below code snippet is automatically added from ./apiExamples/basic.html -->
-
-```html
-<auro-select>
-  <span slot="bib.fullscreen.headline">Bib Headline</span>
-  <span slot="label">Select Example</span>
-  <auro-menu>
-    <auro-menuoption value="stops">Stops</auro-menuoption>
-    <auro-menuoption value="price">Price</auro-menuoption>
-    <auro-menuoption value="duration">Duration</auro-menuoption>
-    <auro-menuoption value="departure">Departure</auro-menuoption>
-    <auro-menuoption value="arrival">Arrival</auro-menuoption>
-    <auro-menuoption value="prefer alaska">Prefer Alaska</auro-menuoption>
-  </auro-menu>
-</auro-select>
-```
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ### Design Token CSS Custom Property dependency
 
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/WC-Generator/master/componentDocs/partials/development/designTokens.md) -->
-The use of any Auro custom element has a dependency on the [Auro Design Tokens](https://auro.alaskaair.com/getting-started/developers/design-tokens).
-
 <!-- AURO-GENERATED-CONTENT:END -->
+
 
 ## Install from CDN
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=../../docs/templates/bundleInstallDescription.md) -->
-<!-- The below content is automatically added from ../../docs/templates/bundleInstallDescription.md -->
-In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
-
-```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-formkit@latest/auro-select/+esm"></script>
-```
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## UI development browser support
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/WC-Generator/master/componentDocs/partials/browserSupport.md) -->
-For the most up to date information on [UI development browser support](https://auro.alaskaair.com/support/browsersSupport)
-
 <!-- AURO-GENERATED-CONTENT:END -->
 
-## auro-select use cases
+## {{ withAuroNamespace name }} use cases
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/useCases.md) -->
-<!-- The below content is automatically added from ./docs/partials/useCases.md -->
-See description.
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## Formkit development
 
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=../../docs/partials/developmentDescription.md) -->
-<!-- The below content is automatically added from ../../docs/partials/developmentDescription.md -->
-
-### Filtering
-
-Running the `dev` command will open a `localhost` development server for all components in the monorepo at once.
-
-To only develop a single component, use the `--filter` flag:
-
-```shell
-npx turbo dev --filter=@aurodesignsystem/auro-input
-```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/components/select/apiExamples/emphasized/basic-ondark.html
+++ b/components/select/apiExamples/emphasized/basic-ondark.html
@@ -1,15 +1,79 @@
-<auro-select layout="emphasized" shape="pill" size="xl" value="flights" ondark required forceDisplayValue style="display:inline-block;">
+<auro-select layout="emphasized" shape="pill" size="xl" value="flights" forceDisplayValue ondark required style="display:inline-block;">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Select Example</span>
-  <span slot="helptext">Example help text</span>
-  <div slot="displayValue">
-    <auro-icon style="--ds-auro-icon-size: 40px;" category="terminal" name="plane-diag-fill" ondark></auro-icon>
-  </div>
-  <auro-menu nocheckmark ondark>
-    <auro-menuoption value="flights"><auro-icon category="terminal" name="plane-diag-fill" customcolor></auro-icon> Flights</auro-menuoption>
-    <auro-menuoption value="cars"><auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars</auro-menuoption>
-    <auro-menuoption value="hotels"><auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels</auro-menuoption>
-    <auro-menuoption value="packages"><auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages</auro-menuoption>
-    <auro-menuoption value="cruises"><auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises</auro-menuoption>
+  <span slot="helptext">forceDisplayValue</span>
+  <span slot="placeholder">Placeholder</span>
+  <auro-menu nocheckmark>
+    <auro-menuoption value="flights">
+      <auro-icon category="terminal" name="plane-diag-stroke" customcolor></auro-icon> Flights
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="terminal" name="plane-diag-fill" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cars">
+      <auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="car-rental-stroke" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="hotels">
+      <auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="hotel-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="packages">
+      <auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="shop" name="gift-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cruises">
+      <auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="in-flight" name="boarding" customcolor></auro-icon>
+    </auro-menuoption>
+  </auro-menu>
+</auro-select>
+
+<auro-select layout="emphasized" shape="pill" size="xl" value="flights" ondark required style="display:inline-block;">
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
+  <span slot="helptext">displayValue</span>
+  <auro-menu nocheckmark>
+    <auro-menuoption value="flights">
+      <auro-icon category="terminal" name="plane-diag-stroke" customcolor></auro-icon> Flights
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="terminal" name="plane-diag-fill" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cars">
+      <auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="car-rental-stroke" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="hotels">
+      <auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="hotel-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="packages">
+      <auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="shop" name="gift-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cruises">
+      <auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="in-flight" name="boarding" customcolor></auro-icon>
+    </auro-menuoption>
+  </auro-menu>
+</auro-select>
+
+<auro-select layout="emphasized" shape="pill" size="xl" value="flights" ondark required style="display:inline-block;">
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
+  <span slot="helptext">no displayValue in menuoption</span>
+  <auro-menu nocheckmark>
+    <auro-menuoption value="flights">
+      <auro-icon category="terminal" name="plane-diag-stroke" customcolor></auro-icon> Flights
+    </auro-menuoption>
+    <auro-menuoption value="cars">
+      <auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars
+    </auro-menuoption>
+    <auro-menuoption value="hotels">
+      <auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels
+    </auro-menuoption>
+    <auro-menuoption value="packages">
+      <auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages
+    </auro-menuoption>
+    <auro-menuoption value="cruises">
+      <auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises
+    </auro-menuoption>
   </auro-menu>
 </auro-select>

--- a/components/select/apiExamples/emphasized/basic.html
+++ b/components/select/apiExamples/emphasized/basic.html
@@ -1,15 +1,79 @@
-<auro-select layout="emphasized" shape="pill" size="xl" value="flights" required forceDisplayValue style="display:inline-block;">
+<auro-select layout="emphasized" shape="pill" size="xl" forceDisplayValue required style="display:inline-block;">
   <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Select Example</span>
-  <span slot="helptext">Example help text</span>
-  <div slot="displayValue">
-    <auro-icon style="--ds-auro-icon-size: 40px;" category="terminal" name="plane-diag-fill"></auro-icon>
-  </div>
+  <span slot="helptext">forceDisplayValue</span>
+  <span slot="placeholder">Placeholder</span>
   <auro-menu nocheckmark>
-    <auro-menuoption value="flights"><auro-icon category="terminal" name="plane-diag-fill" customcolor></auro-icon> Flights</auro-menuoption>
-    <auro-menuoption value="cars"><auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars</auro-menuoption>
-    <auro-menuoption value="hotels"><auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels</auro-menuoption>
-    <auro-menuoption value="packages"><auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages</auro-menuoption>
-    <auro-menuoption value="cruises"><auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises</auro-menuoption>
+    <auro-menuoption value="flights">
+      <auro-icon category="terminal" name="plane-diag-stroke" customcolor></auro-icon> Flights
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="terminal" name="plane-diag-fill" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cars">
+      <auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="car-rental-stroke" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="hotels">
+      <auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="hotel-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="packages">
+      <auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="shop" name="gift-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cruises">
+      <auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="in-flight" name="boarding" customcolor></auro-icon>
+    </auro-menuoption>
+  </auro-menu>
+</auro-select>
+
+<auro-select layout="emphasized" shape="pill" size="xl" value="flights" required style="display:inline-block;">
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
+  <span slot="helptext">displayValue</span>
+  <auro-menu nocheckmark>
+    <auro-menuoption value="flights">
+      <auro-icon category="terminal" name="plane-diag-stroke" customcolor></auro-icon> Flights
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="terminal" name="plane-diag-fill" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cars">
+      <auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="car-rental-stroke" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="hotels">
+      <auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="destination" name="hotel-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="packages">
+      <auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="shop" name="gift-filled" customcolor></auro-icon>
+    </auro-menuoption>
+    <auro-menuoption value="cruises">
+      <auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises
+      <auro-icon style="--ds-auro-icon-size: 40px;" slot="displayValue" category="in-flight" name="boarding" customcolor></auro-icon>
+    </auro-menuoption>
+  </auro-menu>
+</auro-select>
+
+<auro-select layout="emphasized" shape="pill" size="xl" value="flights" required style="display:inline-block;">
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
+  <span slot="helptext">no displayValue in menuoption</span>
+  <auro-menu nocheckmark>
+    <auro-menuoption value="flights">
+      <auro-icon category="terminal" name="plane-diag-stroke" customcolor></auro-icon> Flights
+    </auro-menuoption>
+    <auro-menuoption value="cars">
+      <auro-icon category="destination" name="car-rental-stroke" customcolor></auro-icon> Cars
+    </auro-menuoption>
+    <auro-menuoption value="hotels">
+      <auro-icon category="destination" name="hotel-stroke" customcolor></auro-icon> Hotels
+    </auro-menuoption>
+    <auro-menuoption value="packages">
+      <auro-icon category="shop" name="gift-stroke" customcolor></auro-icon> Packages
+    </auro-menuoption>
+    <auro-menuoption value="cruises">
+      <auro-icon category="in-flight" name="boarding" customcolor></auro-icon> Cruises
+    </auro-menuoption>
   </auro-menu>
 </auro-select>

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -29,6 +29,10 @@
   flex: 1;
 }
 
+.valueContainer [slot="displayValue"] {
+  display: none;
+}
+
 .accents {
   display: flex;
   flex-direction: row;
@@ -41,10 +45,14 @@
 }
 
 .displayValue {
-  display: none;
+  display: block;
 
-  &.hasContent:is(.withValue):not(.hasFocus) {
-    display: block;
+  &:not(.force) {
+    display: none;
+
+    &.hasContent:is(.withValue):not(.hasFocus) {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is to show selected menuoption's `displayValue` slot instead of textContent

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enable the select component to carry over and render a menuoptions displayValue slot in the trigger, replacing textContent-based value rendering and deprecating the old forceDisplayValue behavior.

New Features:
- Clone and render the selected menuoptions displayValue slot inside the select trigger instead of using plain textContent.

Enhancements:
- Remove the forceDisplayValue property, its related class toggles, and the checkDisplayValueSlotChange logic.
- Simplify the component template to use a single displayValue slot with a fallback value container.
- Update API examples to define displayValue slots on menuoption elements without requiring forceDisplayValue.

Documentation:
- Remove forceDisplayValue from the API documentation.