### PR TITLE
Datepicker: Update wcss type class utilization

### DIFF
--- a/components/datepicker/src/auro-calendar-cell.js
+++ b/components/datepicker/src/auro-calendar-cell.js
@@ -344,6 +344,8 @@ export class AuroCalendarCell extends LitElement {
   render() {
     const buttonClasses = {
       'day': true,
+      'body-default': true,
+      'body-lg--breakpoint-sm': true,
       'currentDate': this.currentDate,
       'selected': this.selected,
       'inRange': this.hovered && this.isInRange(this.day, this.dateFrom, this.dateTo),
@@ -369,7 +371,7 @@ export class AuroCalendarCell extends LitElement {
           tabindex="-1">
           <div class="buttonWrapper">
             <div class="currentDayMarker">${(_b = this.day) === null || _b === void 0 ? void 0 : _b.title}</div>
-            <div class="dateSlot" part="dateSlot">
+            <div class="dateSlot body-2xs" part="dateSlot">
               <slot name="date_${this.dateStr}"></slot>
             </div>
           </div>

--- a/components/datepicker/src/auro-calendar-cell.js
+++ b/components/datepicker/src/auro-calendar-cell.js
@@ -344,7 +344,7 @@ export class AuroCalendarCell extends LitElement {
   render() {
     const buttonClasses = {
       'day': true,
-      'body-default': true,
+      'body-lg': true,
       'currentDate': this.currentDate,
       'selected': this.selected,
       'inRange': this.hovered && this.isInRange(this.day, this.dateFrom, this.dateTo),

--- a/components/datepicker/src/auro-calendar-cell.js
+++ b/components/datepicker/src/auro-calendar-cell.js
@@ -345,7 +345,6 @@ export class AuroCalendarCell extends LitElement {
     const buttonClasses = {
       'day': true,
       'body-default': true,
-      'body-lg--breakpoint-sm': true,
       'currentDate': this.currentDate,
       'selected': this.selected,
       'inRange': this.hovered && this.isInRange(this.day, this.dateFrom, this.dateTo),

--- a/components/datepicker/src/auro-calendar-month.js
+++ b/components/datepicker/src/auro-calendar-month.js
@@ -118,12 +118,12 @@ export class AuroCalendarMonth extends RangeDatepickerCalendar {
   /* eslint-disable */
   render() {
     var _a, _b;
-    
+
     return html `
       <div>
         <div class="header">
           ${this.renderPrevButton()}
-          <div class="headerTitle">
+          <div class="headerTitle heading-xs">
             ${this.monthFirst ? html`
               <div>${this.computeCurrentMonthName(this.month)}</div>
               <div>${this.renderYear()}</div>

--- a/components/datepicker/src/auro-calendar.js
+++ b/components/datepicker/src/auro-calendar.js
@@ -342,7 +342,7 @@ export class AuroCalendar extends RangeDatepicker {
 
       <div slot="subheader" class="mobileHeader">
         <div class="headerDateFrom">
-          <span class="mobileDateLabel">${this.slots["bib.fullscreen.dateLabel"]}</span>
+          <span class="mobileDateLabel body-xs">${this.slots["bib.fullscreen.dateLabel"]}</span>
           <slot name="bib.fullscreen.fromStr"></slot>
         </div>
         <div class="headerDateTo"><slot name="mobileDateToStr"></slot></div>

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1288,6 +1288,10 @@ export class AuroDatePicker extends AuroElement {
     };
 
     const labelClassMap = {
+      mainLabel: true,
+
+      hasValue: this.hasValue,
+      hasFocus: this.hasFocus,
       [this.hasFocus || this.hasValue ? 'body-xs' : 'body-lg']: true,
     };
 

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1288,8 +1288,7 @@ export class AuroDatePicker extends AuroElement {
     };
 
     const labelClassMap = {
-      hasValue: this.hasValue,
-      hasFocus: this.hasFocus,
+      [this.hasFocus || this.hasValue ? 'body-xs' : 'body-lg']: true,
     };
 
     return html`
@@ -1334,11 +1333,6 @@ export class AuroDatePicker extends AuroElement {
       hasFocus: this.hasFocus,
     };
 
-    const labelClassMap = {
-      hasValue: this.hasValue,
-      hasFocus: this.hasFocus,
-    };
-
     return html`
       <div
         class="wrapper trigger"
@@ -1347,9 +1341,6 @@ export class AuroDatePicker extends AuroElement {
           ${this.renderHtmlIconCalendar()}
         </div>
         <div class="mainContent">
-          <label class="${classMap(labelClassMap)}" part="mainLabel">
-            <slot name="label"></slot>
-          </label>
           <div class="${classMap(inputSectionClassMap)}" part="inputSection">
             ${this.renderHtmlInputs()}
           </div>
@@ -1404,9 +1395,14 @@ export class AuroDatePicker extends AuroElement {
    * @returns {import('lit').TemplateResult}
    */
   renderDisplayTextDate(dateValue) {
+    const displayTextClasses = {
+      'displayValueText': true,
+      'body-lg': true
+    };
+
     return html`
         <div>
-          <div class="displayValueText">
+          <div class="${classMap(displayTextClasses)}">
             ${dateValue && this.util.validDateStr(dateValue, this.format)
         ? this.formatShortDate(dateValue)
         : undefined
@@ -1436,20 +1432,21 @@ export class AuroDatePicker extends AuroElement {
           .format="${this.format}"
           .max="${this.maxDate}"
           .min="${this.minDate}"
-          id="${this.generateRandomString(12)}"
           .placeholder="${this.placeholder}"
           .size="${this.size}"
           .shape="${this.shape}"
-          noValidate
           class="dateFrom ${classMap(inputClasses)}"
-          type="date"
+          id="${this.generateRandomString(12)}"
+          inputmode="${ifDefined(this.inputmode)}"
+          layout="classic"
+          noValidate
           part="input"
           setCustomValidity="${this.setCustomValidity}"
           setCustomValidityCustomError="${this.setCustomValidityCustomError}"
           setCustomValidityValueMissing="${this.setCustomValidityValueMissing}"
           setCustomValidityRangeOverflow="${this.setCustomValidityRangeOverflow}"
           setCustomValidityRangeUnderflow="${this.setCustomValidityRangeUnderflow}"
-          inputmode="${ifDefined(this.inputmode)}"
+          type="date"
         >
           ${this.layout !== "classic"
         ? html`
@@ -1471,23 +1468,27 @@ export class AuroDatePicker extends AuroElement {
       ${this.range ? html`
         <div class="inputContainer">
           <${this.inputTag}
+            ?disabled="${this.disabled}"
             ?onDark="${this.onDark}"
             ?required="${this.required}"
             .format="${this.format}"
             .max="${this.maxDate}"
             .min="${this.minDate}"
             .placeholder="${this.placeholderEndDate || this.placeholder}"
-            id="${this.generateRandomString(12)}"
+            .size="${this.size}"
+            .shape="${this.shape}"
             class="dateTo ${classMap(inputClasses)}"
+            id="${this.generateRandomString(12)}"
+            layout="classic"
             noValidate
-            type="date"
+            part="input"
             setCustomValidity="${this.setCustomValidity}"
             setCustomValidityCustomError="${this.setCustomValidityCustomError}"
             setCustomValidityValueMissing="${this.setCustomValidityValueMissing}"
             setCustomValidityRangeOverflow="${this.setCustomValidityRangeOverflow}"
             setCustomValidityRangeUnderflow="${this.setCustomValidityRangeUnderflow}"
-            ?disabled="${this.disabled}"
-            part="input">
+            type="date"
+          >
             ${this.layout !== "classic"
           ? html`
               <span slot="displayValue">

--- a/components/datepicker/src/styles/snowflake/style.scss
+++ b/components/datepicker/src/styles/snowflake/style.scss
@@ -3,7 +3,6 @@
 :host([layout*='snowflake']) {
   [auro-input] {
     flex: 1;
-
     text-align: center;
 
     &::part(label),
@@ -16,8 +15,6 @@
       padding-bottom: unset;
       text-align: center;
 
-      font-size: var(--ds-text-body-size-lg, vac.$ds-text-body-size-lg);
-      line-height: var(--ds-text-body-height-lg, vac.$ds-text-body-height-lg);
       transition: unset; // default transition makes input "slide" in
     }
 
@@ -38,8 +35,6 @@
 
     &::part(displayValue) {
       justify-content: center;
-      font-size: var(--ds-text-body-size-lg, vac.$ds-text-body-size-lg);
-      line-height: var(--ds-text-body-height-lg, vac.$ds-text-body-height-lg);
     }
   }
 
@@ -69,19 +64,9 @@
   // unfocused state(s)
 
   label {
-    font-size: var(--ds-text-body-size-lg, vac.$ds-text-body-size-lg);
-    line-height: var(--ds-text-body-height-lg, vac.$ds-text-body-height-lg);
-    font-weight: 450;
-    letter-spacing: 0;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-
-    &.hasFocus,
-    &.hasValue {
-      font-size: var(--ds-text-body-size-xs, vac.$ds-text-body-size-xs);
-      line-height: var(--ds-text-body-height-xs, vac.$ds-text-body-height-xs);
-    }
   }
 
   .inputDivider {

--- a/components/datepicker/src/styles/snowflake/style.scss
+++ b/components/datepicker/src/styles/snowflake/style.scss
@@ -23,6 +23,7 @@
       min-height: unset;
       max-height: unset;
       box-shadow: unset;
+      border-radius: unset;
 
       .mainContent {
         padding-bottom: unset;
@@ -38,10 +39,6 @@
     }
   }
 
-  [auro-dropdown]::part(trigger) {
-    width: 100%;
-  }
-
   // for the trigger content
 
   .dpTriggerContent {
@@ -49,31 +46,33 @@
   }
 
   .wrapper {
-    height: 60px;
-    // TODO: update to tokens (token x 2 for 48px)
-    width: calc(100% - 48px);
+    width: calc(100% - var(--ds-size-600, vac.$ds-size-600));
     display: flex;
     flex-direction: row;
     justify-content: space-between;
 
-    // TODO: update to tokens
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-inline: var(--ds-size-300, vac.$ds-size-300);
   }
 
-  // unfocused state(s)
-
-  label {
+  .mainLabel {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+
+    // designs want 16px height, fill the space and center text
+    display: flex;
+    align-items: center;
+  }
+
+  .mainLabel:is(.hasFocus, .hasValue) {
+    padding-block-start: var(--ds-size-75, vac.$ds-size-75);
   }
 
   .inputDivider {
-    // TODO: add fallback for tokens
-    height: 18px;
-    margin: 4px 12px;
-    width: 2px;
+    // 18px - size-200 + size-25
+    height: calc(var(--ds-size-200, vac.$ds-size-200) + var(--ds-size-25, vac.$ds-size-25));
+    margin: var(--ds-size-50, vac.$ds-size-50) var(--ds-size-150, vac.$ds-size-150);
+    width: var(--ds-size-25, vac.$ds-size-25);
   }
 
   .inputSection:not(:is(.disabled, .hasFocus, .hasValue)) {

--- a/components/datepicker/src/styles/style-auro-calendar-cell.scss
+++ b/components/datepicker/src/styles/style-auro-calendar-cell.scss
@@ -8,30 +8,12 @@
 @use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 
-@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css' as *;
+// not directly used in this file, but needs to be imported here
+// for JS classMap application(s). TODO: consider moving this to a shared import for js files?
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css';
 
 /* stylelint-disable selector-max-class, order/properties-order, declaration-empty-line-before, scss/selector-nest-combinators,
    selector-pseudo-element-colon-notation, max-nesting-depth, at-rule-empty-line-before, no-descending-specificity, declaration-no-important */
-
-// =~   DATEPICKER TEXT CLASSES   ~=
-@include vb.auro_grid-breakpoint--sm {
-  .body-lg--breakpoint-sm {
-    font-family:var(--wcss-body-family, "AS Circular", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
-    font-weight: var(--wcss-body-weight, 450);
-    letter-spacing: var(--wcss-body-letter-spacing, 0);
-    font-size: var(--wcss-body-lg-font-size, 1.125rem);
-    line-height: var(--wcss-body-lg-line-height, 1.63);
-  }
-
-  .body-xs--breakpoint-sm {
-    font-family:var(--wcss-body-family, "AS Circular", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
-    font-weight: var(--wcss-body-weight, 450);
-    letter-spacing: var(--wcss-body-letter-spacing, 0);
-    font-size: var(--wcss-body-xs-font-size, 0.75rem);
-    line-height: var(--wcss-body-xs-line-height, 1);
-  }
-}
-// =~ END DATEPICKER TEXT CLASSES ~=
 
 
 @mixin in-range-pseudo-elem {

--- a/components/datepicker/src/styles/style-auro-calendar-cell.scss
+++ b/components/datepicker/src/styles/style-auro-calendar-cell.scss
@@ -2,13 +2,37 @@
 // // See LICENSE in the project root for license information.
 
 // // ---------------------------------------------------------------------
+@use "sass:meta";
 
 @use '@aurodesignsystem/webcorestylesheets/src/breakpoints' as vb;
 @use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css' as *;
+
 /* stylelint-disable selector-max-class, order/properties-order, declaration-empty-line-before, scss/selector-nest-combinators,
    selector-pseudo-element-colon-notation, max-nesting-depth, at-rule-empty-line-before, no-descending-specificity, declaration-no-important */
+
+// =~   DATEPICKER TEXT CLASSES   ~=
+@include vb.auro_grid-breakpoint--sm {
+  .body-lg--breakpoint-sm {
+    font-family:var(--wcss-body-family, "AS Circular", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
+    font-weight: var(--wcss-body-weight, 450);
+    letter-spacing: var(--wcss-body-letter-spacing, 0);
+    font-size: var(--wcss-body-lg-font-size, 1.125rem);
+    line-height: var(--wcss-body-lg-line-height, 1.63);
+  }
+
+  .body-xs--breakpoint-sm {
+    font-family:var(--wcss-body-family, "AS Circular", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
+    font-weight: var(--wcss-body-weight, 450);
+    letter-spacing: var(--wcss-body-letter-spacing, 0);
+    font-size: var(--wcss-body-xs-font-size, 0.75rem);
+    line-height: var(--wcss-body-xs-line-height, 1);
+  }
+}
+// =~ END DATEPICKER TEXT CLASSES ~=
+
 
 @mixin in-range-pseudo-elem {
   position: absolute;
@@ -44,11 +68,6 @@
   border-radius: var(--ds-size-300, vac.$ds-size-300);
 
   cursor: pointer;
-
-  font-size: 16px; // var(--ds-basic-text-body-default-font-size, v.$ds-basic-text-body-default-font-size); /* This must be declared here because the browser clients unset it in the user agent style sheet */
-  font-weight: 450; // var(--ds-basic-text-body-default-font-weight, v.$ds-basic-text-body-default-font-weight); /* This must be declared here because the browser clients unset it in the user agent style sheet */
-  letter-spacing: 0; // var(--ds-basic-text-body-default-letter-spacing, v.$ds-basic-text-body-default-letter-spacing); /* This must be declared here because the browser clients unset it in the user agent style sheet */
-  line-height: 24px; // var(--ds-basic-text-body-default-line-height, v.$ds-basic-text-body-default-line-height); /* This must be declared here because the browser clients unset it in the user agent style sheet */
 
   user-select: none;
 
@@ -95,11 +114,6 @@
 .dateSlot {
   display: flex;
   flex-direction: column;
-
-  font-size: 10px; // var(--ds-basic-text-body-xxs-font-size, v.$ds-basic-text-body-xxs-font-size);
-  font-weight: 450; // var(--ds-basic-text-body-xxs-font-weight, v.$ds-basic-text-body-xxs-font-weight);
-  letter-spacing: 0; // var(--ds-basic-text-body-xxs-letter-spacing, v.$ds-basic-text-body-xxs-letter-spacing);
-  line-height: 14px; // var(--ds-basic-text-body-xxs-line-height, v.$ds-basic-text-body-xxs-line-height);
 }
 
 ::slotted([slot^="date_"]) {
@@ -107,9 +121,8 @@
   top: 80%;
   left: 50%;
 
-  width: 80%;
+  width: 100%;
 
-  overflow: hidden;
   white-space: nowrap;
 
   transform: translate(-50%, -50%);
@@ -140,20 +153,8 @@
     width: var(--ds-size-600, vac.$ds-size-600);
     height: var(--ds-size-800, vac.$ds-size-800);
 
-    font-size: 18px; // var(--ds-basic-text-body-lg-font-size, v.$ds-basic-text-body-lg-font-size);
-    font-weight: 450; // var(--ds-basic-text-body-lg-font-weight, v.$ds-basic-text-body-lg-font-weight);
-    letter-spacing: 0; // var(--ds-basic-text-body-lg-letter-spacing, v.$ds-basic-text-body-lg-letter-spacing);
-    line-height: 26px; // var(--ds-basic-text-body-lg-line-height, v.$ds-basic-text-body-lg-line-height);
-
     &:hover {
       cursor: pointer;
     }
-  }
-
-  .dateSlot {
-    font-size: 12px; // var(--ds-basic-text-body-xs-font-size, v.$ds-basic-text-body-xs-font-size);
-    font-weight: 450; // var(--ds-basic-text-body-xs-font-weight, v.$ds-basic-text-body-xs-font-weight);
-    letter-spacing: 0; // var(--ds-basic-text-body-xs-letter-spacing, v.$ds-basic-text-body-xs-letter-spacing);
-    line-height: 16px; // var(--ds-basic-text-body-xs-line-height, v.$ds-basic-text-body-xs-line-height);
   }
 }

--- a/components/datepicker/src/styles/style-auro-calendar-month.scss
+++ b/components/datepicker/src/styles/style-auro-calendar-month.scss
@@ -10,6 +10,8 @@
 @use '@aurodesignsystem/webcorestylesheets/src/breakpoints' as vb;
 @use '@aurodesignsystem/webcorestylesheets/src/core';
 
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css';
+
 /* stylelint-disable selector-class-pattern, property-no-vendor-prefix, order/properties-order, no-descending-specificity, color-function-notation, max-line-length, declaration-empty-line-before */
 
 $calendar-width: 336px;
@@ -66,11 +68,6 @@ $calendar-padding-desktop: var(--ds-size-200, vac.$ds-size-200);
   flex: 1;
   flex-direction: row;
   justify-content: center;
- 
-  font-size: 20px; // var(--ds-basic-text-heading-xs-breakpoint-md-font-size, v.$ds-basic-text-heading-xs-breakpoint-md-font-size);
-  font-weight: 450; // var(--ds-basic-text-heading-xs-breakpoint-md-font-weight, v.$ds-basic-text-heading-xs-breakpoint-md-font-weight);
-  letter-spacing: 0; // var(--ds-basic-text-heading-xs-breakpoint-md-letter-spacing, v.$ds-basic-text-heading-xs-breakpoint-md-letter-spacing);
-  line-height: 130%; // var(--ds-basic-text-heading-xs-breakpoint-md-line-height, v.$ds-basic-text-heading-xs-breakpoint-md-line-height);
 
   div {
     &:first-child {
@@ -112,8 +109,6 @@ $calendar-padding-desktop: var(--ds-size-200, vac.$ds-size-200);
 
   align-items: center;
   justify-content: center;
-
-  font-weight: 700;
 }
 
 .tbody {
@@ -121,7 +116,7 @@ $calendar-padding-desktop: var(--ds-size-200, vac.$ds-size-200);
 
   transition: all 0ms;
   transform: translateX(0);
-  
+
   @include vb.auro_grid-breakpoint--sm {
     height: 384px; // height is fixed to always leave room for months spanning 6 rows
   }

--- a/components/datepicker/src/styles/style-auro-calendar.scss
+++ b/components/datepicker/src/styles/style-auro-calendar.scss
@@ -6,6 +6,8 @@
 @use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css';
+
 /* stylelint-disable color-function-notation, at-rule-empty-line-before, order/properties-order, declaration-empty-line-before, declaration-block-no-duplicate-properties */
 
 :host {
@@ -84,10 +86,8 @@
 }
 
 .mobileDateLabel {
-  font-size: 12px; // var(--ds-basic-text-body-xs-font-size, v.$ds-basic-text-body-xs-font-size);
-  font-weight: 450; // var(--ds-basic-text-body-xs-font-weight, v.$ds-basic-text-body-xs-font-weight);
-  letter-spacing: 0; // var(--ds-basic-text-body-xs-letter-spacing, v.$ds-basic-text-body-xs-letter-spacing);
-  line-height: 16px; // var(--ds-basic-text-body-xs-line-height, v.$ds-basic-text-body-xs-line-height);
+  // padding to make up for body-xs line height
+  padding: var(--ds-size-25, vac.$ds-size-25) 0;
 }
 
 .headerDateTo {

--- a/components/datepicker/src/styles/style.scss
+++ b/components/datepicker/src/styles/style.scss
@@ -5,9 +5,10 @@
 
 @use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
-
 @use '@aurodesignsystem/webcorestylesheets/src/breakpoints' as vb;
+
 @use '@aurodesignsystem/webcorestylesheets/src/utilityClasses/displayProperties';
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css';
 
 .accents {
   flex-grow: 0;

--- a/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-calendar.js
+++ b/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-calendar.js
@@ -117,7 +117,7 @@ export class RangeDatepickerCalendar extends LitElement {
   }
 
   renderDayOfWeek(dayOfWeek) {
-    return html`<div class="th">${dayOfWeek}</div>`;
+    return html`<div class="th body-default">${dayOfWeek}</div>`;
   }
 
   renderWeek(week) {

--- a/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-cell.js
+++ b/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-cell.js
@@ -43,7 +43,7 @@ class RangeDatepickerCell extends LitElement {
       @click="${this.handleTap}"
       @mouseover="${this.handleHover}"
       @focus="${this.handleHover}"
-      class="day ${this.isCurrentDate ? 'currentDate' : ''} ${this.isSelected(this.selected)} ${this.isHovered(this.hovered)} ${this.isEnabled(this.day, this.min, this.max, this.disabledDays)}"
+      class="day body-default body-lg--breakpoint-sm ${this.isCurrentDate ? 'currentDate' : ''} ${this.isSelected(this.selected)} ${this.isHovered(this.hovered)} ${this.isEnabled(this.day, this.min, this.max, this.disabledDays)}"
       ?disabled="${this.disabled}"
       title="${this.getTitle((_a = this.day) === null || _a === void 0 ? void 0 : _a.date)}">
       <div class="currentDayMarker">${(_b = this.day) === null || _b === void 0 ? void 0 : _b.title}</div>
@@ -185,6 +185,7 @@ RangeDatepickerCell.styles = css`
 
     width: 80%;
     height: 80%;
+    // TODO: talk to design about this
     font-weight: var(--wc-current-day-font-weight, bold);
     border-radius: 50%;
     background-color: var(--wc-current-day-color);

--- a/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-cell.js
+++ b/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-cell.js
@@ -43,7 +43,7 @@ class RangeDatepickerCell extends LitElement {
       @click="${this.handleTap}"
       @mouseover="${this.handleHover}"
       @focus="${this.handleHover}"
-      class="day body-default ${this.isCurrentDate ? 'currentDate' : ''} ${this.isSelected(this.selected)} ${this.isHovered(this.hovered)} ${this.isEnabled(this.day, this.min, this.max, this.disabledDays)}"
+      class="day body-lg ${this.isCurrentDate ? 'currentDate' : ''} ${this.isSelected(this.selected)} ${this.isHovered(this.hovered)} ${this.isEnabled(this.day, this.min, this.max, this.disabledDays)}"
       ?disabled="${this.disabled}"
       title="${this.getTitle((_a = this.day) === null || _a === void 0 ? void 0 : _a.date)}">
       <div class="currentDayMarker">${(_b = this.day) === null || _b === void 0 ? void 0 : _b.title}</div>

--- a/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-cell.js
+++ b/components/datepicker/src/vendor/wc-range-datepicker/range-datepicker-cell.js
@@ -43,7 +43,7 @@ class RangeDatepickerCell extends LitElement {
       @click="${this.handleTap}"
       @mouseover="${this.handleHover}"
       @focus="${this.handleHover}"
-      class="day body-default body-lg--breakpoint-sm ${this.isCurrentDate ? 'currentDate' : ''} ${this.isSelected(this.selected)} ${this.isHovered(this.hovered)} ${this.isEnabled(this.day, this.min, this.max, this.disabledDays)}"
+      class="day body-default ${this.isCurrentDate ? 'currentDate' : ''} ${this.isSelected(this.selected)} ${this.isHovered(this.hovered)} ${this.isEnabled(this.day, this.min, this.max, this.disabledDays)}"
       ?disabled="${this.disabled}"
       title="${this.getTitle((_a = this.day) === null || _a === void 0 ? void 0 : _a.date)}">
       <div class="currentDayMarker">${(_b = this.day) === null || _b === void 0 ? void 0 : _b.title}</div>

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -147,6 +147,11 @@ export class AuroInput extends BaseInput {
       return 'body-lg';
     }
 
+    // edge case for enabling visual overrides in datepicker
+    if (this.layout === 'classic' && this.shape === 'snowflake') {
+      return 'body-lg';
+    }
+
     // classic layout (default) - same for both hidden and visible
     return 'body-default';
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

MERGE AFTER INPUT PR :D

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Unify and refactor typography in form controls and datepicker by introducing dynamic font class logic and replacing hardcoded styles with bundled CSS type classes. Bump the webcorestylesheets dependency and remove deprecated font declarations.

New Features:
- Introduce dynamic font class getters in AuroInput and AuroSelect to apply typography classes based on state and layout.

Enhancements:
- Replace hardcoded font-size and line-height declarations across input, select, and datepicker SCSS with bundled type classes and import the Alaska CSS classes from webcorestylesheets.
- Update datepicker and calendar components (AuroDatePicker, AuroCalendarCell, AuroCalendarMonth, AuroCalendar) to use body-xx typography classes for labels, display values, and date slots.
- Remove obsolete inline typography styles (shapeSize-css.d.ts and scattered font declarations) and consolidate font styling through CSS utility classes.
- Bump @aurodesignsystem/webcorestylesheets dependency to v10.0.1 to align with the new bundled type classes.