### PR TITLE
fix: menuoption inherit shape and size from parent's attributes

### DIFF
--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -39,12 +39,12 @@ export class AuroMenuOption extends AuroElement {
     /**
      * @private
      */
-    this.shape = "box";
+    this.shape = undefined;
 
     /**
      * @private
      */
-    this.size = "sm";
+    this.size = undefined;
 
     /**
      * Generate unique names for dependency components.
@@ -116,6 +116,13 @@ export class AuroMenuOption extends AuroElement {
   firstUpdated() {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
+
+    if (!this.hasAttribute('size')) {
+      this.size = this.parentElement.getAttribute('size') || 'sm';
+    }
+    if (!this.hasAttribute('shape')) {
+      this.shape = this.parentElement.getAttribute('shape') || 'box';
+    }
 
     this.setAttribute('role', 'option');
     this.setAttribute('aria-selected', 'false');


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update AuroMenuOption to inherit shape and size attributes from its parent element when not explicitly set

Bug Fixes:
- Ensure AuroMenuOption inherits parent size and shape attributes instead of using fixed defaults

Enhancements:
- Remove hardcoded default shape and size values in AuroMenuOption initialization