### PR TITLE
fix: update ondark error color to match to the figma spec #955

### DIFF
--- a/components/counter/src/styles/tokens.scss
+++ b/components/counter/src/styles/tokens.scss
@@ -26,7 +26,7 @@
   --ds-auro-counter-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
   --ds-auro-counter-placeholder-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
   --ds-auro-counter-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
-  --ds-auro-counter-error-icon-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-counter-error-icon-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
   --ds-auro-counter-outline-color: transparent;
 
   /* Classic Tokens */

--- a/components/datepicker/src/styles/tokens.scss
+++ b/components/datepicker/src/styles/tokens.scss
@@ -27,7 +27,7 @@
 
 :host([ondark]) {
   --ds-auro-datepicker-range-input-divider-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
-  --ds-auro-datepicker-error-icon-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-datepicker-error-icon-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
   --ds-auro-datepicker-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
 
   // calendar

--- a/components/dropdown/src/styles/color.scss
+++ b/components/dropdown/src/styles/color.scss
@@ -62,5 +62,5 @@
 }
 
 :host([ondark][error]) {
-  --ds-auro-dropdown-trigger-border-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-dropdown-trigger-border-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 }

--- a/components/helptext/src/styles/color.scss
+++ b/components/helptext/src/styles/color.scss
@@ -11,7 +11,7 @@
 }
 
 :host([onDark][error]) {
-  --ds-auro-helptext-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-helptext-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 }
 
 .helptext-wrapper {

--- a/components/input/src/styles/classic/color.scss
+++ b/components/input/src/styles/classic/color.scss
@@ -47,8 +47,8 @@
 }
 
 :host([layout*="classic"][ondark]:is([validity]:not([validity='valid']))) {
-  --ds-auro-input-border-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
-  --ds-auro-input-outline-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-input-border-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
+  --ds-auro-input-outline-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 
   .layout-classic {
     &:focus-within {

--- a/components/input/src/styles/color.scss
+++ b/components/input/src/styles/color.scss
@@ -62,7 +62,7 @@
 
 :host([ondark]:is([validity]:not([validity='valid']))) {
   .wrapper {
-    --ds-auro-input-border-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+    --ds-auro-input-border-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
   }
 }
 

--- a/components/input/src/styles/default/color.scss
+++ b/components/input/src/styles/default/color.scss
@@ -95,7 +95,7 @@
   --ds-auro-input-placeholder-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
   --ds-auro-input-border-color: var(--ds-basic-color-border-inverse, #{v.$ds-basic-color-border-inverse});
   --ds-auro-input-container-color: var(--ds-advanced-color-shared-background-inverse, #{v.$ds-advanced-color-shared-background-inverse});
-  --ds-auro-input-error-icon-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-input-error-icon-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 
   .wrapper {
     &:focus-within {
@@ -109,7 +109,7 @@
 :host([class='layoutDefault'][onDark][validity]:not([validity='valid'])[bordered]),
 :host(:not([layout])[onDark][validity]:not([validity='valid'])[bordered]) {
   .wrapper {
-    --ds-auro-input-border-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+    --ds-auro-input-border-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 
     box-shadow: inset 0 0 0 1px var(--ds-auro-input-border-color);
   }

--- a/components/input/src/styles/tokens.scss
+++ b/components/input/src/styles/tokens.scss
@@ -21,7 +21,7 @@
   --ds-auro-input-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
   --ds-auro-input-placeholder-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
   --ds-auro-input-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
-  --ds-auro-input-error-icon-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-input-error-icon-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
 
   --ds-auro-input-outline-color: transparent;
 }

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -129,7 +129,7 @@ label {
 
 :host([ondark]:is([validity]:not([validity='valid']))) {
   [auro-dropdown] {
-    --ds-auro-select-border-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+    --ds-auro-select-border-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
     --ds-auro-dropdown-helptext-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
   }
 }

--- a/components/select/src/styles/tokens.scss
+++ b/components/select/src/styles/tokens.scss
@@ -16,6 +16,6 @@
   --ds-auro-select-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
   --ds-auro-select-placeholder-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
   --ds-auro-select-text-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
-  --ds-auro-select-error-icon-color: var(--ds-basic-color-status-error-subtle, #{v.$ds-basic-color-status-error-subtle});
+  --ds-auro-select-error-icon-color: var(--ds-advanced-color-state-error-inverse, #{v.$ds-advanced-color-state-error-inverse});
   --ds-auro-select-outline-color: transparent;
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Figma: https://www.figma.com/design/VpUz89Ov6ImBpY5YvzYbZW/Auro-toolkit?node-id=14375-13529&m=dev

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Replace basic-color-status-error-subtle with advanced-color-state-error-inverse for error borders and icons on dark backgrounds