### PR TITLE
fix: remove `aria-hidden` from -/+ buttons in counter #814

### DIFF
--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -389,7 +389,7 @@ export class AuroCounter extends LitElement {
             tabindex="${this.disabled ? '-1' : '0'}" 
           >
             <auro-counter-button
-              aria-hidden="true"
+              aria-label="-"
               .tabindex="${'-1'}"
               part="controlMinus"
               @click="${() => this.decrement()}"
@@ -404,7 +404,7 @@ export class AuroCounter extends LitElement {
             </div>
 
             <auro-counter-button
-              aria-hidden="true"
+              aria-label="+"
               .tabindex="${'-1'}"
               part="controlPlus"
               @click="${() => this.increment()}"


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve accessibility of the counter component by exposing the plus and minus controls to assistive technologies.

Bug Fixes:
- Remove aria-hidden attributes from the minus and plus buttons to ensure they are not hidden from screen readers

Enhancements:
- Add aria-label attributes with '-' and '+' to the counter buttons to provide accessible names