### PR TITLE
Fix emphasized select/combobox background color

### DIFF
--- a/components/bibtemplate/src/iconVersion.js
+++ b/components/bibtemplate/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '8.1.1';
+export default '8.1.2';

--- a/components/combobox/apiExamples/emphasized/basic.html
+++ b/components/combobox/apiExamples/emphasized/basic.html
@@ -1,4 +1,4 @@
-<auro-combobox layout="emphasized" value="Oranges" shape="pill" size="xl" placeholder="Placeholder content" required ondark style="width: 249px;">
+<auro-combobox layout="emphasized" value="Oranges" shape="pill" size="xl" placeholder="Placeholder content" required style="width: 249px;">
   <span slot="ariaLabel.bib.close">Close combobox</span>
   <span slot="ariaLabel.input.clear">Clear All</span>
   <span slot="bib.fullscreen.headline">Bib Header</span>

--- a/components/combobox/docs/partials/index.md
+++ b/components/combobox/docs/partials/index.md
@@ -24,7 +24,7 @@
 
 ### Emphasized
 
-<div class="exampleWrapper--ondark">
+<div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/emphasized/basic.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>

--- a/components/combobox/src/styles/emphasized/style.scss
+++ b/components/combobox/src/styles/emphasized/style.scss
@@ -1,6 +1,18 @@
+@use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
+
+// TODO: Move color styles to separate file
+
 :host([layout*='emphasized'][shape*='pill']) {
   [auro-input] { // CAN I MOVE THESE INTO DROPDOWN? DROPDOWN SHOULD BE SMART ENOUGH TO HIDE THE HELP TEXT OF ANY INPUT INSIDE IT
+    --ds-auro-input-background-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
+    --ds-auro-input-container-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
+
     width: 100%;
+
+    &:hover {
+      --ds-auro-input-background-color: var(--ds-advanced-color-dropdown-emphasized-background-hover, #{v.$ds-advanced-color-dropdown-emphasized-background-hover});
+      --ds-auro-input-container-color: var(--ds-advanced-color-dropdown-emphasized-background-hover, #{v.$ds-advanced-color-dropdown-emphasized-background-hover});
+    }
 
     &::part(inputHelpText) {
       display: none;

--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -9,9 +9,8 @@
   display: block;
   text-align: left;
 
-  [auro-input] {
-    --ds-auro-input-background-color: transparent;
-    --ds-auro-input-container-color: transparent;
+  [auro-dropdown] {
+    --ds-auro-dropdown-trigger-background-color: transparent;
   }
 
   #inputInBib {

--- a/components/counter/src/iconVersion.js
+++ b/components/counter/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '8.1.1';
+export default '8.1.2';

--- a/components/dropdown/src/styles/color.scss
+++ b/components/dropdown/src/styles/color.scss
@@ -22,6 +22,10 @@
       --ds-auro-dropdown-trigger-border-color: var(--ds-advanced-color-state-focused, #{v.$ds-advanced-color-state-focused});
       --ds-auro-dropdown-trigger-outline-color: var(--ds-advanced-color-state-focused, #{v.$ds-advanced-color-state-focused});
     }
+
+    &:hover {
+      --ds-auro-dropdown-trigger-background-color: var(--ds-auro-dropdown-trigger-hover-background-color);
+    }
   }
 }
 
@@ -51,6 +55,10 @@
     &:active {
       --ds-auro-dropdown-trigger-border-color: var(--ds-advanced-color-state-focused-inverse, #{v.$ds-advanced-color-state-focused-inverse});
       --ds-auro-dropdown-trigger-outline-color: var(--ds-advanced-color-state-focused-inverse, #{v.$ds-advanced-color-state-focused-inverse});
+    }
+    
+    &:hover {
+      --ds-auro-dropdown-trigger-background-color: var(--ds-auro-dropdown-trigger-hover-background-color);
     }
   }
 }

--- a/components/dropdown/src/styles/tokens.scss
+++ b/components/dropdown/src/styles/tokens.scss
@@ -5,6 +5,7 @@
 :host(:not([ondark])) {
   --ds-auro-dropdown-label-text-color: var(--ds-basic-color-texticon-muted, #{v.$ds-basic-color-texticon-muted});
   --ds-auro-dropdown-trigger-background-color: var(--ds-basic-color-surface-default, #{v.$ds-basic-color-surface-default});
+  --ds-auro-dropdown-trigger-hover-background-color: var(--ds-basic-color-surface-default, #{v.$ds-basic-color-surface-default});
   --ds-auro-dropdown-trigger-container-color: var(--ds-basic-color-surface-default, #{v.$ds-basic-color-surface-default});
   --ds-auro-dropdown-trigger-border-color: var(--ds-basic-color-border-bold, #{v.$ds-basic-color-border-bold});
   --ds-auro-dropdown-trigger-outline-color: transparent;
@@ -18,6 +19,7 @@
 :host([ondark]) {
   --ds-auro-dropdown-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});
   --ds-auro-dropdown-trigger-background-color: var(--ds-advanced-color-shared-background-inverse, #{v.$ds-advanced-color-shared-background-inverse});
+  --ds-auro-dropdown-trigger-hover-background-color: var(--ds-advanced-color-shared-background-inverse, #{v.$ds-advanced-color-shared-background-inverse});
   --ds-auro-dropdown-trigger-container-color: var(--ds-advanced-color-shared-background-inverse, #{v.$ds-advanced-color-shared-background-inverse});
   --ds-auro-dropdown-trigger-border-color: var(--ds-basic-color-border-inverse, #{v.$ds-basic-color-border-inverse});
   --ds-auro-dropdown-trigger-outline-color: transparent;

--- a/components/input/src/styles/emphasized/color.scss
+++ b/components/input/src/styles/emphasized/color.scss
@@ -4,21 +4,9 @@
 
 /* stylelint-disable scss/dollar-variable-pattern, selector-class-pattern, selector-max-class */
 
-// Support for fallback values
-@use '@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska' as v;
-
-@mixin emphasized-active-label {
-  --ds-auro-input-label-text-color: var(--ds-basic-color-texticon-inverse-muted, #{v.$ds-basic-color-texticon-inverse-muted});;
-}
-
 .layout-emphasized,
 .layout-emphasized-left,
 .layout-emphasized-right {
-  &:focus-within,
-  &.withValue {
-    @include emphasized-active-label;
-  }
-
   &:focus-within {
     --auro-input-border-color: var(--ds-auro-input-border-color);
   }

--- a/components/layoutElement/src/auroElement.js
+++ b/components/layoutElement/src/auroElement.js
@@ -36,6 +36,7 @@ export class AuroElement extends LitElement {
 
   /**
    * Returns true if the element has focus.
+   * @private
    * @returns {boolean} - Returns true if the element has focus.
    */
   get componentHasFocus() {

--- a/components/menu/src/iconVersion.js
+++ b/components/menu/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '8.1.1';
+export default '8.1.2';

--- a/components/select/apiExamples/emphasized/constantDisplayValue.html
+++ b/components/select/apiExamples/emphasized/constantDisplayValue.html
@@ -1,4 +1,4 @@
-<auro-select layout="emphasized" shape="pill" size="xl" value="flights" ondark forceDisplayValue style="display:inline-block;">
+<auro-select layout="emphasized" shape="pill" size="xl" value="flights" forceDisplayValue style="display:inline-block;">
   <span slot="label">Select Example</span>
   <auro-menu nocheckmark>
     <auro-menuoption value="flights">

--- a/components/select/docs/partials/index.md
+++ b/components/select/docs/partials/index.md
@@ -71,14 +71,14 @@ The `emphasized` layout supports the following shapes:
 The `emphasized` layout supports the following sizes:
 - `xl`
 
-<div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/emphasized/basic-ondark.html) -->
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/emphasized/basic.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/emphasized/basic-ondark.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/emphasized/basic.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/components/select/docs/partials/index.md
+++ b/components/select/docs/partials/index.md
@@ -110,7 +110,7 @@ The custom display value content is inserted using `slot="displayValue"` on each
 The following example demonstrates menu options with an icon and text. When selected, the auro-select renders an icon with no text.
 
 
-<div class="exampleWrapper--ondark">
+<div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/emphasized/constantDisplayValue.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -37,6 +37,7 @@ import { AuroHelpText } from '@aurodesignsystem/auro-helptext';
 import helpTextVersion from './helptextVersion.js';
 
 import styleCss from "./styles/style-css.js";
+import emphasizedColorCss from "./styles/emphasized/color-css.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
@@ -434,6 +435,7 @@ export class AuroSelect extends AuroElement {
       css`${shapeSizeCss}`,
       css`${tokensCss}`,
       css`${styleCss}`,
+      css`${emphasizedColorCss}`
     ];
   }
 

--- a/components/select/src/styles/emphasized/color.scss
+++ b/components/select/src/styles/emphasized/color.scss
@@ -1,0 +1,17 @@
+// See LICENSE in the project root for license information.
+
+// ---------------------------------------------------------------------
+
+/* stylelint-disable scss/dollar-variable-pattern, selector-class-pattern, selector-max-class */
+
+@use "@aurodesignsystem/design-tokens/dist/themes/alaska/SCSSVariables--alaska" as v;
+
+:host([layout="emphasized"]) {
+  [auro-dropdown] {
+    --ds-auro-dropdown-trigger-background-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
+
+    &:hover {
+      --ds-auro-dropdown-trigger-hover-background-color: var(--ds-advanced-color-dropdown-emphasized-background-hover, #{v.$ds-advanced-color-dropdown-emphasized-background-hover});
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       },
       "devDependencies": {
         "@aurodesignsystem/auro-library": "^5.3.2",
-        "@aurodesignsystem/design-tokens": "^8.3.0",
+        "@aurodesignsystem/design-tokens": "^8.4.0",
         "@aurodesignsystem/eslint-config": "^1.3.5",
-        "@aurodesignsystem/webcorestylesheets": "^10.0.2",
+        "@aurodesignsystem/webcorestylesheets": "^10.0.3",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@open-wc/testing": "^4.0.0",
@@ -2015,9 +2015,9 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.3.0.tgz",
-      "integrity": "sha512-O93Z2kQOyAJqkG1HK/ZiUfPMjeJ9AEdIZJsUzOZ/8gVTbmZVWrTJ90HIVWKLBsJ8OA9cePxKxBVtz7sV7DAjGQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.0.tgz",
+      "integrity": "sha512-3jXgv11RFiUlU6DRBCUUUTKKSwtVPGpcvaWfZauLzNg8Hs6fdLq5BmPIsUkVm54hIGTjxtj2/R9Y+6XJSh9l8w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2116,14 +2116,14 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.2.tgz",
-      "integrity": "sha512-dcr3TRLMTSCM4JwNFoRWynDBDkdnuOJOwHrxTiq8hwW+tSM8Fguvdx9ni3gEIYT7cRJ+cQ+lnzrvX1LxLO3O3w==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.3.tgz",
+      "integrity": "sha512-t9xVhJgh0tX/Yriyn/9kwIHmDNSYYNv2rHVHfJup+JbKpRHHk6uIB4ka7SRqpvYduTGjsi1XA43Qh0+MWaXGeA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.2.2",
+        "@aurodesignsystem/design-tokens": "8.3.2",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -2134,24 +2134,24 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.2.2.tgz",
-      "integrity": "sha512-qft1euYj7ePbQNzNB2uLICFMIYpku3gwsT9p90VOfsHijgPESTVtwx9txUY17skRqlkiI4y+tCkX4nYHqo71Xg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.3.2.tgz",
+      "integrity": "sha512-aOLFKw5IRNrQlniUyGrHKtlKJdGygTHBL758UbaDJBf7i1rYoamE5WYac/IHzOvOhtZrntCWrKs/mIIfooYUmw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",
-        "postcss": "^8.5.3"
+        "postcss": "^8.5.6"
       },
       "engines": {
         "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
+      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "@rollup/rollup-linux-x64-gnu": "*"
   },
   "devDependencies": {
-    "@aurodesignsystem/design-tokens": "^8.3.0",
+    "@aurodesignsystem/design-tokens": "^8.4.0",
     "@aurodesignsystem/eslint-config": "^1.3.5",
     "@aurodesignsystem/auro-library": "^5.3.2",
-    "@aurodesignsystem/webcorestylesheets": "^10.0.2",
+    "@aurodesignsystem/webcorestylesheets": "^10.0.3",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@open-wc/testing": "^4.0.0",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Temporary solution to fix the background color for combobox and select using emphasized layout.
Adds hover color as well.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix emphasized layout background colors for combobox and select by introducing new custom properties and hover states, update dropdown trigger hover background, bump design tokens and component versions, and streamline documentation examples.

New Features:
- Add emphasized layout background and hover custom properties for combobox and select inputs
- Add hover background support for dropdown triggers via new CSS variables

Enhancements:
- Introduce separate SCSS file for select emphasized colors and include it in the AuroSelect component
- Upgrade design-tokens and webcorestylesheets dependencies and bump iconVersion numbers for bibtemplate, counter, and menu

Documentation:
- Remove ondark-specific example wrappers and update generated content references in select and combobox documentation