### PR TITLE
fix: remove hover state background on emphasized combobox and select

### DIFF
--- a/components/combobox/src/styles/emphasized/style.scss
+++ b/components/combobox/src/styles/emphasized/style.scss
@@ -9,11 +9,6 @@
 
     width: 100%;
 
-    &:hover {
-      --ds-auro-input-background-color: var(--ds-advanced-color-dropdown-emphasized-background-hover, #{v.$ds-advanced-color-dropdown-emphasized-background-hover});
-      --ds-auro-input-container-color: var(--ds-advanced-color-dropdown-emphasized-background-hover, #{v.$ds-advanced-color-dropdown-emphasized-background-hover});
-    }
-
     &::part(inputHelpText) {
       display: none;
     }

--- a/components/select/src/styles/emphasized/color.scss
+++ b/components/select/src/styles/emphasized/color.scss
@@ -11,7 +11,7 @@
     --ds-auro-dropdown-trigger-background-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
 
     &:hover {
-      --ds-auro-dropdown-trigger-hover-background-color: var(--ds-advanced-color-dropdown-emphasized-background-hover, #{v.$ds-advanced-color-dropdown-emphasized-background-hover});
+      --ds-auro-dropdown-trigger-hover-background-color:  var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
     }
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

hover state will have the same bg color on emphasized combobox and select

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Unify hover backgrounds for emphasized combobox and select by removing the special hover-state background and using the default emphasized background color.

Bug Fixes:
- Remove hover state background override for emphasized combobox
- Update emphasized select hover background to use default emphasized background