### PR TITLE
Counter: Update wcss type class utilization

### DIFF
--- a/components/counter/package.json
+++ b/components/counter/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@alaskaairux/icons": "^5.5.0",
     "@aurodesignsystem/auro-bibtemplate": "*",
-    "@aurodesignsystem/auro-button": "^11.2.1",
+    "@aurodesignsystem/auro-button": "^11.3.0",
     "@aurodesignsystem/auro-dropdown": "*",
     "chalk": "^5.4.1",
     "lit": "^3.2.1"

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -709,7 +709,7 @@ export class AuroCounterGroup extends AuroElement {
   renderDropdownTrigger() {
 
     const labelClasses = {
-      filled: typeof this.valueText === 'string' && this.valueText.length
+      [typeof this.valueText === 'string' && this.valueText.length ? 'body-xs' : 'body-default']: true
     };
 
     return html`
@@ -721,7 +721,7 @@ export class AuroCounterGroup extends AuroElement {
           <label class="${classMap(labelClasses)}">
             <slot name="label"></slot>
           </label>
-          <slot name="valueText" @slotChange="${this.updateValueText}">
+          <slot name="valueText" @slotChange="${this.updateValueText}" class="body-default">
             ${this.counters && Array.from(this.counters).map((counter, index) => html`${counter.value} ${counter.defaultSlot}${index !== this.counters.length - 1 ? ', ' : ''}`)}
           </slot>
         </div>

--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -371,8 +371,10 @@ export class AuroCounter extends LitElement {
       <div class="counterWrapper">
         <div class="counter">
           <div class="content" >
-            <label id="counter-label" class="label"><slot @slotchange="${this.onDefaultSlotChange}" ></slot></label>
-            <slot id="counter-description" name="description"></slot>
+            <label id="counter-label" class="label">
+              <slot @slotchange="${this.onDefaultSlotChange}"></slot>
+            </label>
+            <slot id="counter-description" name="description" class="body-xs"></slot>
           </div>
           <div 
             part="counterControl" 
@@ -397,7 +399,7 @@ export class AuroCounter extends LitElement {
               <${this.iconTag} class="controlIcon" customSvg> ${IconUtil.generateSvgHtml(minusIcon)} </${this.iconTag}>
             </auro-counter-button>
 
-            <div class="quantityWrapper">
+            <div class="quantityWrapper body-lg">
               <div class="quantity">${this.value !== undefined ? this.value : this.min}</div>
             </div>
 

--- a/components/counter/src/styles/counter-group.scss
+++ b/components/counter/src/styles/counter-group.scss
@@ -10,6 +10,9 @@
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 @use '@aurodesignsystem/webcorestylesheets/src/breakpoints';
 
+// Import type classes
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.min.css';
+
 :host(:not([layout="classic"])) {
   .triggerContent {
     padding: 0 var(--ds-size-100, vac.$ds-size-100) 0 var(--ds-size-300, vac.$ds-size-300);
@@ -47,12 +50,7 @@
 }
 
 label {
-  font-size: var(--ds-text-body-size-default, vac.$ds-text-body-size-default);
-  line-height: 20px;
-
-  &.filled {
-    font-size: var(--ds-text-body-size-xs, vac.$ds-text-body-size-xs);
-  }
+  margin-block: 0.25rem;
 }
 
 .accents {
@@ -73,7 +71,6 @@ label {
 
 slot {
   &[name="valueText"] {
-    font-size: var(--ds-text-body-size-default, vac.$ds-text-body-size-default);
     overflow-x: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/components/counter/src/styles/counter-group.scss
+++ b/components/counter/src/styles/counter-group.scss
@@ -21,7 +21,7 @@
 
 :host([layout="classic"]) {
   .triggerContent {
-    padding: 0 0 0 var(--ds-size-100, 0.5rem);
+    padding: 0 0 0 var(--ds-size-100, vac.$ds-size-100);
   }
 }
 
@@ -50,12 +50,12 @@
 }
 
 label {
-  margin-block: 0.25rem;
+  padding-block: var(--ds-size-25, vac.$ds-size-25);
 }
 
 .accents {
   ::slotted([slot="typeIcon"]) {
-    margin-right: 8px;
+    margin-right: var(--ds-size-100, vac.$ds-size-100);
   }
 
   ::slotted(*) {
@@ -64,7 +64,7 @@ label {
       flex-direction: row;
       align-items: center;
       justify-content: center;
-      gap: 8px;
+      gap: var(--ds-size-100, vac.$ds-size-100);
     }
   }
 }

--- a/components/counter/src/styles/style.scss
+++ b/components/counter/src/styles/style.scss
@@ -4,9 +4,11 @@
 // ---------------------------------------------------------------------
 
 // Support for fallback values
-// @use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 @use '@aurodesignsystem/webcorestylesheets/src/breakpoints';
+
+// Import type classes
+@use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.min.css';
 
 .counter {
   display: flex;
@@ -23,10 +25,6 @@
 [name="description"] {
   &::slotted(*) {
     display: block;
-    font-size: 12px; // var(--ds-basic-text-body-xs-font-size, v.$ds-basic-text-body-xs-font-size);
-    font-weight: 450; // var(--ds-basic-text-body-xs-font-weight, v.$ds-basic-text-body-xs-font-weight);
-    letter-spacing: 0; // var(--ds-basic-text-body-xs-letter-spacing, v.$ds-basic-text-body-xs-letter-spacing);
-    line-height: 16px; // var(--ds-basic-text-body-xs-line-height, v.$ds-basic-text-body-xs-line-height);
   }
 }
 
@@ -35,11 +33,11 @@
   height: calc(var(--ds-size-25, vac.$ds-size-25) + var(--ds-size-400, vac.$ds-size-400));
   align-content: center;
   cursor: default;
-  font-size: 12px; // var(--ds-basic-text-body-xs-font-size, v.$ds-basic-text-body-xs-font-size);
-  font-weight: 450; // var(--ds-basic-text-body-xs-font-weight, v.$ds-basic-text-body-xs-font-weight);
-  letter-spacing: 0; // var(--ds-basic-text-body-xs-letter-spacing, v.$ds-basic-text-body-xs-letter-spacing);
-  line-height: 16px; // var(--ds-basic-text-body-xs-line-height, v.$ds-basic-text-body-xs-line-height);
   text-align: center;
+}
+
+.quantity {
+  margin-top: 0.25rem;
 }
 
 :host{
@@ -48,7 +46,6 @@
   &::part(counterControl) {
     display: flex;
     border-radius: var(--ds-size-500, vac.$ds-size-500);
-    line-height: 0;
 
     // prevent double-tap zoom on iOS (included in button for enabled state behaving differently)
     touch-action: manipulation;

--- a/components/dropdown/src/styles/classic/style.scss
+++ b/components/dropdown/src/styles/classic/style.scss
@@ -31,6 +31,7 @@
 
   .wrapper {
     display: flex;
+    box-sizing: border-box;
     flex-direction: row;
     box-shadow: inset 0 0 0 1px var(--ds-auro-dropdown-trigger-outline-color);
   }

--- a/components/dropdown/src/styles/style.scss
+++ b/components/dropdown/src/styles/style.scss
@@ -11,7 +11,6 @@
 
 .wrapper {
   display: flex;
-  box-sizing: border-box;
   flex: 1;
   flex-direction: row;
   align-items: center;

--- a/components/input/src/styles/classic/style.scss
+++ b/components/input/src/styles/classic/style.scss
@@ -16,10 +16,14 @@
 
 @use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 
-.layout-classic {
-  display: flex;
-  flex-direction: row;
-  box-shadow: inset 0 0 0 1px var(--ds-auro-input-outline-color);
+
+:host([layout*='classic']) {
+  .wrapper {
+    display: flex;
+    box-sizing: border-box;
+    flex-direction: row;
+    box-shadow: inset 0 0 0 1px var(--ds-auro-input-outline-color);
+  }  
 
   .mainContent {
     position: relative;

--- a/components/input/src/styles/snowflake/style.scss
+++ b/components/input/src/styles/snowflake/style.scss
@@ -28,7 +28,7 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    padding-block: var(--ds-size-50, vac.$ds-size-50);
+    padding-block-start: var(--ds-size-50, vac.$ds-size-50);
   }
 
   input {

--- a/components/input/src/styles/style.scss
+++ b/components/input/src/styles/style.scss
@@ -10,7 +10,6 @@
 }
 
 .wrapper {
-  box-sizing: border-box;
   cursor: text;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,7 @@
       "dependencies": {
         "@alaskaairux/icons": "^5.5.0",
         "@aurodesignsystem/auro-bibtemplate": "*",
-        "@aurodesignsystem/auro-button": "^11.2.1",
+        "@aurodesignsystem/auro-button": "^11.3.0",
         "@aurodesignsystem/auro-dropdown": "*",
         "chalk": "^5.4.1",
         "lit": "^3.2.1"


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Fixed sizing issue with counter value

| Before | After |
| -------- | -------- |
|  <img width="133" height="57" alt="image" src="https://github.com/user-attachments/assets/3100b1a9-609a-4120-832f-b597aee5aad1" />  |  <img width="132" height="59" alt="image" src="https://github.com/user-attachments/assets/c0c027b0-6aee-4ece-924e-c466536be434" />  |


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Migrate typography styling in the Counter components to use webcorestylesheets type classes, remove manual typography declarations, adjust spacing, and bump the button dependency version

Enhancements:
- Import webcorestylesheets type classes and apply body-xs, body-lg, and body-default utility classes in counter and counter-group components
- Remove redundant font-size, font-weight, letter-spacing, and line-height rules from SCSS and templates
- Add consistent spacing to quantity elements and remove unused line-height declarations

Chores:
- Update @aurodesignsystem/auro-button dependency to version 11.3.0