### PR TITLE
add `showBib`/`hideBib` on all dropdown related components

### DIFF
--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -57,9 +57,10 @@
 
 ## CSS Shadow Parts
 
-| Part       | Description                                  |
-|------------|----------------------------------------------|
-| `chevron`  | The collapsed/expanded state icon container. |
-| `helpText` | The helpText content container.              |
-| `popover`  | The bib content container.                   |
-| `trigger`  | The trigger content container.               |
+| Part       | Description                                      |
+|------------|--------------------------------------------------|
+| `chevron`  | The collapsed/expanded state icon container.     |
+| `helpText` | The helpText content container.                  |
+| `popover`  | The bib content container.                       |
+| `size`     | The size of the dropdown bib. (height, width, maxHeight, maxWidth only) |
+| `trigger`  | The trigger content container.                   |

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -57,6 +57,7 @@ import { AuroElement } from '../../layoutElement/src/auroElement.js';
  * @slot trigger - Defines the content of the trigger.
  * @csspart trigger - The trigger content container.
  * @csspart chevron - The collapsed/expanded state icon container.
+ * @csspart size - The size of the dropdown bib. (height, width, maxHeight, maxWidth only)
  * @csspart helpText - The helpText content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -63,6 +63,9 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 
 ## CSS Shadow Parts
 
-| Part       | Description                 |
-|------------|-----------------------------|
-| `helpText` | Apply CSS to the help text. |
+| Part              | Description                                      |
+|-------------------|--------------------------------------------------|
+| `dropdownChevron` | Apply CSS to the collapsed/expanded state icon container. |
+| `dropdownSize`    | Apply size styles to the dropdown bib. (height, width, maxHeight, maxWidth only) |
+| `dropdownTrigger` | Apply CSS to the trigger content container.      |
+| `helpText`        | Apply CSS to the help text.                      |

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -53,6 +53,10 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
  * @event auroSelect-valueSet - Notifies that the component has a new value set.
  * @event input - Notifies every time the value prop of the element is changed. The updated `value` and `optionSelected` will be delivered in `detail` object.
  * @event auroFormElement-validated - Notifies that the `validity` and `errorMessage` values have changed.
+ *
+ * @csspart dropdownTrigger - Apply CSS to the trigger content container.
+ * @csspart dropdownChevron - Apply CSS to the collapsed/expanded state icon container.
+ * @csspart dropdownSize - Apply size styles to the dropdown bib. (height, width, maxHeight, maxWidth only)
  * @csspart helpText - Apply CSS to the help text.
  */
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

close #795 #831 

This is to add `showBib` and `hideBib` public functions to all dropdown like components (select, combobox, counter-group, datepicker)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce public showBib and hideBib functions to dropdown-like components for controlling bib visibility, enhance styling flexibility with new CSS parts, and reflect these changes in the API docs.

New Features:
- Add showBib and hideBib methods to Select, Combobox, CounterGroup, and Datepicker for programmatic dropdown control

Enhancements:
- Expose new CSS shadow parts (dropdownSize/size, dropdownTrigger, dropdownChevron) for customizing dropdown bib styling

Documentation:
- Update component API documentation to include the new methods and CSS parts