### PR TITLE
fix: revert the update on menu/menuoption shapeSize

### DIFF
--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -5,7 +5,6 @@
 
 import { html } from "lit";
 
-import shapeSizeCss from "./styles/shapeSize-css.js";
 import styleCss from "./styles/default/style-menu-css.js";
 import colorCss from "./styles/default/color-menu-css.js";
 import tokensCss from "./styles/default/tokens-css.js";
@@ -173,7 +172,6 @@ export class AuroMenu extends AuroElement {
 
   static get styles() {
     return [
-      shapeSizeCss,
       styleCss,
       colorCss,
       tokensCss

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -6,7 +6,6 @@
 // ---------------------------------------------------------------------
 import { html } from 'lit/static-html.js';
 
-import shapeSizeCss from "./styles/shapeSize-css.js";
 import styleCss from "./styles/default/style-menuoption-css.js";
 import colorCss from "./styles/default/color-menuoption-css.js";
 import tokensCss from "./styles/default/tokens-css.js";
@@ -94,7 +93,6 @@ export class AuroMenuOption extends AuroElement {
 
   static get styles() {
     return [
-      shapeSizeCss,
       styleCss,
       colorCss,
       tokensCss

--- a/components/menu/src/styles/default/color-menuoption.scss
+++ b/components/menu/src/styles/default/color-menuoption.scss
@@ -9,9 +9,9 @@
 
 :host {
   .wrapper {
-    border: 1px solid var(--ds-auro-menuoption-container-border-color);
     background-color: var(--ds-auro-menuoption-container-color);
     color: var(--ds-auro-menuoption-text-color);
+    outline: 1px solid var(--ds-auro-menuoption-container-border-color);
   }
 
   svg {

--- a/components/menu/src/styles/default/style-menu.scss
+++ b/components/menu/src/styles/default/style-menu.scss
@@ -20,7 +20,8 @@
 
   .menuWrapper {
     box-sizing: border-box;
-    display: inline-block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
 
     margin: 0;
@@ -65,10 +66,12 @@
   .menuWrapper {
     &.lg {
       padding: var(--ds-size-150, vac.$ds-size-150);
+      gap: var(--ds-size-50, vac.$ds-size-50);
     }
 
     &.xl {
       padding: var(--ds-size-200, vac.$ds-size-200);
+      gap: var(--ds-size-100, vac.$ds-size-100);
     }
   }
 }

--- a/components/menu/src/styles/default/style-menuoption.scss
+++ b/components/menu/src/styles/default/style-menuoption.scss
@@ -5,7 +5,7 @@
 
 /* stylelint-disable declaration-empty-line-before */
 
-@use '@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables' as vac;
+@use "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables" as vac;
 @use '@aurodesignsystem/webcorestylesheets/src/breakpoints';
 @use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.css';
 
@@ -16,15 +16,44 @@
   user-select: none;
 
   .wrapper {
-    box-sizing: border-box;
     display: flex;
     align-items: center;
-    padding-right: var(--ds-size-150, vac.$ds-size-150);
-    padding-left: calc(var(--ds-size-100, vac.$ds-size-100) + var(--ds-size-300, vac.$ds-size-300) + var(--ds-size-100, vac.$ds-size-100));
+    padding-right: var(--ds-size-200, vac.$ds-size-200);    
+    padding-left: calc(var(--ds-size-150, vac.$ds-size-150) + var(--ds-size-300, vac.$ds-size-300) + var(--ds-size-100, vac.$ds-size-100));
     padding-top: var(--ds-size-50, vac.$ds-size-50);
     padding-bottom: var(--ds-size-50, vac.$ds-size-50);
+    border-radius: var(--ds-size-100, vac.$ds-size-100);
 
     -webkit-tap-highlight-color: transparent;
+
+    &[class*="shape-box"] {
+      border-radius: unset;
+    }
+
+    &[class*="shape-snowflake"] {
+      border-radius: unset;
+      line-height: 24px;
+    }
+
+    &[class*="shape-pill"] {
+      border-radius: 30px;
+    }
+
+    &[class*="-lg"] {
+      padding-top: var(--ds-size-75, vac.$ds-size-75);
+      padding-bottom: var(--ds-size-75, vac.$ds-size-75);
+      padding-right: var(--ds-size-150, vac.$ds-size-150);
+      margin-bottom: var(--ds-size-50, vac.$ds-size-50);
+      line-height: 26px;
+    }
+
+    &[class*="-xl"] {
+      padding-top: var(--ds-size-100, vac.$ds-size-100);
+      padding-bottom: var(--ds-size-100, vac.$ds-size-100);
+      padding-right: var(--ds-size-200, vac.$ds-size-200);
+      margin-bottom: var(--ds-size-100, vac.$ds-size-100);
+      line-height: 26px;
+    }
 
   }
 
@@ -37,7 +66,7 @@
 
   [auro-icon] {
     --ds-auro-icon-size: var(--ds-size-300, #{vac.$ds-size-300});
-    margin-right: var(--ds-size-100, vac.$ds-size-100);
+    margin-right: var(--ds-size-150, vac.$ds-size-150);
     margin-left: var(--ds-size-100, vac.$ds-size-100);
   }
 
@@ -47,9 +76,15 @@
   }
 }
 
+:host(:last-child) {
+  .wrapper {
+    margin-bottom: unset;
+  }
+}
+
 :host([loadingplaceholder]) {
   .wrapper {
-    padding-left: calc(var(--ds-size-100, vac.$ds-size-100) + var(--ds-size-300, vac.$ds-size-300) + var(--ds-size-100, vac.$ds-size-100));
+    padding-left: calc(var(--ds-size-150, vac.$ds-size-150) + var(--ds-size-300, vac.$ds-size-300) + var(--ds-size-100, vac.$ds-size-100));
   }
 }
 

--- a/components/menu/src/styles/default/style-menuoption.scss
+++ b/components/menu/src/styles/default/style-menuoption.scss
@@ -43,7 +43,6 @@
       padding-top: var(--ds-size-75, vac.$ds-size-75);
       padding-bottom: var(--ds-size-75, vac.$ds-size-75);
       padding-right: var(--ds-size-150, vac.$ds-size-150);
-      margin-bottom: var(--ds-size-50, vac.$ds-size-50);
       line-height: 26px;
     }
 
@@ -51,7 +50,6 @@
       padding-top: var(--ds-size-100, vac.$ds-size-100);
       padding-bottom: var(--ds-size-100, vac.$ds-size-100);
       padding-right: var(--ds-size-200, vac.$ds-size-200);
-      margin-bottom: var(--ds-size-100, vac.$ds-size-100);
       line-height: 26px;
     }
 
@@ -73,12 +71,6 @@
   ::slotted(.nestingSpacer) {
     display: inline-block;
     width: var(--ds-size-300, vac.$ds-size-300);
-  }
-}
-
-:host(:last-child) {
-  .wrapper {
-    margin-bottom: unset;
   }
 }
 

--- a/components/menu/src/styles/shapeSize.scss
+++ b/components/menu/src/styles/shapeSize.scss
@@ -1,4 +1,0 @@
-/* stylelint-disable */
-
-@use '../../../layoutElement/src/styles/shapeSize.scss';
-


### PR DESCRIPTION
# Alaska Airlines Pull Request

menu/menuoption do not follow the universal shapesize t-shirts sizing

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Revert the universal shapeSize mixin in the menu and menuoption components, remove the shapeSize stylesheet, and manually restore padding, border-radius, and spacing values to comply with legacy t-shirt sizing guidelines.

Bug Fixes:
- Reinstate legacy padding values for menuoption wrappers to match universal t-shirt sizing
- Replace container border with an outline for consistent focus and hover states
- Remove shapeSizeCss imports from AuroMenu and AuroMenuOption to disable the shapeSize mixin
- Eliminate the deprecated shapeSize.scss file

Enhancements:
- Add manual border-radius defaults and shape-specific overrides (box, snowflake, pill)
- Adjust padding and line-height for -lg and -xl modifiers
- Reset bottom margin on the last child wrapper
- Tweak icon margin-right spacing