### PR TITLE
fix: move focus to the next date input after selecting date in datepicker #848

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -884,23 +884,33 @@ export class AuroDatePicker extends AuroElement {
     const convertedDate = this.convertWcTimeToDate(time);
     const newDate = this.util.toCustomFormat(convertedDate, this.format);
 
+    let onEndValue = false;
     if (this.util.validDateStr(newDate, this.format)) {
-      if (this.inputList.length > 1) {
-        if (!this.value || !this.util.validDateStr(this.value, this.format)) {
-          this.value = newDate;
-        } else if (!this.valueEnd || !this.util.validDateStr(this.valueEnd, this.format)) {
+      if (this.range) {
+        const isValueValid = this.value && this.util.validDateStr(this.value, this.format);
+        const isValueEndValid = this.valueEnd && this.util.validDateStr(this.valueEnd, this.format);
+
+        if (isValueValid && !isValueEndValid) {
           // verify the date is after this.value to insure we are setting a proper range
           if (new Date(this.util.toNorthAmericanFormat(newDate, this.format)) >= new Date(this.formattedValue)) {
-            this.valueEnd = newDate;
-          } else {
-            this.value = newDate;
+            onEndValue = true;
           }
-        } else {
-          this.value = newDate;
+        } else if (isValueValid && isValueEndValid) {
+          // both dateTo and dateFrom are valid, then reset datTo
           this.valueEnd = '';
+        }
+      }
+
+      if (onEndValue) {
+        this.valueEnd = newDate;
+        if (this.dropdown.isPopoverVisible && !this.dropdown.isBibFullscreen) {
+          this.focus('startDate');
         }
       } else {
         this.value = newDate;
+        if (this.dropdown.isPopoverVisible && !this.dropdown.isBibFullscreen) {
+          this.focus('endDate');
+        }
       }
     }
   }


### PR DESCRIPTION

# Alaska Airlines Pull Request

Only when the date is selected from non-fullscreen bib calendar, 
When the startDate get selected, move focus to endDate input, 
When the endDate gets selected, move foucs back to startDate input.

However, the current position of focus does not mean, the selected date is going to get filled in that input element. 
For example, even when the endDate input is holding the focus but without valid startDate value set, the selected date will be filled in to the startDate.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
