### PR TITLE
add `optionalLabel` slot

### DIFF
--- a/components/checkbox/apiExamples/optionalLabel.html
+++ b/components/checkbox/apiExamples/optionalLabel.html
@@ -1,0 +1,8 @@
+<auro-checkbox-group>
+  <span slot="legend">Form label goes here</span>
+  <span slot="optionalLabel" style="font-size: small; color: grey"> - optional</span>
+  <auro-checkbox value="value1" name="basic" id="checkbox-basic1">Checkbox option</auro-checkbox>
+  <auro-checkbox value="value2" name="basic" id="checkbox-basic2" checked>Checkbox option</auro-checkbox>
+  <auro-checkbox value="value3" name="basic" id="checkbox-basic3">Checkbox option that has some extra text that should wrap when rendered in a narrow container</auro-checkbox>
+  <auro-checkbox value="value4" name="basic" id="checkbox-basic4">Checkbox option</auro-checkbox>
+</auro-checkbox-group>

--- a/components/checkbox/docs/api.md
+++ b/components/checkbox/docs/api.md
@@ -33,11 +33,11 @@ The auro-checkbox-group element is a wrapper for auro-checkbox element.
 
 ## Slots
 
-| Name            | Description                                     |
-|-----------------|-------------------------------------------------|
-| `helpText`      | Allows for the helper text to be overridden.    |
-| `legend`        | Allows for the legend to be overridden.         |
-| `optionalLabel` | Allows for the optional label to be overridden. |
+| Name            | Description                                      |
+|-----------------|--------------------------------------------------|
+| `helpText`      | Allows for the helper text to be overridden.     |
+| `legend`        | Allows for the legend to be overridden.          |
+| `optionalLabel` | Allows overriding the optional display text "(optional)", which appears next to the label. |
 
 
 # auro-checkbox

--- a/components/checkbox/docs/partials/api.md
+++ b/components/checkbox/docs/partials/api.md
@@ -123,6 +123,23 @@ When present, the `required` attribute specifies that at least one or more `<aur
 
 </auro-accordion>
 
+### Custom optional label <a name="optionalLabel"></a>
+
+The `<auro-checkbox-group>` supports an `optionalLabel` slot, where users can can override the default `(optional)` notification text.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/optionalLabel.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/optionalLabel.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 ### Functional Examples
 
 #### Reset State

--- a/components/checkbox/src/auro-checkbox-group.js
+++ b/components/checkbox/src/auro-checkbox-group.js
@@ -25,7 +25,7 @@ import helpTextVersion from './helptextVersion.js';
  * The auro-checkbox-group element is a wrapper for auro-checkbox element.
  *
  * @slot {HTMLSlotElement} legend - Allows for the legend to be overridden.
- * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
+ * @slot {HTMLSlotElement} optionalLabel - Allows overriding the optional display text "(optional)", which appears next to the label.
  * @slot {HTMLSlotElement} helpText - Allows for the helper text to be overridden.
  * @event auroFormElement-validated - Notifies that the `validity` and `errorMessage` values have changed.
  */
@@ -395,7 +395,7 @@ export class AuroCheckboxGroup extends LitElement {
       <fieldset class="${classMap(groupClasses)}">
         <legend>
           <slot name="legend"></slot>
-          ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+          ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
         </legend>
         <slot @slotchange=${this.handleItems}></slot>
       </fieldset>

--- a/components/checkbox/src/auro-checkbox-group.js
+++ b/components/checkbox/src/auro-checkbox-group.js
@@ -393,10 +393,10 @@ export class AuroCheckboxGroup extends LitElement {
 
     return html`
       <fieldset class="${classMap(groupClasses)}">
-        ${this.required
-          ? html`<legend><slot name="legend"></slot></legend>`
-          : html`<legend><slot name="legend"></slot> (optional)</legend>`
-        }
+        <legend>
+          <slot name="legend"></slot>
+          ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+        </legend>
         <slot @slotchange=${this.handleItems}></slot>
       </fieldset>
 

