### PR TITLE
fix: menu to notify `auroMenu-selectedOption` event when only selectedItems's value is changed

### DIFF
--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -248,11 +248,17 @@ export class AuroMenu extends AuroElement {
     }
   }
 
+  // eslint-disable-next-line complexity
   updated(changedProperties) {
     super.updated(changedProperties);
 
     if (changedProperties.has('optionSelected')) {
-      this.notifySelectionChange();
+      const old = changedProperties.get('optionSelected');
+      if ((old && this.optionSelected && old.value !== this.optionSelected.value) ||
+        (!old && this.optionSelected) ||
+        (old && !this.optionSelected)) {
+        this.notifySelectionChange();
+      }
     }
 
     if (changedProperties.has('multiSelect') && !changedProperties.has("value")) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

### Problem flow
- user typing on dynamic combobox
- menuoptions get regenerated
- slotchange event gets fired
- menu to reset`optionSelected`
- `auroMenu-selectedOption` event gets fired
- combobox to close bib when a selected is made

### Solution
menu to compare the value of `optionsSelected` and fire the event when the value of `optionSelected` is changed.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Modify the AuroMenu updated() hook to only emit the auroMenu-selectedOption event when the selected option's value actually changes.

Bug Fixes:
- Only fire the auroMenu-selectedOption event when the new optionSelected value differs from the old one

Enhancements:
- Add value comparison logic in updated() to suppress redundant selection-change notifications