### PR TITLE
fix: center-align trigger and helpText for snowflake dropdown #957

### DIFF
--- a/components/datepicker/src/styles/snowflake/style.scss
+++ b/components/datepicker/src/styles/snowflake/style.scss
@@ -39,6 +39,10 @@
     }
   }
 
+  &::part(helpText) {
+    text-align: center;
+  }
+
   // for the trigger content
 
   .dpTriggerContent {

--- a/components/dropdown/src/styles/color.scss
+++ b/components/dropdown/src/styles/color.scss
@@ -38,7 +38,7 @@
 
 /* onDark */
 :host([onDark]) {
-  .label {
+  .label, .helpText {
     color: var(--ds-auro-dropdown-label-text-color);
   }
 

--- a/components/dropdown/src/styles/snowflake/style.scss
+++ b/components/dropdown/src/styles/snowflake/style.scss
@@ -25,6 +25,11 @@
     width: calc(100% - var(--ds-size-600, vac.$ds-size-600));
     margin-right: var(--ds-size-300, vac.$ds-size-300);
   }
+
+  .trigger,
+  .helpText {
+    text-align: center;
+  }
 }
 
 .layout-snowflake,


### PR DESCRIPTION
# Alaska Airlines Pull Request

Solved Problem
- helpText in Datepicker and counter group was not center aligned
- trigger in counter, dropdown is not center aligned
- helpText in onDark dropdown was not visible

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Center-align helpText and triggers across Snowflake dropdown and datepicker and restore helpText visibility on dark backgrounds

Bug Fixes:
- Center-align trigger and helpText in Snowflake dropdown
- Center-align helpText in Snowflake datepicker
- Include helpText in onDark dropdown color rules to ensure visibility