--- a/components/combobox/apiExamples/optionalLabel.html
+++ b/components/combobox/apiExamples/optionalLabel.html
@@ -1,0 +1,13 @@
+<auro-combobox>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Name</span>
+  <span slot="optionalLabel" style="font-size: small; color: grey"> - optional</span>
+  <auro-menu>
+    <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+    <auro-menuoption value="Peaches" id="option-2">Peaches</auro-menuoption>
+    <auro-menuoption value="Grapes" id="option-3">Grapes</auro-menuoption>
+    <auro-menuoption value="Cherries" id="option-4">Cherries</auro-menuoption>
+    <auro-menuoption static nomatch>No matching option</auro-menuoption>
+  </auro-menu>
+</auro-combobox>

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -57,3 +57,4 @@
 | `displayValue`            | Allows custom HTML content to display the selected value when the combobox is not focused. Only works with `snowflake` and `emphasized` layouts. |
 | `helpText`                | Defines the content of the helpText.             |
 | `label`                   | Defines the content of the label.                |
+| `optionalLabel`           | Allows for the optional label to be overridden.  |

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -57,4 +57,4 @@
 | `displayValue`            | Allows custom HTML content to display the selected value when the combobox is not focused. Only works with `snowflake` and `emphasized` layouts. |
 | `helpText`                | Defines the content of the helpText.             |
 | `label`                   | Defines the content of the label.                |
-| `optionalLabel`           | Allows for the optional label to be overridden.  |
+| `optionalLabel`           | Allows overriding the optional display text "(optional)", which appears next to the label. |

--- a/components/combobox/docs/partials/api.md
+++ b/components/combobox/docs/partials/api.md
@@ -167,6 +167,24 @@ Populates the `required` attribute on the input. Used for client-side validation
 
 </auro-accordion>
 
