### PR TITLE
fix: make loading attr to show loading slots in combobox bib

### DIFF
--- a/components/combobox/apiExamples/loading.js
+++ b/components/combobox/apiExamples/loading.js
@@ -29,8 +29,8 @@ export function auroMenuLoadingExample() {
 
   }
 
-  combobox.addEventListener("input", (e) => {
-    if (e.target.value && e.target.value !== e.target.optionSelected?.textContent) {
+  combobox.addEventListener("inputValue", (e) => {
+    if (e.target.inputValue && e.target.value !== e.target.inputValue) {
       load();
     }
   });

--- a/components/menu/src/styles/default/style-menu.scss
+++ b/components/menu/src/styles/default/style-menu.scss
@@ -52,6 +52,7 @@
     slot[name="loadingIcon"] {
       vertical-align: middle;
       display: inline-block;
+      margin-bottom: var(--ds-size-25, vac.$ds-size-25);
 
       &::slotted(*) {
         margin-right: var(--ds-size-150, vac.$ds-size-150);


### PR DESCRIPTION
# Alaska Airlines Pull Request

### Problem
combobox was not showing bib while menu has `loading` attr.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Refine AuroCombobox initialization and behavior, add methods for programmatic value and option management, align documentation and examples, and update form tests to use change events.

New Features:
- Add inputValue setter to programmatically update the combobox input
- Introduce updateActiveOption method in AuroCombobox and AuroMenu to change the active option by index

Enhancements:
- Reorder and group combobox default property initializations for clearer semantics
- Synchronize combobox value, input, and menu state on initialization and updates
- Improve dynamicMenu example to correctly fetch and render initial data
- Remove debug console statements from combobox logic

Documentation:
- Document dvInputOnly attribute and updateActiveOption method in combobox and menu API docs
- Add displayValue slot to snowflake input example

Tests:
- Adjust auro-form-interactions test to set combobox value asynchronously and wait for change event before asserting