### PR TITLE
fix: add nowrap to white space for slot=label

### DIFF
--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -12,6 +12,10 @@
 
 /* stylelint-disable selector-class-pattern */
 
+[slot='label'] {
+  white-space: nowrap;
+}
+
 [slot='trigger'] {
   width: 100%;
   padding: 0;


### PR DESCRIPTION
# Alaska Airlines Pull Request

To avoid issues with labels in auro-select the property nowrap was added to white-space

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Add CSS rule white-space: nowrap to [slot='label'] to prevent label text from wrapping