### PR TITLE
fix: fixed position the bib when open and isBibFullscreen

### DIFF
--- a/components/bibtemplate/src/buttonVersion.js
+++ b/components/bibtemplate/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.3.0';
+export default '11.3.2';

--- a/components/bibtemplate/src/buttonVersion.js
+++ b/components/bibtemplate/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.3.2';
+export default '11.3.0';

--- a/components/dropdown/src/styles/style.scss
+++ b/components/dropdown/src/styles/style.scss
@@ -11,6 +11,12 @@
   z-index: var(--depth-tooltip, #{vac.$ds-depth-tooltip});
 }
 
+:host([open][isbibfullscreen]) {
+  position: fixed;
+  top: 0;
+  left: 0;
+}
+
 .wrapper {
   display: flex;
   flex: 1;

--- a/components/menu/src/styles/default/style-menuoption.scss
+++ b/components/menu/src/styles/default/style-menuoption.scss
@@ -14,6 +14,8 @@
 :host {
   cursor: pointer;
   user-select: none;
+  text-overflow: ellipsis;
+  max-width: 100dvw;
 
   .wrapper {
     display: flex;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Apply fixed positioning to the dropdown in fullscreen mode and synchronize the bibtemplate version export

Bug Fixes:
- Fix dropdown component to use fixed positioning at top-left when open in fullscreen mode

Enhancements:
- Update bibtemplate buttonVersion export to 11.3.0