### PR TITLE
fix: set to default menu shape and size when bib is fullscreen in combobox and select

### DIFF
--- a/components/bibtemplate/src/auro-bibtemplate.js
+++ b/components/bibtemplate/src/auro-bibtemplate.js
@@ -142,13 +142,15 @@ export class AuroBibtemplate extends LitElement {
       <div id="bibTemplate" part="bibtemplate">
       ${this.isFullscreen ? html`
         <div id="headerContainer">
-          <${this.buttonTag} id="closeButton" aria-label="Close" variant="ghost" shape="circle" size="sm" @click="${this.onCloseButtonClick}">
-            <${this.iconTag} category="interface" name="x-lg"></${this.iconTag}>
-          </${this.buttonTag}>
-          <${this.headerTag} display="${this.large ? 'display' : '600'}" level="3" size="none" id="header" no-margin-block>
-            <slot name="header"></slot>
-          </${this.headerTag}>
-          <span id="subheader">
+          <div class="titleRow">
+            <${this.headerTag} class="header" display="${this.large ? 'display' : '600'}" level="3" size="none" id="header" no-margin-block>
+              <slot name="header"></slot>
+            </${this.headerTag}>
+            <${this.buttonTag} id="closeButton" aria-label="Close" variant="ghost" shape="circle" size="sm" @click="${this.onCloseButtonClick}">
+              <${this.iconTag} category="interface" name="x-lg"></${this.iconTag}>
+            </${this.buttonTag}>
+          </div>
+          <span class="subheader">
             <slot name="subheader"></slot>
           </span>
         </div>` : null}

--- a/components/bibtemplate/src/styles/style.scss
+++ b/components/bibtemplate/src/styles/style.scss
@@ -11,36 +11,31 @@
 #headerContainer {
   display: flex;
   flex-direction: column;
-}
-
-#header {
-  display: flex;
-  width: 100%;
-  min-height: var(--ds-size-1000, #{vac.$ds-size-1000});
-  box-sizing: border-box;
-  align-items: end;
+  padding: var(--ds-size-200, #{vac.$ds-size-200});
   padding-top: var(--ds-size-400, #{vac.$ds-size-400});
-  padding-right: var(--ds-size-700, #{vac.$ds-size-700});
-  padding-left: var(--ds-size-200, #{vac.$ds-size-200});
-  pointer-events: none;
-}
+  padding-bottom: 0;
 
-#subheader {
-  width: 100%;
+  .titleRow {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: var(--ds-size-100, #{vac.$ds-size-100});
+  }
 
-  ::slotted([auro-input]) {
-    box-sizing: border-box;
-    padding: 0 var(--ds-size-200, #{vac.$ds-size-200});
+  .header {
+    max-width: calc(100vw - var(--ds-size-900, #{vac.$ds-size-900}));
+    padding-top: var(--ds-size-200, #{vac.$ds-size-200});
+  }
+
+  .subheader {
+    width: 100%;
   }
 }
 
-#closeButton{
-  position: absolute;
-  top: var(--ds-size-400, #{vac.$ds-size-400});
-  right: var(--ds-size-200, #{vac.$ds-size-200});
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
+#closeButton {
+  [auro-icon] {
+    --ds-auro-icon-size: var(--ds-size-500, #{vac.$ds-size-500});
+  }
 }
 
 #bodyContainer {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -569,6 +569,7 @@ export class AuroCombobox extends AuroElement {
     // Listen for the dropdown to be shown or hidden
     this.dropdown.addEventListener("auroDropdown-toggled", (ev) => {
       this.dropdownOpen = ev.detail.expanded;
+      this.updateMenuShapeSize();
 
       // wait a frame in case the bib gets hide immediately after showing because there is no value
       setTimeout(() => {
@@ -595,7 +596,11 @@ export class AuroCombobox extends AuroElement {
     this.setInputFocus = this.setInputFocus.bind(this);
     this.dropdown.addEventListener('auroDropdown-strategy-change', () => {
       // event when the strategy(bib mode) is changed between fullscreen and floating
-      setTimeout(this.setInputFocus, 0);
+      this.updateMenuShapeSize();
+
+      setTimeout(() => {
+        this.setInputFocus();
+      }, 0);
     });
   }
 
@@ -611,6 +616,30 @@ export class AuroCombobox extends AuroElement {
   }
 
   /**
+   * Update menu to default for fullscreen bib, otherwise to this.size and this.shape.
+   * @private
+   */
+  updateMenuShapeSize() {
+    if (!this.menu) {
+      return;
+    }
+
+    if (this.dropdown && this.dropdown.isBibFullscreen) {
+      this.menu.setAttribute('size', 'md');
+      this.menu.setAttribute('shape', 'box');
+    } else {
+      // set menu's default size if there it's not specified.
+      if (!this.menu.getAttribute('size')) {
+        this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
+      }
+
+      if (!this.getAttribute('shape')) {
+        this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
+      }
+    }
+  }
+
+  /**
    * Binds all behavior needed to the menu after rendering.
    * @private
    * @returns {void}
@@ -618,14 +647,7 @@ export class AuroCombobox extends AuroElement {
   configureMenu() {
     this.menu = this.querySelector('auro-menu, [auro-menu]');
 
-    // set menu's default size if there it's not specified.
-    if (!this.menu.getAttribute('size')) {
-      this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
-    }
-
-    if (!this.getAttribute('shape')) {
-      this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
-    }
+    this.updateMenuShapeSize();
 
     // a racing condition on custom-combobox with custom-menu
     if (!this.menu || this.menuShadowRoot === null) {
@@ -1101,6 +1123,7 @@ export class AuroCombobox extends AuroElement {
             <slot name="bib.fullscreen.headline" slot="header"></slot>
             <slot></slot>
             <${this.inputTag}
+              id="inputInBib"
               @input="${this.handleInputValueChange}"
               .a11yControls="${this.dropdownId}"
               .autocomplete="${this.autocomplete}"

--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -11,6 +11,12 @@
   [auro-input] {
     --ds-auro-input-background-color: transparent;
   }
+
+  #inputInBib {
+    &::part(accent-left) {
+      display: none;
+    }
+  }
 }
 
 :host([layout*='classic']) {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -509,6 +509,7 @@ export class AuroSelect extends AuroElement {
       this.isPopoverVisible = this.dropdown.isPopoverVisible;
 
       if (this.dropdown.isPopoverVisible) {
+        this.updateMenuShapeSize();
         // wait til the bib gets fully rendered
         setTimeout(() => {
           if (this.dropdown.isBibFullscreen) {
@@ -522,6 +523,10 @@ export class AuroSelect extends AuroElement {
           }
         });
       }
+    });
+
+    this.dropdown.addEventListener('auroDropdown-strategy-change', () => {
+      this.updateMenuShapeSize();
     });
 
     // setting up bibtemplate
@@ -589,6 +594,30 @@ export class AuroSelect extends AuroElement {
   }
 
   /**
+   * Update menu to default for fullscreen bib, otherwise to this.size and this.shape.
+   * @private
+   */
+  updateMenuShapeSize() {
+    if (!this.menu) {
+      return;
+    }
+
+    if (this.dropdown && this.dropdown.isBibFullscreen) {
+      this.menu.setAttribute('size', 'md');
+      this.menu.setAttribute('shape', 'box');
+    } else {
+      // set menu's default size if there it's not specified.
+      if (!this.menu.getAttribute('size')) {
+        this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
+      }
+
+      if (!this.getAttribute('shape')) {
+        this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
+      }
+    }
+  }
+
+  /**
    * Binds all behavior needed to the menu after rendering.
    * @private
    * @returns {void}
@@ -604,14 +633,7 @@ export class AuroSelect extends AuroElement {
       return;
     }
 
-    // set menu's default size if there it's not specified.
-    if (!this.menu.getAttribute('size')) {
-      this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
-    }
-
-    if (!this.getAttribute('shape')) {
-      this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
-    }
+    this.updateMenuShapeSize();
 
     if (this.multiSelect) {
       this.menu.multiSelect = this.multiSelect;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix menu sizing and shape behavior for fullscreen bib in combobox and select by introducing a centralized updateMenuShapeSize() method and ensuring it runs on dropdown events and configuration

Bug Fixes:
- Reset menu shape and size to ‘md’ and ‘box’ by default when using fullscreen bib mode in Combobox and Select

Enhancements:
- Centralize menu size and shape logic in a new updateMenuShapeSize() method for both components
- Invoke updateMenuShapeSize() on dropdown toggled, strategy change, and during menu configuration
- Adjust Combobox input focus timing by wrapping setInputFocus in a delayed callback after strategy changes