### PR TITLE
fix: set bg color on clasic input, consolidate token for input's bg color #845

### DIFF
--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -9,7 +9,7 @@
   display: block;
 
   [auro-input] {
-    --ds-auro-input-background-color: transparent;
+    --ds-auro-input-container-color: transparent;
   }
 
   #inputInBib {

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -97,7 +97,7 @@ export class AuroInput extends BaseInput {
    * or when the input has no value, is not focused, and has no placeholder text.
    * @returns {boolean} - True if the input should be visually hidden, false otherwise.
    * @private
-  */
+   */
   get inputHidden() {
     return (this.hasDisplayValueContent && !this.hasFocus && this.hasValue) || ((!this.value || this.value.length === 0) && !this.hasFocus && (!this.placeholder || this.placeholder === ''));
   }

--- a/components/input/src/styles/classic/style.scss
+++ b/components/input/src/styles/classic/style.scss
@@ -21,6 +21,7 @@
   .wrapper {
     display: flex;
     flex-direction: row;
+    background-color: var(--ds-auro-input-container-color);
     box-shadow: inset 0 0 0 1px var(--ds-auro-input-outline-color);
   }  
 

--- a/components/input/src/styles/color.scss
+++ b/components/input/src/styles/color.scss
@@ -14,7 +14,7 @@
 
 .wrapper {
   border-color: var(--ds-auro-input-border-color);
-  background-color: var(--ds-auro-input-background-color);
+  background-color: var(--ds-auro-input-container-color);
   color: var(--ds-auro-input-text-color);
 
   label {

--- a/components/input/src/styles/tokens.scss
+++ b/components/input/src/styles/tokens.scss
@@ -4,7 +4,6 @@
 
 :host(:not([ondark])) {
   --ds-auro-input-border-color: var(--ds-basic-color-border-bold, #{v.$ds-basic-color-border-bold});
-  --ds-auro-input-background-color: var(--ds-basic-color-surface-default, #{v.$ds-basic-color-surface-default});
   --ds-auro-input-container-color: var(--ds-basic-color-surface-default, #{v.$ds-basic-color-surface-default});
   --ds-auro-input-caret-color: var(--ds-advanced-color-state-focused, #{v.$ds-advanced-color-state-focused});
   --ds-auro-input-label-text-color: var(--ds-basic-color-texticon-muted, #{v.$ds-basic-color-texticon-muted});
@@ -17,7 +16,6 @@
 
 :host([ondark]) {
   --ds-auro-input-border-color: var(--ds-basic-color-border-inverse, #{v.$ds-basic-color-border-inverse});
-  --ds-auro-input-background-color: var(--ds-advanced-color-shared-background-inverse, #{v.$ds-advanced-color-shared-background-inverse});
   --ds-auro-input-container-color: var(--ds-advanced-color-shared-background-inverse, #{v.$ds-advanced-color-shared-background-inverse});
   --ds-auro-input-caret-color: var(--ds-advanced-color-state-focused-inverse, #{v.$ds-advanced-color-state-focused-inverse});
   --ds-auro-input-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});


### PR DESCRIPTION


# Alaska Airlines Pull Request

1. set classic input's background color which was unset by `shapeSize` mixin
2. consolidate bg-color tokens by removing `--ds-auro-input-background-color` (most of styles are using `--ds-auro-input-container-color` but some were using `--ds-auro-input-background-color`)

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
