### PR TITLE
fix: prevent the alignment breakage from inherited text-align style #880

### DIFF
--- a/components/checkbox/src/styles/auro-checkbox.scss
+++ b/components/checkbox/src/styles/auro-checkbox.scss
@@ -98,8 +98,9 @@ fieldset {
 
 .svg--cbx {
   position: absolute;
-  padding-top: 3px;
-  padding-bottom: 3px;
+  left: 0;
+  top: 3px;
+  bottom: 3px;
 
   z-index: 1;
   pointer-events: none;

--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -7,6 +7,7 @@
 
 :host {
   display: block;
+  text-align: left;
 
   [auro-input] {
     --ds-auro-input-container-color: transparent;

--- a/components/counter/src/styles/counter-group.scss
+++ b/components/counter/src/styles/counter-group.scss
@@ -13,6 +13,10 @@
 // Import type classes
 @use '@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.min.css';
 
+:host {
+  text-align: left;
+}
+
 :host(:not([layout="classic"])) {
   .triggerContent {
     padding: 0 var(--ds-size-100, vac.$ds-size-100) 0 var(--ds-size-300, vac.$ds-size-300);

--- a/components/counter/src/styles/style.scss
+++ b/components/counter/src/styles/style.scss
@@ -42,6 +42,7 @@
 
 :host{
   position: relative;
+  text-align: left;
 
   &::part(counterControl) {
     display: flex;

--- a/components/dropdown/src/styles/style.scss
+++ b/components/dropdown/src/styles/style.scss
@@ -3,6 +3,7 @@
 :host {
   position: relative;
   display: block;
+  text-align: left;
 }
 
 :host([open]) {

--- a/components/input/src/styles/default/style.scss
+++ b/components/input/src/styles/default/style.scss
@@ -29,6 +29,9 @@
 // Support for auroElement styles
 @use '@aurodesignsystem/webcorestylesheets/dist/auroElement/auroElement';
 
+:host {
+  text-align: left;
+}
 
 .layoutDefault,
 :host(:not([layout])) {

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -30,6 +30,7 @@
 
 :host {
   display: inline-block;
+  text-align: left;
 }
 
 :host([layout*='emphasized']),


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #880 

When an ancestor node has text-align set to center, it breaks the alignment of label, value, and helpText. 
This is PR is to set `text-align:left` in `:host` to prevent that. 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Prevent inherited center text alignment from breaking component layouts by explicitly setting text-align:left on component hosts

Bug Fixes:
- Add text-align:left to host in Counter Group to maintain correct label and value alignment
- Add text-align:left to host in Input to prevent help text misalignment
- Add text-align:left to host in Combobox, Counter, Dropdown, and Select components to enforce left-aligned content