### PR TITLE
fix: force rerender snowflake/emphasized input when it gets focus #891

### DIFF
--- a/components/input/src/styles/emphasized/style.scss
+++ b/components/input/src/styles/emphasized/style.scss
@@ -65,6 +65,7 @@
   }
 
   input {
+    transition: all 1ms linear; // force repaint after 0.01s due to iOS safari rendering issue
     text-align: center;
   }
 

--- a/components/input/src/styles/snowflake/style.scss
+++ b/components/input/src/styles/snowflake/style.scss
@@ -32,6 +32,7 @@
   }
 
   input {
+    transition: all 1ms linear;
     text-align: center;
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

### Issue
1. iOS safari defect
When an input element changes size at the same time it gets focus, the cursor appears with the size from before the change.
2. This problem happens only with snowflake/emphasized layout. Classic input does not have this problem because it's repainting with transition effect.

### Solution
Force input to repaint by setting transition style.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
