### PR TITLE
fix: combo box will now validate correctly when `persistValue` is set and a menu option is selected

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -741,6 +741,7 @@ export class AuroCombobox extends AuroElement {
       // current focus is on a menuoption, after clicking on it.
       if (this.persistInput && focusedEl && (focusedEl.tagName.toLowerCase() === 'auro-menuoption' || focusedEl.hasAttribute('auro-menuoption'))) {
         this.setClearBtnFocus();
+        this.validate(true);
       }
     }
   }

--- a/packages/form-validation/src/validation.js
+++ b/packages/form-validation/src/validation.js
@@ -297,12 +297,23 @@ export default class AuroFormValidation {
     }
 
     if (this.auroInputElements?.length > 0 && elem.validity !== "valueMissing") {
-      elem.validity = this.auroInputElements[0].validity;
-      elem.errorMessage = this.auroInputElements[0].errorMessage;
+
+      const isCombobox = this.runtimeUtils.elementMatch(elem, 'auro-combobox');
+
+      // Don't reset combobox validity if persistValue is set since we can't use the input value to validate
+      if (!isCombobox || isCombobox && !elem.persistValue) {
+
+        // run validation on all inputs since we're going to use them to set the validity of this component
+        this.auroInputElements.forEach(input => input.validate());
+
+        // Reset element validity to the validity of the input
+        elem.validity = this.auroInputElements[0].validity;
+        elem.errorMessage = this.auroInputElements[0].errorMessage;
+      }
 
       // multiple input in one components (datepicker)
       // combobox has 2 inputs but no need to check validity on the 2nd one which is in fullscreen bib. 
-      if (elem.validity === 'valid' && this.auroInputElements.length > 1 && !this.runtimeUtils.elementMatch(elem, 'auro-combobox')) {
+      if (elem.validity === 'valid' && this.auroInputElements.length > 1 && !isCombobox) {
         elem.validity = this.auroInputElements[1].validity;
         elem.errorMessage = this.auroInputElements[1].errorMessage;
       }


### PR DESCRIPTION
# Alaska Airlines Pull Request

## fix: combo box will now validate correctly when `persistValue` is set and a menu option is selected

- Update `validation.js` to check for combobox with `persistValue`
- Skip basing the validity on the input validity since the values/validities are not synced for this option
- Update `validation.js` to validate auro inputs before using their validity for the current element
- Update combo box to validate when shifting focus to the clear button to prevent awkward UX on snowflake layout

### Testing Steps:
1. Go to dynamic example on API page for combo box
2. Clear the combobox value
3. Type any value in the combobox but do not select a menu item
4. Blur the combobox input
  4a. The combobox enters the error state
5. Re-focus the combobox input and type a value that shows menu options
6. Select a menu option
  6a. The combobox should enter a valid state without the need to be blurred

#### Other Checks:

It couldn't hurt to recursively test validation on some of the other components (especially date picker) since this change touched validation for all components, especially for these lines of code now being in the check for combo box and persistValue, as well as the addition of the line to validate associated inputs:

```javascript
if (!isCombobox || isCombobox && !elem.persistValue) {

  // run validation on all inputs since we're going to use them to set the validity of this component
  this.auroInputElements.forEach(input => input.validate());

  // Reset element validity to the validity of the input
  elem.validity = this.auroInputElements[0].validity;
  elem.errorMessage = this.auroInputElements[0].errorMessage;
}
```

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix combobox validation behavior when persistValue is enabled by adjusting form validation logic and triggering immediate validation upon clear button focus

Bug Fixes:
- Skip resetting combobox validity based on input validity when persistValue is enabled
- Validate underlying auro input elements before determining component validity for non-persistValue components
- Trigger combobox validation when shifting focus to the clear button after selecting a menu option to avoid stale error state

Enhancements:
- Introduce an isCombobox check in validation.js to streamline conditional logic