+### Custom optional label <a name="optionalLabel"></a>
+
+The `<auro-combobox>` supports an `optionalLabel` slot, where users can can override the default `(optional)` notification text.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/optionalLabel.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/optionalLabel.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+
 #### value
 
 Use the `value` attribute to programmatically set the value of the combobox.

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -35,6 +35,7 @@ import {ifDefined} from "lit/directives/if-defined.js";
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * @slot - Default slot for the menu content.
+ * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
  * @slot bib.fullscreen.headline - Defines the headline to display above menu-options
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
@@ -990,6 +991,9 @@ export class AuroCombobox extends AuroElement {
         // It's because the bib is/will be separated from dropdown to body.
         this.transportAssignedNodes(event.target, this.inputInBib, "label");
         break;
+      case 'optionalLabel':
+        this.transportAssignedNodes(event.target, this.inputInBib, "optionalLabel");
+        break;
       case 'bib.fullscreen.headline':
         this.transportAssignedNodes(event.target, this.bibtemplate, 'header');
         break;
@@ -1061,6 +1065,7 @@ export class AuroCombobox extends AuroElement {
               size="${this.size}"
               slot="trigger">
               <slot name="label" slot="label" @slotchange="${this.handleSlotChange}"></slot>
+              <slot name="optionalLabel" slot="optionalLabel" @slotchange="${this.handleSlotChange}"> (optional)</slot>
               <slot name="displayValue" slot="displayValue"></slot>
             </${this.inputTag}>
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -35,7 +35,7 @@ import {ifDefined} from "lit/directives/if-defined.js";
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * @slot - Default slot for the menu content.
- * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
+ * @slot {HTMLSlotElement} optionalLabel - Allows overriding the optional display text "(optional)", which appears next to the label.
  * @slot bib.fullscreen.headline - Defines the headline to display above menu-options
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.

--- a/components/input/apiExamples/optionalLabel.html
+++ b/components/input/apiExamples/optionalLabel.html
@@ -1,0 +1,5 @@
+<auro-input placeholder="John Doe" bordered>
+  <span slot="label">Full name</span>
+  <span slot="optionalLabel" style="color: grey; font-size: small"> - optional</span>
+  <span slot="helptext">Please enter your full name.</span>
+</auro-input>

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -77,7 +77,7 @@ Generate unique names for dependency components.
 | `displayValue`  | Allows custom HTML content to display in place of the value when the input is not focused. |
 | `helptext`      | Sets the help text displayed below the input.    |
 | `label`         | Sets the label text for the input.               |
-| `optionalLabel` | Allows for the optional label to be overridden.  |
+| `optionalLabel` | Allows overriding the optional display text "(optional)", which appears next to the label. |
 
 ## CSS Shadow Parts
 

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -72,11 +72,12 @@ Generate unique names for dependency components.
 
 ## Slots
 
-| Name           | Description                                      |
-|----------------|--------------------------------------------------|
-| `displayValue` | Allows custom HTML content to display in place of the value when the input is not focused. |
-| `helptext`     | Sets the help text displayed below the input.    |
-| `label`        | Sets the label text for the input.               |
+| Name            | Description                                      |
+|-----------------|--------------------------------------------------|
+| `displayValue`  | Allows custom HTML content to display in place of the value when the input is not focused. |
+| `helptext`      | Sets the help text displayed below the input.    |
+| `label`         | Sets the label text for the input.               |
+| `optionalLabel` | Allows for the optional label to be overridden.  |
 
 ## CSS Shadow Parts
 

--- a/components/input/docs/partials/api.md
+++ b/components/input/docs/partials/api.md
@@ -375,6 +375,24 @@ When the validity check fails, the validityState equals `valueMissing`. The erro
 
 </auro-accordion>
 
+
+### Custom optional label <a name="optionalLabel"></a>
+
+The `<auro-input>` supports an `optionalLabel` slot, where users can can override the default `(optional)` notification text.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/optionalLabel.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/optionalLabel.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 ### Validation on input <a name="validateOnInput"></a>
 
 Use the `validateOnInput` attribute to enable live validation on the `input` event. Recommended use is with setting a custom `pattern` and validation is required prior to a `blur` event.

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -267,7 +267,7 @@ export class AuroInput extends BaseInput {
         <slot name="label">
           ${this.label}
         </slot>
-        ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+        ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
       </label>
 
       <!-- Attributes are grouped into: basic attributes, event handlers, ARIA attributes, and input-specific attributes -->

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -267,6 +267,7 @@ export class AuroInput extends BaseInput {
         <slot name="label">
           ${this.label}
         </slot>
+        ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
       </label>
 
       <!-- Attributes are grouped into: basic attributes, event handlers, ARIA attributes, and input-specific attributes -->

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -24,7 +24,7 @@ import { AuroElement } from '../../layoutElement/src/auroElement.js';
  *
  * @slot helptext - Sets the help text displayed below the input.
  * @slot label - Sets the label text for the input.
- * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
+ * @slot {HTMLSlotElement} optionalLabel - Allows overriding the optional display text "(optional)", which appears next to the label.
  * @slot displayValue - Allows custom HTML content to display in place of the value when the input is not focused.
  *
  * @csspart wrapper - Use for customizing the style of the root element

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -24,6 +24,7 @@ import { AuroElement } from '../../layoutElement/src/auroElement.js';
  *
  * @slot helptext - Sets the help text displayed below the input.
  * @slot label - Sets the label text for the input.
+ * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
  * @slot displayValue - Allows custom HTML content to display in place of the value when the input is not focused.
  *
  * @csspart wrapper - Use for customizing the style of the root element

--- a/components/radio/docs/api.md
+++ b/components/radio/docs/api.md
@@ -33,11 +33,11 @@
 
 ## Slots
 
-| Name            | Description                                     |
-|-----------------|-------------------------------------------------|
-| `helpText`      | Allows for the helper text to be overridden.    |
-| `legend`        | Allows for the legend to be overridden.         |
-| `optionalLabel` | Allows for the optional label to be overridden. |
+| Name            | Description                                      |
+|-----------------|--------------------------------------------------|
+| `helpText`      | Allows for the helper text to be overridden.     |
+| `legend`        | Allows for the legend to be overridden.          |
+| `optionalLabel` | Allows overriding the optional display text "(optional)", which appears next to the label. |
 
 ## CSS Shadow Parts
 

--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -464,10 +464,10 @@ export class AuroRadioGroup extends LitElement {
 
     return html`
       <fieldset class="${classMap(groupClasses)}" part="radio-group">
-        ${this.required
-        ? html`<legend><slot name="legend"></slot></legend>`
-        : html`<legend><slot name="legend"></slot> <slot name="optionalLabel">(optional)</slot></legend>`
-      }
+        <legend>
+          <slot name="legend"></slot>
+          ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+        </legend>
         <slot @slotchange=${this.handleSlotChange}></slot>
       </fieldset>
 

--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -39,7 +39,7 @@ import helpTextVersion from './helptextVersion.js';
  * @attr {Object} optionSelected - Specifies the current selected radio button.
  * @csspart radio-group - Apply css to the fieldset element in the shadow DOM
  * @slot {HTMLSlotElement} legend - Allows for the legend to be overridden.
- * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
+ * @slot {HTMLSlotElement} optionalLabel - Allows overriding the optional display text "(optional)", which appears next to the label.
  * @slot {HTMLSlotElement} helpText - Allows for the helper text to be overridden.
  * @event auroFormElement-validated - Notifies that the element has been validated.
  * @event input - Notifies every time the value prop of the element is changed.
@@ -466,7 +466,7 @@ export class AuroRadioGroup extends LitElement {
       <fieldset class="${classMap(groupClasses)}" part="radio-group">
         <legend>
           <slot name="legend"></slot>
-          ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+          ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
         </legend>
         <slot @slotchange=${this.handleSlotChange}></slot>
       </fieldset>

--- a/components/select/apiExamples/optionalLabel.html
+++ b/components/select/apiExamples/optionalLabel.html
@@ -1,0 +1,13 @@
+<auro-select>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Please select a preference</span>
+  <span slot="optionalLabel" style="color: grey; font-size: small"> - optional</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menuoption value="duration">Duration</auro-menuoption>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+    <auro-menuoption value="arrival">Arrival</auro-menuoption>
+    <auro-menuoption value="prefer alaska">Prefer Alaska</auro-menuoption>
+  </auro-menu>
+</auro-select>

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -60,6 +60,7 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | `displayValue`            | Allows custom HTML content to display the selected value when select is not focused. |
 | `helpText`                | Defines the content of the helpText.             |
 | `label`                   | Defines the content of the label.                |
+| `optionalLabel`           | Allows for the optional label to be overridden.  |
 | `placeholder`             | Defines the content of the placeholder to be shown when there is no value |
 | `valueText`               | Dropdown value text display.                     |
 

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -60,7 +60,7 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | `displayValue`            | Allows custom HTML content to display the selected value when select is not focused. |
 | `helpText`                | Defines the content of the helpText.             |
 | `label`                   | Defines the content of the label.                |
-| `optionalLabel`           | Allows for the optional label to be overridden.  |
+| `optionalLabel`           | Allows overriding the optional display text "(optional)", which appears next to the label. |
 | `placeholder`             | Defines the content of the placeholder to be shown when there is no value |
 | `valueText`               | Dropdown value text display.                     |
 

--- a/components/select/docs/partials/api.md
+++ b/components/select/docs/partials/api.md
@@ -92,6 +92,24 @@ When the validity check fails the validityState, equals `valueMissing`. The erro
 
 </auro-accordion>
 
+### Custom optional label <a name="optionalLabel"></a>
+
+The `<auro-select>` supports an `optionalLabel` slot, where users can can override the default `(optional)` notification text.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/optionalLabel.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/optionalLabel.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+
 #### error <a name="error"></a>
 
 Use the `error` boolean attribute to toggle the error UI.

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -53,6 +53,7 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
  * @slot - Default slot for the menu content.
  * @slot bib.fullscreen.headline - Defines the headline to display above menu-options
  * @slot label - Defines the content of the label.
+ * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
  * @slot helpText - Defines the content of the helpText.
  * @slot placeholder - Defines the content of the placeholder to be shown when there is no value
  * @slot valueText - Dropdown value text display.
@@ -1097,6 +1098,7 @@ export class AuroSelect extends AuroElement {
               <div class="${classMap(valueContainerClasses)}">
                 <label class="${classMap(this.commonLabelClasses)}">
                   <slot name="label"></slot>
+                  ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
                 </label>
                 <div class="value" id="value"></div>
                 ${this.value ? undefined : html`
@@ -1177,6 +1179,7 @@ export class AuroSelect extends AuroElement {
               <div class="${classMap(valueContainerClasses)}">
                 <label class="${classMap(this.commonLabelClasses)}">
                   <slot name="label"></slot>
+                  ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
                 </label>
                 <div class="value" id="value"></div>
                 ${this.value ? undefined : html`
@@ -1258,6 +1261,7 @@ export class AuroSelect extends AuroElement {
               <div class="${classMap(valueContainerClasses)}">
                 <label class="${classMap(this.commonLabelClasses)}">
                   <slot name="label"></slot>
+                  ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
                 </label>
                 <div class="value" id="value"></div>
                 ${this.value ? undefined : html`
@@ -1372,6 +1376,7 @@ export class AuroSelect extends AuroElement {
             <slot></slot>
           </${this.bibtemplateTag}>
           <slot name="label" slot="label"></slot>
+          ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
           <p slot="helpText">
             ${!this.validity || this.validity === undefined || this.validity === 'valid'
               ? html`

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -53,7 +53,7 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
  * @slot - Default slot for the menu content.
  * @slot bib.fullscreen.headline - Defines the headline to display above menu-options
  * @slot label - Defines the content of the label.
- * @slot {HTMLSlotElement} optionalLabel - Allows for the optional label to be overridden.
+ * @slot {HTMLSlotElement} optionalLabel - Allows overriding the optional display text "(optional)", which appears next to the label.
  * @slot helpText - Defines the content of the helpText.
  * @slot placeholder - Defines the content of the placeholder to be shown when there is no value
  * @slot valueText - Dropdown value text display.
@@ -1098,7 +1098,7 @@ export class AuroSelect extends AuroElement {
               <div class="${classMap(valueContainerClasses)}">
                 <label class="${classMap(this.commonLabelClasses)}">
                   <slot name="label"></slot>
-                  ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+                  ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
                 </label>
                 <div class="value" id="value"></div>
                 ${this.value ? undefined : html`
@@ -1179,7 +1179,7 @@ export class AuroSelect extends AuroElement {
               <div class="${classMap(valueContainerClasses)}">
                 <label class="${classMap(this.commonLabelClasses)}">
                   <slot name="label"></slot>
-                  ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+                  ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
                 </label>
                 <div class="value" id="value"></div>
                 ${this.value ? undefined : html`
@@ -1261,7 +1261,7 @@ export class AuroSelect extends AuroElement {
               <div class="${classMap(valueContainerClasses)}">
                 <label class="${classMap(this.commonLabelClasses)}">
                   <slot name="label"></slot>
-                  ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+                  ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
                 </label>
                 <div class="value" id="value"></div>
                 ${this.value ? undefined : html`
@@ -1376,7 +1376,7 @@ export class AuroSelect extends AuroElement {
             <slot></slot>
           </${this.bibtemplateTag}>
           <slot name="label" slot="label"></slot>
-          ${this.required ? '' : html`<slot name="optionalLabel"> (optional)</slot>`}
+          ${this.required ? undefined : html`<slot name="optionalLabel"> (optional)</slot>`}
           <p slot="helpText">
             ${!this.validity || this.validity === undefined || this.validity === 'valid'
               ? html`

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -106,6 +106,7 @@ describe('auro-select', () => {
 
   it('should sync value changes from native select to component', async () => {
     const element = await defaultFixture();
+    element.setAttribute('required', '');
     const nativeSelect = element.shadowRoot.querySelector('.nativeSelectWrapper select');
     nativeSelect.value = 'Apples';
     nativeSelect.dispatchEvent(new Event('change'));


### PR DESCRIPTION
# Alaska Airlines Pull Request

adding `optionalLabel` slot in checkbox-group, combobox, input, select
close #710

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add an `optionalLabel` slot across form components to allow overriding the default “(optional)” indicator.

New Features:
- Add `optionalLabel` slot to `<auro-input>`, `<auro-combobox>`, `<auro-select>`, and `<auro-checkbox-group>` components to customize the optional field label.

Enhancements:
- Provide a default “(optional)” label fallback for components without a custom slot override.

Documentation:
- Update API documentation for each component to include the new `optionalLabel` slot and add corresponding example snippets.