### PR TITLE
fix: set default menu size and shape for select/combobox correctly

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -733,13 +733,21 @@ export class AuroCombobox extends AuroElement {
       this.menu.setAttribute('size', 'md');
       this.menu.setAttribute('shape', 'box');
     } else {
-      // set menu's default size if there it's not specified.
-      if (!this.menu.getAttribute('size')) {
-        this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
-      }
+      this.menu.setAttribute('size', this.layout === 'emphasized' ? 'lg' : 'md');
 
-      if (!this.getAttribute('shape')) {
-        this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
+      switch (this.layout) {
+        case 'classic':
+          this.menu.setAttribute('shape', 'box');
+          break;
+        case 'emphasized':
+          if (this.dropdown && this.dropdown.bib) {
+            this.dropdown.bib.shape = 'rounded';
+          }
+          this.menu.setAttribute('shape', 'rounded');
+          break;
+        default:
+          this.menu.setAttribute('shape', this.defaultMenuShape || this.shape);
+          break;
       }
     }
   }
@@ -751,6 +759,7 @@ export class AuroCombobox extends AuroElement {
    */
   configureMenu() {
     this.menu = this.querySelector('auro-menu, [auro-menu]');
+    this.defaultMenuShape = this.menu.getAttribute('shape');
 
     this.menu.value = this.value;
 
@@ -1120,11 +1129,21 @@ export class AuroCombobox extends AuroElement {
     }
 
     if (changedProperties.has('shape') && this.menu) {
-      this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
+      switch (this.layout) {
+        case 'classic':
+          this.menu.setAttribute('shape', 'box');
+          break;
+        case 'emphasized':
+          this.menu.setAttribute('shape', 'rounded');
+          break;
+        default:
+          this.menu.setAttribute('shape', this.defaultMenuShape || this.shape);
+          break;
+      }
     }
 
     if (changedProperties.has('size') && this.menu) {
-      this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
+      this.menu.setAttribute('size', this.layout === 'emphasized' ? 'lg' : 'md');
     }
   }
 

--- a/components/dropdown/src/styles/classic/bibStyles.scss
+++ b/components/dropdown/src/styles/classic/bibStyles.scss
@@ -50,6 +50,7 @@
 :host([common]:not([isfullscreen])),
 :host([rounded]:not([isfullscreen])) {
   .container {
+    // classic
     border-radius: var(--ds-border-radius, #{vac.$ds-border-radius});
   }
 }
@@ -72,6 +73,11 @@
     &[class*="shape-pill"],
     &[class*="shape-snowflake"] {
       border-radius: 30px;
+    }
+
+    // emphasized
+    &[class*="shape-rounded"] {
+      border-radius: 16px;
     }
   }
 }

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -622,12 +622,21 @@ export class AuroSelect extends AuroElement {
       this.menu.setAttribute('shape', 'box');
     } else {
       // set menu's default size if there it's not specified.
-      if (!this.menu.getAttribute('size')) {
-        this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
-      }
+      this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.defaultMenuSize || this.size);
 
-      if (!this.getAttribute('shape')) {
-        this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
+      switch (this.layout) {
+        case 'classic':
+          this.menu.setAttribute('shape', 'box');
+          break;
+        case 'emphasized':
+          if (this.dropdown && this.dropdown.bib) {
+            this.dropdown.bib.shape = 'rounded';
+          }
+          this.menu.setAttribute('shape', 'rounded');
+          break;
+        default:
+          this.menu.setAttribute('shape', this.defaultMenuShape || this.shape);
+          break;
       }
     }
   }
@@ -639,6 +648,8 @@ export class AuroSelect extends AuroElement {
    */
   configureMenu() {
     this.menu = this.querySelector('auro-menu, [auro-menu]');
+    this.defaultMenuSize = this.menu.getAttribute('size');
+    this.defaultMenuShape = this.menu.getAttribute('shape');
 
     // racing condition on custom-select with custom-menu
     if (!this.menu) {
@@ -1016,11 +1027,21 @@ export class AuroSelect extends AuroElement {
     }
 
     if (changedProperties.has('shape') && this.menu) {
-      this.menu.setAttribute('shape', this.layout === 'classic' ? 'box' : this.shape);
+      switch (this.layout) {
+        case 'classic':
+          this.menu.setAttribute('shape', 'box');
+          break;
+        case 'emphasized':
+          this.menu.setAttribute('shape', 'rounded');
+          break;
+        default:
+          this.menu.setAttribute('shape', this.defaultMenuShape || this.shape);
+          break;
+      }
     }
 
     if (changedProperties.has('size') && this.menu) {
-      this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.size);
+      this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.defaultMenuSize || this.size);
     }
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

1. update select/combobox to set default menu shape/size properly
<img width="467" height="408" alt="image" src="https://github.com/user-attachments/assets/b5d10977-2c7d-4b37-92d6-30f432cedeb3" />


2. emphasized combobox will always have medium rounded menu and rounded bib regardless combobox's shape
<img width="619" height="214" alt="image" src="https://github.com/user-attachments/assets/762f424c-4464-48e6-a033-a148cc06de66" />


https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1340172

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix default menu size and shape behavior for select and combobox components in the snowflake layout

Bug Fixes:
- Adjust default menu size logic to apply 'md' only for classic layout and respect custom sizes for other layouts
- Update default menu shape logic to apply pill shape for snowflake layout
- Add SCSS rules to apply appropriate border-radius for pill and snowflake shapes