### PR TITLE
fix: make dropdown `inline-block` as default and add `fluid` attr

### DIFF
--- a/components/combobox/apiExamples/fluid.html
+++ b/components/combobox/apiExamples/fluid.html
@@ -1,0 +1,14 @@
+<auro-combobox fluid>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Name</span>
+  <auro-menu>
+    <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+    <auro-menuoption value="Peaches" id="option-2">Peaches</auro-menuoption>
+    <auro-menuoption value="Grapes" id="option-3">Grapes</auro-menuoption>
+    <auro-menuoption value="Cherries" id="option-4">Cherries</auro-menuoption>
+    <auro-menuoption static nomatch>No matching option</auro-menuoption>
+  </auro-menu>
+</auro-combobox>

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -1,5 +1,11 @@
 # auro-combobox
 
+## Attributes
+
+| Attribute | Description                                      |
+|-----------|--------------------------------------------------|
+| `fluid`   | When attribute is present, element will be 100% width of container element. |
+
 ## Properties
 
 | Property                        | Attribute                       | Type          | Default        | Description                                      |

--- a/components/combobox/docs/partials/api.md
+++ b/components/combobox/docs/partials/api.md
@@ -94,6 +94,23 @@ You can manually set the input mode for the input.
 
 </auro-accordion>
 
+#### fluid <a name="fluid"></a>
+
+Use `fluid` attribute to make `<auro-combobox>` to take the full width of its container.
+
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/fluid.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/fluid.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 #### noFilter
 
 If set, combobox will not do suggestion filtering of the menuoptions. This option is useful when the `<auro-menuoption>` elements are being pre-filtered externally to combobox (e.g. using the citysearch API).

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -34,6 +34,7 @@ import {ifDefined} from "lit/directives/if-defined.js";
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
+ * @attr fluid - When attribute is present, element will be 100% width of container element.
  * @slot - Default slot for the menu content.
  * @slot {HTMLSlotElement} optionalLabel - Allows overriding the optional display text "(optional)", which appears next to the label.
  * @slot ariaLabel.input.clear - Sets aria-label on clear button

--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -6,7 +6,7 @@
 @use '@aurodesignsystem/webcorestylesheets/src/utilityClasses/displayProperties';
 
 :host {
-  display: block;
+  display: inline-block;
   text-align: left;
 
   [auro-input] {
@@ -26,6 +26,10 @@
       display: none;
     }
   }
