### PR TITLE
fix: execute `validate()` with force on `auroRadio-selected`

### DIFF
--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -195,7 +195,7 @@ export class AuroRadioGroup extends LitElement {
 
     this.optionSelected = event.target;
 
-    this.validation.validate(this);
+    this.validation.validate(this, this.optionSelected !== undefined);
   }
 
   /**


### PR DESCRIPTION
# Alaska Airlines Pull Request

It's to force validate the radio group when any radio is selected. 
Before, the validate didnt actually executed unless one of radio gets blurred. 

closes #571 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
