### PR TITLE
fix: hide datepicker's clear when it's not holding focus/hover #843

### DIFF
--- a/components/datepicker/src/styles/style.scss
+++ b/components/datepicker/src/styles/style.scss
@@ -71,6 +71,11 @@
   width: 100%;
 }
 
+.wrapper:not(:focus-within):not(:hover) { // stylelint-disable selector-not-notation
+  .notification.clear {
+    display: none;
+  }
+}
 
 @include vb.auro_breakpoint($max: vac.$ds-grid-breakpoint-sm) {
   ::part(popover) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #843 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Hide the clear button on the datepicker when it loses focus and hover state