### PR TITLE
fix: don't reset touched status of elements on validation reset so th…

### DIFF
--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -36,6 +36,7 @@
 
 | Method     | Type                                   | Description                                      |
 |------------|----------------------------------------|--------------------------------------------------|
+| `clear`    | `(): void`                             | Clears the current value of the combobox.        |
 | `focus`    | `(): void`                             | Focuses the combobox trigger input.              |
 | `isValid`  | `(): boolean`                          | Checks if the element is valid.                  |
 | `reset`    | `(): void`                             | Resets component to initial state.               |

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -690,7 +690,7 @@ export class AuroCombobox extends AuroElement {
     });
 
     this.menu.addEventListener('auroMenu-selectValueReset', () => {
-      this.reset();
+      this.clear();
     });
   }
 
@@ -710,7 +710,7 @@ export class AuroCombobox extends AuroElement {
     });
 
     /**
-     * Validate every time we remove focus from the datepicker.
+     * Validate every time we remove focus from the combo box.
      */
     this.addEventListener('focusout', () => {
       if (document.activeElement !== this) {
@@ -914,8 +914,17 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   reset() {
-    this.input.reset();
+    this.input.clear();
     this.validation.reset(this);
+    this.menu.value = undefined;
+  }
+
+  /**
+   * Clears the current value of the combobox.
+   * @returns {void}
+   */
+  clear() {
+    this.input.clear();
     this.menu.value = undefined;
   }
 
@@ -941,7 +950,7 @@ export class AuroCombobox extends AuroElement {
           this.hideBib();
         }
       } else {
-        this.reset();
+        this.clear();
       }
     }
 

--- a/components/datepicker/docs/api.md
+++ b/components/datepicker/docs/api.md
@@ -47,6 +47,7 @@
 
 | Method                        | Type                                   | Description                                      |
 |-------------------------------|----------------------------------------|--------------------------------------------------|
+| `clear`                       | `(): void`                             | Clears the current value(s) of the datepicker.   |
 | `focus`                       | `(focusInput: string): void`           | Focuses the datepicker trigger input.<br /><br />**focusInput**: Pass in `endDate` to focus on the return input. No parameter is needed to focus on the depart input. |
 | `renderHtmlActionClear`       | `(): TemplateResult`                   |                                                  |
 | `renderHtmlIconCalendar`      | `(): TemplateResult`                   |                                                  |

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -897,7 +897,7 @@ export class AuroDatePicker extends AuroElement {
    */
   resetValues() {
     this.inputList.forEach((input) => {
-      input.reset();
+      input.clear();
     });
   }
 
@@ -907,8 +907,15 @@ export class AuroDatePicker extends AuroElement {
    */
   reset() {
     this.resetValues();
-
     this.validation.reset(this);
+  }
+
+  /**
+   * Clears the current value(s) of the datepicker.
+   * @returns {void}
+   */
+  clear() {
+    this.resetValues();
   }
 
   /**

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -57,8 +57,9 @@ Generate unique names for dependency components.
 
 | Method     | Type                                   | Description                                      |
 |------------|----------------------------------------|--------------------------------------------------|
+| `clear`    | `(): void`                             | Clears the input value                           |
 | `focus`    | `(): void`                             | Function to set element focus.                   |
-| `reset`    | `(): void`                             | Resets component to initial state.               |
+| `reset`    | `(): void`                             | Resets component to initial state, including resetting the touched state and validity. |
 | `validate` | `(force?: boolean \| undefined): void` | Validates value.<br /><br />**force**: Whether to force validation. |
 
 ## Events

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -732,9 +732,9 @@ export default class BaseInput extends AuroElement {
     this.inputElement.value = "";
     this.value = "";
     this.labelElement.classList.remove('inputElement-label--sticky');
+    this.notifyValueChanged();
     this.focus();
     this.validation.validate(this);
-    this.notifyValueChanged();
   }
 
   /**
@@ -829,11 +829,18 @@ export default class BaseInput extends AuroElement {
   }
 
   /**
-   * Resets component to initial state.
+   * Resets component to initial state, including resetting the touched state and validity.
    * @returns {void}
    */
   reset() {
     this.validation.reset(this);
+  }
+
+  /**
+   * Clears the input value
+   */
+  clear() {
+    this.value = undefined;
   }
 
   /**

--- a/packages/form-validation/src/validation.js
+++ b/packages/form-validation/src/validation.js
@@ -22,6 +22,7 @@ export default class AuroFormValidation {
   reset(elem) {
     elem.validity = undefined;
     elem.value = undefined;
+    elem.touched = false;
 
     // Resets the second value of the datepicker in range state
     if (elem.valueEnd) {
@@ -228,13 +229,24 @@ export default class AuroFormValidation {
     this.getInputElements(elem);
     this.getAuroInputs(elem);
 
-    // Validate only if noValidate is not true and the input does not have focus
+    // Check if validation should run
     let validationShouldRun =
+
+      // If the validation was forced
       force ||
-      (!elem.contains(document.activeElement) &&
-        (elem.touched ||
-          (!elem.touched && typeof elem.value !== "undefined"))) ||
-      elem.validateOnInput;
+
+      // If the validation should run on input
+      elem.validateOnInput ||
+
+      // State-based checks
+      (
+        // Element is not currently focused
+        !elem.contains(document.activeElement) && // native input is not focused directly
+        !document.activeElement.shadowRoot?.contains(elem) && // native input is not focused in the shadow DOM of another component
+
+        // And element has been touched or is untouched but has a value
+        ( elem.touched || (!elem.touched && typeof elem.value !== "undefined") )
+      );
 
     if (elem.hasAttribute('error')) {
       elem.validity = 'customError';

--- a/packages/form-validation/src/validation.js
+++ b/packages/form-validation/src/validation.js
@@ -22,7 +22,6 @@ export default class AuroFormValidation {
   reset(elem) {
     elem.validity = undefined;
     elem.value = undefined;
-    elem.touched = false;
 
     // Resets the second value of the datepicker in range state
     if (elem.valueEnd) {


### PR DESCRIPTION
…at validation occurs as expected

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Do not reset the touched status of form elements when calling the validation reset method