+}
+
+:host([fluid]) {
+  display: block;
 }
 
 :host([layout*='classic']) {

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -680,6 +680,7 @@ export class AuroCounterGroup extends AuroElement {
       <${this.dropdownTag} 
         noHideOnThisFocusLoss
         chevron
+        fluid
         part="dropdown"
         ?autoPlacement="${this.autoPlacement}"
         ?error="${this.validity !== undefined && this.validity !== 'valid'}"

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1664,6 +1664,7 @@ export class AuroDatePicker extends AuroElement {
     // Base HTML render() handles dropdown and calendar bib
     return html`
       <${this.dropdownTag}
+          fluid
           ?autoPlacement="${this.autoPlacement}"
           ?onDark="${this.onDark}"
           ?disabled="${this.disabled}"

--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -1,5 +1,11 @@
 # auro-dropdown
 
+## Attributes
+
+| Attribute | Description                                      |
+|-----------|--------------------------------------------------|
+| `fluid`   | To make dropdown `block` instead of `inline-block` |
+
 ## Properties
 
 | Property                | Attribute               | Type        | Default        | Description                                      |

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -52,6 +52,7 @@ import { AuroElement } from '../../layoutElement/src/auroElement.js';
 
 
 /*
+ * @attr fluid - To make dropdown `block` instead of `inline-block`
  * @slot - Default slot for the popover content.
  * @slot helpText - Defines the content of the helpText.
  * @slot trigger - Defines the content of the trigger.

--- a/components/dropdown/src/styles/style.scss
+++ b/components/dropdown/src/styles/style.scss
@@ -2,8 +2,16 @@
 
 :host {
   position: relative;
-  display: block;
+  display: inline-block;
   text-align: left;
+}
+
+:host([fluid]) {
+  display: block;
+
+  ::slotted([slot='trigger']) {
+    width: 100%;
+  }
 }
 
 :host([open]) {

--- a/components/select/apiExamples/fluid.html
+++ b/components/select/apiExamples/fluid.html
@@ -1,0 +1,13 @@
+<auro-select fluid>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Select Example</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menuoption value="duration">Duration</auro-menuoption>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+    <auro-menuoption value="arrival">Arrival</auro-menuoption>
+    <auro-menuoption value="prefer alaska">Prefer Alaska</auro-menuoption>
+  </auro-menu>
+</auro-select>

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -2,6 +2,12 @@
 
 The auro-select element is a wrapper for auro-dropdown and auro-menu to create a dropdown menu control.
 
+## Attributes
+
+| Attribute | Description                                      |
+|-----------|--------------------------------------------------|
+| `fluid`   | When attribute is present, element will be 100% width of container element. |
+
 ## Properties
 
 | Property                        | Attribute                       | Type                              | Default        | Description                                      |
@@ -10,7 +16,6 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | `autocomplete`                  | `autocomplete`                  | `string`                          |                | If declared, sets the autocomplete attribute for the select element. |
 | `disabled`                      | `disabled`                      | `boolean`                         |                | When attribute is present, element shows disabled state. |
 | `error`                         | `error`                         | `string`                          |                | When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value. |
-| `fluid`                         | `fluid`                         | `boolean`                         |                | When attribute is present, element will be 100% width of container element. |
 | `forceDisplayValue`             | `forceDisplayValue`             | `boolean`                         | false          | If declared, the label and value will be visually hidden and the displayValue will render 100% of the time. |
 | `fullscreenBreakpoint`          | `fullscreenBreakpoint`          | `string`                          | "sm"           | Defines the screen size breakpoint (`xs`, `sm`, `md`, `lg`, `xl`, `disabled`)<br />at which the dropdown switches to fullscreen mode on mobile. `disabled` indicates a dropdown should _never_ enter fullscreen.<br /><br />When expanded, the dropdown will automatically display in fullscreen mode<br />if the screen size is equal to or smaller than the selected breakpoint. |
 | `largeFullscreenHeadline`       | `largeFullscreenHeadline`       | `boolean`                         |                | If declared, make bib.fullscreen.headline in HeadingDisplay.<br />Otherwise, Heading 600. |

--- a/components/select/docs/partials/api.md
+++ b/components/select/docs/partials/api.md
@@ -228,6 +228,24 @@ Use the `helpText` slot to provide additional information back to your user abou
 
 </auro-accordion>
 
+#### fluid <a name="fluid"></a>
+
+Use `fluid` attribute to make `<auro-select>` to take the full width of its container.
+
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/fluid.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/fluid.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+
 ## Functional Examples
 
 ### Reset State

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1207,6 +1207,7 @@ export class AuroSelect extends AuroElement {
           .offset="${this.offset}"
           .placement="${this.placement}"
           chevron
+          fluid
           for="selectMenu"
           layout="${this.layout}"
           part="dropdown"
@@ -1285,6 +1286,7 @@ export class AuroSelect extends AuroElement {
           .offset="${this.offset}"
           .placement="${this.placement}"
           chevron
+          fluid
           for="selectMenu"
           layout="${this.layout}"
           part="dropdown"
@@ -1369,6 +1371,7 @@ export class AuroSelect extends AuroElement {
           .offset="${this.offset}"
           .placement="${this.placement}"
           chevron
+          fluid
           for="selectMenu"
           layout="${this.layout}"
           part="dropdown"

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -43,6 +43,8 @@ import { ifDefined } from "lit-html/directives/if-defined.js";
 /**
  * The auro-select element is a wrapper for auro-dropdown and auro-menu to create a dropdown menu control.
  *
+ * @attr fluid - When attribute is present, element will be 100% width of container element.
+ *
  * @slot - Default slot for the menu content.
  * @slot ariaLabel.bib.close - Sets aria-label on close button in fullscreen bib
  * @slot bib.fullscreen.headline - Defines the headline to display above menu-options
@@ -189,14 +191,6 @@ export class AuroSelect extends AuroElement {
        * When attribute is present, element shows disabled state.
        */
       disabled: {
-        type: Boolean,
-        reflect: true
-      },
-
-      /**
-       * When attribute is present, element will be 100% width of container element.
-       */
-      fluid: {
         type: Boolean,
         reflect: true
       },

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -33,6 +33,10 @@
   text-align: left;
 }
 
+:host([fluid]) {
+  display: block;
+}
+
 :host([layout*='emphasized']),
 :host([layout*='snowflake']) {
   [auro-dropdown] {


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Make dropdown `inline-block` as default to match display with auro-button
- Add `fluid` attribute to make it `block`

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce a `fluid` attribute to the dropdown component, change its default display to `inline-block`, and update related component usages and documentation accordingly.

New Features:
- Add `fluid` attribute to make dropdown display as block and stretch the trigger to full width.

Enhancements:
- Change dropdown’s default host display to `inline-block` for consistency with buttons.
- Apply the new `fluid` attribute to dropdowns in select, counter-group, and datepicker components.

Documentation:
- Document the `fluid` attribute in the dropdown API.