### PR TITLE
Fix radio selection bug #836

### DIFF
--- a/components/radio/src/auro-radio.js
+++ b/components/radio/src/auro-radio.js
@@ -287,7 +287,7 @@ export class AuroRadio extends LitElement {
           @input="${this.handleInput}"
           @change="${this.handleChange}"
           ?disabled="${this.disabled}"
-          ?checked="${this.checked}"
+          .checked="${this.checked}"
           id="${this.inputId}"
           name="${ifDefined(this.name)}"
           type="radio"

--- a/components/radio/test/auro-radio.test.js
+++ b/components/radio/test/auro-radio.test.js
@@ -165,6 +165,35 @@ describe('auro-radio', () => {
 });
 
 describe('auro-radio-group', () => {
+  it('ensures radio buttons can be selected, unselected, and reselected', async () => {
+    const el = await fixture(html`
+      <auro-radio-group name="group">
+        <span slot="legend">Form label goes here</span>
+        <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes">T</auro-radio>
+        <auro-radio id="radio2" label="No" name="radioDemo" value="no">N</auro-radio>
+        <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe">?</auro-radio>
+      </auro-radio-group>
+    `);
+
+    const radioOne = el.querySelector('#radio1');
+    const radioTwo = el.querySelector('#radio2');
+
+    radioOne.shadowRoot.querySelector('input').click();
+    await elementUpdated(el);
+    await expect(radioOne.hasAttribute('checked')).to.be.true;
+
+    radioTwo.shadowRoot.querySelector('input').click();
+    await elementUpdated(el);
+    await expect(radioOne.hasAttribute('checked')).to.be.false;
+    await expect(radioTwo.hasAttribute('checked')).to.be.true;
+
+    radioOne.shadowRoot.querySelector('input').click();
+    await elementUpdated(el);
+    await expect(radioOne.hasAttribute('checked')).to.be.true;
+    await expect(radioTwo.hasAttribute('checked')).to.be.false;
+  });
+
+
   it('emits an input event when value changes', async () => {
     const el = await fixture(html`
       <auro-radio-group name="group">


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Reverts `checked` property binding from `?` back to `.`
- Adds test to cover situation of selecting, unselecting, and reselecting radio buttons.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix radio button selection bug by reverting to property binding for checked state and add a test covering select, unselect, and reselect scenarios

Bug Fixes:
- Switch checked binding from attribute to property to fix radio selection state

Tests:
- Add test to ensure radio buttons can be selected, unselected, and reselected