### PR TITLE
feat: add `shift` property to dropdown components to adjust position based on viewport

### DIFF
--- a/components/bibtemplate/src/buttonVersion.js
+++ b/components/bibtemplate/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.3.2';
+export default '11.3.4';

--- a/components/combobox/apiExamples/floaterConfig.html
+++ b/components/combobox/apiExamples/floaterConfig.html
@@ -40,4 +40,18 @@
       <auro-menuoption static nomatch>No matching option</auro-menuoption>
     </auro-menu>
   </auro-combobox>
+
+  <auro-combobox width="350px" offset="20" noFlip placement="bottom-start" shift>
+    <span slot="bib.fullscreen.headline">Bib Header</span>
+    <span slot="label">Label</span>
+    <span slot="helpText">bottom-start bib with 20px offset, noFlip and shift</span>
+    <auro-menu>
+      <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+      <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+      <auro-menuoption value="Peaches" id="option-2">Peaches</auro-menuoption>
+      <auro-menuoption value="Grapes" id="option-3">Grapes</auro-menuoption>
+      <auro-menuoption value="Cherries" id="option-4">Cherries</auro-menuoption>
+      <auro-menuoption static nomatch>No matching option</auro-menuoption>
+    </auro-menu>
+  </auro-combobox>
 </div>

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -32,6 +32,7 @@
 | `setCustomValidityCustomError`  | `setCustomValidityCustomError`  |           | `string`              |                            | Custom help text message to display when validity = `customError`. |
 | `setCustomValidityValueMissing` | `setCustomValidityValueMissing` |           | `string`              |                            | Custom help text message to display when validity = `valueMissing`. |
 | `shape`                         |                                 |           | `string`              | "classic"                  |                                                  |
+| `shift`                         | `shift`                         |           | `boolean`             | "false"                    | If declared, the dropdown will shift its position to avoid being cut off by the viewport. |
 | `size`                          |                                 |           | `string`              | "xl"                       |                                                  |
 | `triggerIcon`                   | `triggerIcon`                   |           | `boolean`             | false                      | If set, the `icon` attribute will be applied to the trigger `auro-input` element. |
 | `type`                          | `type`                          |           | `string`              |                            | Applies the defined value as the type attribute on auro-input. |

--- a/components/combobox/docs/partials/api.md
+++ b/components/combobox/docs/partials/api.md
@@ -348,12 +348,13 @@ While content is loading, the menu can either remain empty or display a loading 
 </auro-accordion>
 
 ### Customized bib position
-The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement` attributes.
+The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement`, and `shift` attributes.
 
 - `placement` specifies the preferred position where the bib should appear relative to the trigger.
 - `offset` sets the distance between the trigger and the bib.
 - When `autoPlacement` is enabled, smart positioning logic is applied to determine the best placement for the bib. If all sides have sufficient space, the bib will appear in the position specified by `placement`.
 - Unless `noFlip` is enabled, if there isn't enough space for the preferred `placement`, the bib will automatically flip to an alternative position.
+- `shift` when enabled, adjusts the bib position when it would overflow the viewport boundaries, ensuring it remains visible.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/floaterConfig.html) -->

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -79,6 +79,7 @@ export class AuroCombobox extends AuroElement {
     this.placement = 'bottom-start';
     this.offset = 0;
     this.noFlip = false;
+    this.shift = false;
     this.autoPlacement = false;
 
     this.privateDefaults();
@@ -233,6 +234,15 @@ export class AuroCombobox extends AuroElement {
        * @default false
        */
       noFlip: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * If declared, the dropdown will shift its position to avoid being cut off by the viewport.
+       * @default false
+       */
+      shift: {
         type: Boolean,
         reflect: true
       },
@@ -1272,6 +1282,7 @@ export class AuroCombobox extends AuroElement {
           ?disabled="${this.disabled}"
           ?error="${this.validity !== undefined && this.validity !== 'valid'}"
           ?noFlip="${this.noFlip}"
+          ?shift="${this.shift}"
           ?onDark="${this.onDark}"
           disableEventShow
           fluid

--- a/components/counter/apiExamples/floaterConfig.html
+++ b/components/counter/apiExamples/floaterConfig.html
@@ -38,4 +38,17 @@
       <span slot="description">2-17 years</span>
     </auro-counter>
   </auro-counter-group>
+  <auro-counter-group width="350px" isDropdown offset="20" placement="bottom-start" shift noFlip>
+    <div slot="bib.fullscreen.headline">Passengers</div>
+    <span slot="label">Label</span>
+    <span slot="helpText">bottom-start with 20px offset, noFlip and shift enabled</span>
+    <auro-counter>
+      Adults
+      <span slot="description">18 years or older</span>
+    </auro-counter>
+    <auro-counter>
+      Children
+      <span slot="description">2-17 years</span>
+    </auro-counter>
+  </auro-counter-group>
 </div>

--- a/components/counter/docs/api.md
+++ b/components/counter/docs/api.md
@@ -53,6 +53,7 @@
 | `offset`                  | `offset`                  | `number`                 | "0"            | Gap between the trigger element and bib.         |
 | `onDark`                  | `onDark`                  | `boolean`                | false          | If declared, counters and dropdown will be rendered with onDark styles. |
 | `placement`               | `placement`               | `string`                 | "bottom-start" | Position where the bib should appear relative to the trigger.<br />Accepted values:<br />"top" \| "right" \| "bottom" \| "left" \|<br />"bottom-start" \| "top-start" \| "top-end" \|<br />"right-start" \| "right-end" \| "bottom-end" \|<br />"left-start" \| "left-end". |
+| `shift`                   | `shift`                   | `boolean`                | "false"        | If declared, the dropdown will shift its position to avoid being cut off by the viewport. |
 | `total`                   | `total`                   | `number`                 | "undefined"    | The total value of the counters.                 |
 | `validity`                | `validity`                | `string`                 | "undefined"    | Reflects the validity state.                     |
 | `value`                   | `value`                   | `object`                 | "undefined"    | The current individual values of the nested counters. |

--- a/components/counter/docs/partials/api.md
+++ b/components/counter/docs/partials/api.md
@@ -210,12 +210,13 @@ You can also individually set the max or min value for each counter in a group.
 </auro-accordion>
 
 ### Customized bib position
-The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement` attributes.
+The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement`, and `shift` attributes.
 
 - `placement` specifies the preferred position where the bib should appear relative to the trigger.
 - `offset` sets the distance between the trigger and the bib.
 - When `autoPlacement` is enabled, smart positioning logic is applied to determine the best placement for the bib. If all sides have sufficient space, the bib will appear in the position specified by `placement`.
 - Unless `noFlip` is enabled, if there isn't enough space for the preferred `placement`, the bib will automatically flip to an alternative position.
+- `shift` when enabled, adjusts the bib position when it would overflow the viewport boundaries, ensuring it remains visible.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/floaterConfig.html) -->

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -78,6 +78,7 @@ export class AuroCounterGroup extends AuroElement {
     this.largeFullscreenHeadline = false;
     this.autoPlacement = false;
     this.noFlip = false;
+    this.shift = false;
 
     this.placement = 'bottom-start';
 
@@ -241,6 +242,15 @@ export class AuroCounterGroup extends AuroElement {
        * @default false
        */
       noFlip: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * If declared, the dropdown will shift its position to avoid being cut off by the viewport.
+       * @default false
+       */
+      shift: {
         type: Boolean,
         reflect: true
       },
@@ -685,6 +695,7 @@ export class AuroCounterGroup extends AuroElement {
         ?error="${this.validity !== undefined && this.validity !== 'valid'}"
         ?matchWidth="${this.matchWidth}"
         ?noFlip="${this.noFlip}"
+        ?shift="${this.shift}"
         ?onDark="${this.onDark}"
         .fullscreenBreakpoint="${this.fullscreenBreakpoint}"
         .offset="${this.offset}"

--- a/components/datepicker/apiExamples/floaterConfig.html
+++ b/components/datepicker/apiExamples/floaterConfig.html
@@ -15,3 +15,14 @@
     <span slot="bib.fullscreen.dateLabel">Choose a date</span>
   </auro-datepicker>
 </div>
+
+<div style="width: 600px; padding-top: 1em;">
+  <p>Range bottom-start with 20px offset, noFlip and shift enabled</p>
+  <auro-datepicker range offset="20" placement="bottom-start" shift noFlip minDate="07/08/2025">
+    <span slot="ariaLabel.bib.close">Close Calendar</span>
+    <span slot="bib.fullscreen.headline">Datepicker Range Headline</span>
+    <span slot="fromLabel">Departure</span>
+    <span slot="toLabel">Return</span>
+    <span slot="bib.fullscreen.dateLabel">Roundtrip</span>
+  </auro-datepicker>
+</div>

--- a/components/datepicker/docs/api.md
+++ b/components/datepicker/docs/api.md
@@ -36,6 +36,7 @@
 | `setCustomValidityRangeUnderflow` | `setCustomValidityRangeUnderflow` |           | `string`   |                                                  | Custom help text message to display when validity = `rangeUnderflow`. |
 | `setCustomValidityValueMissing`   | `setCustomValidityValueMissing`   |           | `string`   |                                                  | Custom help text message to display when validity = `valueMissing`. |
 | `shape`                           |                                   |           | `string`   | "classic"                                        |                                                  |
+| `shift`                           | `shift`                           |           | `boolean`  | "false"                                          | If declared, the dropdown will shift its position to avoid being cut off by the viewport. |
 | `size`                            |                                   |           | `string`   | "lg"                                             |                                                  |
 | `stacked`                         | `stacked`                         |           | `boolean`  | false                                            | Set true to make datepicker stacked style.       |
 | `validity`                        | `validity`                        |           | `string`   | "undefined"                                      | Specifies the `validityState` this element is in. |

--- a/components/datepicker/docs/partials/api.md
+++ b/components/datepicker/docs/partials/api.md
@@ -269,12 +269,13 @@ Set stacked attribute to make range datepicker stacked style.
 </auro-accordion>
 
 ### Customized bib position
-The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement` attributes.
+The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement`, and `shift` attributes.
 
 - `placement` specifies the preferred position where the bib should appear relative to the trigger.
 - `offset` sets the distance between the trigger and the bib.
 - When `autoPlacement` is enabled, smart positioning logic is applied to determine the best placement for the bib. If all sides have sufficient space, the bib will appear in the position specified by `placement`.
 - Unless `noFlip` is enabled, if there isn't enough space for the preferred `placement`, the bib will automatically flip to an alternative position.
+- `shift` when enabled, adjusts the bib position when it would overflow the viewport boundaries, ensuring it remains visible.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/floaterConfig.html) -->

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -133,6 +133,7 @@ export class AuroDatePicker extends AuroElement {
     this.placement = 'bottom-start';
     this.offset = 0;
     this.noFlip = false;
+    this.shift = false;
     this.autoPlacement = false;
 
     this.largeFullscreenHeadline = false;
@@ -354,6 +355,15 @@ export class AuroDatePicker extends AuroElement {
        * @default false
        */
       noFlip: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * If declared, the dropdown will shift its position to avoid being cut off by the viewport.
+       * @default false
+       */
+      shift: {
         type: Boolean,
         reflect: true
       },
@@ -1671,6 +1681,7 @@ export class AuroDatePicker extends AuroElement {
           ?disabled="${this.disabled}"
           ?error="${this.validity !== undefined && this.validity !== 'valid'}"
           ?noFlip="${this.noFlip}"
+          ?shift="${this.shift}"
           .fullscreenBreakpoint="${this.fullscreenBreakpoint}"
           .layout="${this.layout}"
           .matchWidth="${false}"

--- a/components/datepicker/src/buttonVersion.js
+++ b/components/datepicker/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.3.2';
+export default '11.3.4';

--- a/components/dropdown/apiExamples/floaterConfig.html
+++ b/components/dropdown/apiExamples/floaterConfig.html
@@ -67,3 +67,25 @@
     </div>
   </auro-dropdown>
 </div>
+
+<div aria-label="custom label">
+  <auro-dropdown width="350px" class="floaterConfigDropdown" layout="classic" shape="classic" size="lg" chevron noFlip placement="bottom-start" shift offset="20">
+    <div width="500px">
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+    </div>
+    <div slot="trigger">
+      Trigger
+    </div>
+    <div slot="helpText">
+      Trigger for bottom-start bib with 20px offset, shift and noFlip
+    </div>
+  </auro-dropdown>
+</div>

--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -27,6 +27,7 @@
 | `onSlotChange`          | `onSlotChange`          |             |                | If declared, and a function is set, that function will execute when the slot content is updated. |
 | `placement`             | `placement`             | `string`    | "bottom-start" | Position where the bib should appear relative to the trigger. |
 | `shape`                 |                         |             | "undefined"    |                                                  |
+| `shift`                 | `shift`                 | `boolean`   | "false"        | If declared, the dropdown will shift its position to avoid being cut off by the viewport. |
 | `simple`                | `simple`                | `boolean`   |                | If declared, applies a border around the trigger slot. |
 | `size`                  |                         |             | "undefined"    |                                                  |
 

--- a/components/dropdown/docs/partials/api.md
+++ b/components/dropdown/docs/partials/api.md
@@ -226,12 +226,13 @@ On mobile view, adding the `fullscreenBreakpoint="{breakpoint-token}"` will swit
 </auro-accordion>
 
 ### Customized bib position
-The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement` attributes.
+The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement`, and `shift` attributes.
 
 - `placement` specifies the preferred position where the bib should appear relative to the trigger.
 - `offset` sets the distance between the trigger and the bib.
 - When `autoPlacement` is enabled, smart positioning logic is applied to determine the best placement for the bib. If all sides have sufficient space, the bib will appear in the position specified by `placement`.
 - Unless `noFlip` is enabled, if there isn't enough space for the preferred `placement`, the bib will automatically flip to an alternative position.
+- `shift` when enabled, adjusts the bib position when it would overflow the viewport boundaries, ensuring it remains visible.
 
 
 <div class="exampleWrapper">

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -126,6 +126,7 @@ export class AuroDropdown extends AuroElement {
     this.placement = 'bottom-start';
     this.offset = 0;
     this.noFlip = false;
+    this.shift = false;
     this.autoPlacement = false;
 
     /**
@@ -190,6 +191,7 @@ export class AuroDropdown extends AuroElement {
     return {
       placement: this.placement,
       flip: !this.noFlip,
+      shift: this.shift,
       autoPlacement: this.autoPlacement,
       offset: this.offset,
     };
@@ -386,6 +388,15 @@ export class AuroDropdown extends AuroElement {
        * @default false
        */
       noFlip: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * If declared, the dropdown will shift its position to avoid being cut off by the viewport.
+       * @default false
+       */
+      shift: {
         type: Boolean,
         reflect: true
       },

--- a/components/input/src/buttonVersion.js
+++ b/components/input/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.3.2';
+export default '11.3.4';

--- a/components/select/apiExamples/floaterConfig.html
+++ b/components/select/apiExamples/floaterConfig.html
@@ -38,4 +38,17 @@
       <auro-menuoption value="prefer alaska">Prefer Alaska</auro-menuoption>
     </auro-menu>
   </auro-select>
+  <auro-select width="350px" offset="20" noFlip placement="bottom-start" shift noFlip >
+    <span slot="bib.fullscreen.headline">Bib Headline</span>
+    <span slot="label">Label</span>
+    <span slot="helpText">bottom-start bib with 20px offset, noFlip and shift</span>
+    <auro-menu>
+      <auro-menuoption value="stops">Stops</auro-menuoption>
+      <auro-menuoption value="price">Price</auro-menuoption>
+      <auro-menuoption value="duration">Duration</auro-menuoption>
+      <auro-menuoption value="departure">Departure</auro-menuoption>
+      <auro-menuoption value="arrival">Arrival</auro-menuoption>
+      <auro-menuoption value="prefer alaska">Prefer Alaska</auro-menuoption>
+    </auro-menu>
+  </auro-select>
 </div>

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -30,6 +30,7 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | `setCustomValidity`             | `setCustomValidity`             | `string`                          |                | Sets a custom help text message to display for all validityStates. |
 | `setCustomValidityCustomError`  | `setCustomValidityCustomError`  | `string`                          |                | Custom help text message to display when validity = `customError`. |
 | `setCustomValidityValueMissing` | `setCustomValidityValueMissing` | `string`                          |                | Custom help text message to display when validity = `valueMissing`. |
+| `shift`                         | `shift`                         | `boolean`                         | "false"        | If set, the dropdown will shift its position to avoid being cut off by the viewport. |
 | `validity`                      | `validity`                      | `string`                          |                | Specifies the `validityState` this element is in. |
 | `value`                         | `value`                         | `string`                          |                | Value selected for the component.                |
 

--- a/components/select/docs/partials/api.md
+++ b/components/select/docs/partials/api.md
@@ -330,12 +330,13 @@ The label for selected option can be customized using `displayValue` slot under 
 
 
 ### Customized bib position
-The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement` attributes.
+The bib position can be customized with `placement`, `offset`, `flip`, `autoPlacement`, and `shift` attributes.
 
 - `placement` specifies the preferred position where the bib should appear relative to the trigger.
 - `offset` sets the distance between the trigger and the bib.
 - When `autoPlacement` is enabled, smart positioning logic is applied to determine the best placement for the bib. If all sides have sufficient space, the bib will appear in the position specified by `placement`.
 - Unless `noFlip` is enabled, if there isn't enough space for the preferred `placement`, the bib will automatically flip to an alternative position.
+- `shift` when enabled, adjusts the bib position when it would overflow the viewport boundaries, ensuring it remains visible.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/floaterConfig.html) -->

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -79,6 +79,7 @@ export class AuroSelect extends AuroElement {
     this.placement = 'bottom-start';
     this.offset = 0;
     this.noFlip = false;
+    this.shift = false;
     this.autoPlacement = false;
 
     this.forceDisplayValue = false;
@@ -262,6 +263,15 @@ export class AuroSelect extends AuroElement {
        * @default false
        */
       noFlip: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * If set, the dropdown will shift its position to avoid being cut off by the viewport.
+       * @default false
+       */
+      shift: {
         type: Boolean,
         reflect: true
       },
@@ -1225,6 +1235,7 @@ export class AuroSelect extends AuroElement {
           ?error="${this.validity !== undefined && this.validity !== 'valid'}"
           ?matchWidth="${this.matchWidth}"
           ?noFlip="${this.noFlip}"
+          ?shift="${this.shift}"
           ?onDark="${this.onDark}"
           .fullscreenBreakpoint="${this.fullscreenBreakpoint}"
           .offset="${this.offset}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@aurodesignsystem/auro-button": "^11.3.2",
-        "@aurodesignsystem/auro-library": "^5.3.2",
+        "@aurodesignsystem/auro-library": "npm:@aurodesignsystem-dev/auro-library@0.0.0-pr192.0",
         "@aurodesignsystem/design-tokens": "^8.4.0",
         "@aurodesignsystem/eslint-config": "^1.3.5",
         "@aurodesignsystem/webcorestylesheets": "^10.0.3",
@@ -835,6 +835,24 @@
         "node": "^20.x || ^22.x "
       }
     },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/@aurodesignsystem/auro-library": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.4.0.tgz",
+      "integrity": "sha512-CuivH8Kk5iOfdth/jGjLTQ95Ly/8N3htzdP9d2meIV6TRWI4Y7vBl9Ee5JTAY9cNiydHsCthbXFKX7lC6PWh3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.11",
+        "handlebars": "^4.7.8",
+        "markdown-magic": "^2.6.1"
+      },
+      "bin": {
+        "generateDocs": "bin/generateDocs.mjs"
+      },
+      "engines": {
+        "node": "^20.x || ^22.x"
+      }
+    },
     "node_modules/@aurodesignsystem/auro-button/node_modules/@aurodesignsystem/design-tokens": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.2.1.tgz",
@@ -866,6 +884,146 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/markdown-magic": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
+      "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@technote-space/doctoc": "2.4.7",
+        "commander": "^7.2.0",
+        "deepmerge": "^4.2.2",
+        "find-up": "^5.0.0",
+        "globby": "^10.0.2",
+        "is-local-path": "^0.1.6",
+        "json-alexander": "^0.1.8",
+        "mkdirp": "^1.0.4",
+        "sync-request": "^6.1.0"
+      },
+      "bin": {
+        "markdown": "cli.js",
+        "md-magic": "cli.js"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-button/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aurodesignsystem/auro-checkbox": {
@@ -909,6 +1067,23 @@
         "node": "^20.x || ^22.x "
       }
     },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/@aurodesignsystem/auro-library": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.4.0.tgz",
+      "integrity": "sha512-CuivH8Kk5iOfdth/jGjLTQ95Ly/8N3htzdP9d2meIV6TRWI4Y7vBl9Ee5JTAY9cNiydHsCthbXFKX7lC6PWh3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.11",
+        "handlebars": "^4.7.8",
+        "markdown-magic": "^2.6.1"
+      },
+      "bin": {
+        "generateDocs": "bin/generateDocs.mjs"
+      },
+      "engines": {
+        "node": "^20.x || ^22.x"
+      }
+    },
     "node_modules/@aurodesignsystem/auro-header/node_modules/@aurodesignsystem/design-tokens": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.2.1.tgz",
@@ -938,6 +1113,137 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/markdown-magic": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
+      "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@technote-space/doctoc": "2.4.7",
+        "commander": "^7.2.0",
+        "deepmerge": "^4.2.2",
+        "find-up": "^5.0.0",
+        "globby": "^10.0.2",
+        "is-local-path": "^0.1.6",
+        "json-alexander": "^0.1.8",
+        "mkdirp": "^1.0.4",
+        "sync-request": "^6.1.0"
+      },
+      "bin": {
+        "markdown": "cli.js",
+        "md-magic": "cli.js"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-header/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aurodesignsystem/auro-helptext": {
@@ -1226,9 +1532,11 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.3.3.tgz",
-      "integrity": "sha512-UPeVq+rQZ6jVg4qxIM4cuK6qOuDo7qiVTcXsNdW4S6ILuLYJVFPzVlofSurUBJfPr+TITY4ivH0BPLCg6zlxRg==",
+      "name": "@aurodesignsystem-dev/auro-library",
+      "version": "0.0.0-pr192.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem-dev/auro-library/-/auro-library-0.0.0-pr192.0.tgz",
+      "integrity": "sha512-7jcMHiwbM1HgpFuUSSo7vfwKu8Zf8NGlbgnaT6ZVdOKbInrf4jgVC+HG2KwXw7iOJzU/WS8iifA+80FiWdL3Xw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",
@@ -1246,6 +1554,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -1255,6 +1564,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -1271,6 +1581,7 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
       "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/glob": "^7.1.1",
@@ -1290,6 +1601,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -1305,6 +1617,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
       "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@technote-space/doctoc": "2.4.7",
@@ -1326,6 +1639,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -1341,6 +1655,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -1356,6 +1671,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1365,6 +1681,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "lit": "^3.3.1"
       },
       "devDependencies": {
-        "@aurodesignsystem/auro-button": "^11.3.2",
-        "@aurodesignsystem/auro-library": "npm:@aurodesignsystem-dev/auro-library@0.0.0-pr192.0",
-        "@aurodesignsystem/design-tokens": "^8.4.0",
+        "@aurodesignsystem/auro-button": "^11.3.4",
+        "@aurodesignsystem/auro-library": "^5.5.0",
+        "@aurodesignsystem/design-tokens": "^8.4.1",
         "@aurodesignsystem/eslint-config": "^1.3.5",
-        "@aurodesignsystem/webcorestylesheets": "^10.0.3",
+        "@aurodesignsystem/webcorestylesheets": "^10.0.4",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@open-wc/testing": "^4.0.0",
@@ -817,213 +817,22 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/auro-button": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-11.3.2.tgz",
-      "integrity": "sha512-pXDhQSV0c2Em+jkBdpoPwBW4RiCmiyZ+Bp0coR8omjBK/ZvgoUFx5UfbN4nBlXhyd9nX0pl0QKz00nqfjzraRg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-11.3.4.tgz",
+      "integrity": "sha512-YQ6Kv3BVPqoafnemJGPLeANTa31yykfDgnFAwqNpGdn/qMVv+GbOywgtjpcZn20KC/lSlVTbOfKDgownWhX86w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-library": "^5.3.0",
-        "@aurodesignsystem/auro-loader": "^5.1.0",
-        "@aurodesignsystem/design-tokens": "^8.2.1",
-        "@aurodesignsystem/webcorestylesheets": "10.0.0",
+        "@aurodesignsystem/auro-library": "^5.4.0",
+        "@aurodesignsystem/auro-loader": "^5.1.2",
+        "@aurodesignsystem/design-tokens": "^8.4.1",
+        "@aurodesignsystem/webcorestylesheets": "10.0.4",
         "chalk": "^5.4.1",
         "lit": "^3.3.0"
       },
       "engines": {
         "node": "^20.x || ^22.x "
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.4.0.tgz",
-      "integrity": "sha512-CuivH8Kk5iOfdth/jGjLTQ95Ly/8N3htzdP9d2meIV6TRWI4Y7vBl9Ee5JTAY9cNiydHsCthbXFKX7lC6PWh3w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.11",
-        "handlebars": "^4.7.8",
-        "markdown-magic": "^2.6.1"
-      },
-      "bin": {
-        "generateDocs": "bin/generateDocs.mjs"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.2.1.tgz",
-      "integrity": "sha512-1ynmeMj6vUfEvKYLEyf3NSlJEUe1pSrMYKjPRHWKnRAo6lklWK16IcaxeJauSkbPL4Hty4yE+IW0hZ+l/FhGrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.3"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.0.tgz",
-      "integrity": "sha512-ZDjYmWnKszCwphlEMiYwdQ5Bsi0QMkhwv3lCJ6mDF4Viu4bYHi9E9ASyWWOGywJaD9qYWo9KKeToZpDLG1+ovA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.2.1",
-        "chalk": "^5.4.1"
-      },
-      "engines": {
-        "node": "^20 || ^22"
-      },
-      "peerDependencies": {
-        "sass": "^1.42.1"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/globby": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/markdown-magic": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
-      "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@technote-space/doctoc": "2.4.7",
-        "commander": "^7.2.0",
-        "deepmerge": "^4.2.2",
-        "find-up": "^5.0.0",
-        "globby": "^10.0.2",
-        "is-local-path": "^0.1.6",
-        "json-alexander": "^0.1.8",
-        "mkdirp": "^1.0.4",
-        "sync-request": "^6.1.0"
-      },
-      "bin": {
-        "markdown": "cli.js",
-        "md-magic": "cli.js"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-button/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aurodesignsystem/auro-checkbox": {
@@ -1067,23 +876,6 @@
         "node": "^20.x || ^22.x "
       }
     },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.4.0.tgz",
-      "integrity": "sha512-CuivH8Kk5iOfdth/jGjLTQ95Ly/8N3htzdP9d2meIV6TRWI4Y7vBl9Ee5JTAY9cNiydHsCthbXFKX7lC6PWh3w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.11",
-        "handlebars": "^4.7.8",
-        "markdown-magic": "^2.6.1"
-      },
-      "bin": {
-        "generateDocs": "bin/generateDocs.mjs"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
-      }
-    },
     "node_modules/@aurodesignsystem/auro-header/node_modules/@aurodesignsystem/design-tokens": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.2.1.tgz",
@@ -1113,137 +905,6 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/globby": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/markdown-magic": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
-      "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@technote-space/doctoc": "2.4.7",
-        "commander": "^7.2.0",
-        "deepmerge": "^4.2.2",
-        "find-up": "^5.0.0",
-        "globby": "^10.0.2",
-        "is-local-path": "^0.1.6",
-        "json-alexander": "^0.1.8",
-        "mkdirp": "^1.0.4",
-        "sync-request": "^6.1.0"
-      },
-      "bin": {
-        "markdown": "cli.js",
-        "md-magic": "cli.js"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-header/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aurodesignsystem/auro-helptext": {
@@ -1532,11 +1193,9 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "name": "@aurodesignsystem-dev/auro-library",
-      "version": "0.0.0-pr192.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem-dev/auro-library/-/auro-library-0.0.0-pr192.0.tgz",
-      "integrity": "sha512-7jcMHiwbM1HgpFuUSSo7vfwKu8Zf8NGlbgnaT6ZVdOKbInrf4jgVC+HG2KwXw7iOJzU/WS8iifA+80FiWdL3Xw==",
-      "dev": true,
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.5.0.tgz",
+      "integrity": "sha512-viNxcf3Oz8LvneM/6ZL0obUgduQVXpKC8oV5OOVFCQeXxY+2UuhZhBBBr7UF28h1wpPuuEMw2U/kP349s6k4OA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",
@@ -1554,7 +1213,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -1564,7 +1222,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -1581,7 +1238,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
       "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/glob": "^7.1.1",
@@ -1601,7 +1257,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -1617,7 +1272,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
       "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@technote-space/doctoc": "2.4.7",
@@ -1639,7 +1293,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -1655,7 +1308,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -1671,7 +1323,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1681,7 +1332,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1691,16 +1341,16 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-loader/-/auro-loader-5.1.0.tgz",
-      "integrity": "sha512-5I6lKMmWOw9QuboxAMuh5e9shCBGhmPtMdR9xBqwVYbHIjq4bNAtgmRv/8kXgiRiWaRkZHhluVT1rnQPUapqMg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-loader/-/auro-loader-5.1.2.tgz",
+      "integrity": "sha512-7LsE7xZhJVgMJ/aqqr+f1DDjLfNL4NXdgtV7YwMovV+/XnGMr2heONu2PBuxqDXXKM/wvbQ9QHaPzVl3QDw3bg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-library": "^4.1.0",
-        "@aurodesignsystem/design-tokens": "^8.2.1",
-        "@aurodesignsystem/webcorestylesheets": "10.0.0",
+        "@aurodesignsystem/auro-library": "^5.4.0",
+        "@aurodesignsystem/design-tokens": "^8.4.0",
+        "@aurodesignsystem/webcorestylesheets": "10.0.3",
         "chalk": "^5.3.0",
         "lit": "^3.2.1"
       },
@@ -1708,49 +1358,15 @@
         "node": "^20.x || ^22.x "
       }
     },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/@aurodesignsystem/auro-library": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-4.5.0.tgz",
-      "integrity": "sha512-yy1pKRQjYQ808e2hh87BxWwbV/Vweb9IpISm2SnqJ3K0mUKHZ7Zn1BFPWO8hc0Zf5RvHPDa0FqzeXaySytkWaA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.11",
-        "handlebars": "^4.7.8",
-        "markdown-magic": "^2.6.1",
-        "npm-run-all": "^4.1.5"
-      },
-      "bin": {
-        "generateDocs": "bin/generateDocs.mjs"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.2.1.tgz",
-      "integrity": "sha512-1ynmeMj6vUfEvKYLEyf3NSlJEUe1pSrMYKjPRHWKnRAo6lklWK16IcaxeJauSkbPL4Hty4yE+IW0hZ+l/FhGrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.3"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
-      }
-    },
     "node_modules/@aurodesignsystem/auro-loader/node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.0.tgz",
-      "integrity": "sha512-ZDjYmWnKszCwphlEMiYwdQ5Bsi0QMkhwv3lCJ6mDF4Viu4bYHi9E9ASyWWOGywJaD9qYWo9KKeToZpDLG1+ovA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.3.tgz",
+      "integrity": "sha512-t9xVhJgh0tX/Yriyn/9kwIHmDNSYYNv2rHVHfJup+JbKpRHHk6uIB4ka7SRqpvYduTGjsi1XA43Qh0+MWaXGeA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.2.1",
+        "@aurodesignsystem/design-tokens": "8.3.2",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -1760,144 +1376,19 @@
         "sass": "^1.42.1"
       }
     },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+    "node_modules/@aurodesignsystem/auro-loader/node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.3.2.tgz",
+      "integrity": "sha512-aOLFKw5IRNrQlniUyGrHKtlKJdGygTHBL758UbaDJBf7i1rYoamE5WYac/IHzOvOhtZrntCWrKs/mIIfooYUmw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
+        "chalk": "^5.4.1",
+        "postcss": "^8.5.6"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/globby": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/markdown-magic": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-2.6.1.tgz",
-      "integrity": "sha512-i+wPC9bAGzFVftF1P5ItooOCvX+TTD3v504WpupsJz+3B0wRZMuPxeFAE7uZXEZYjsiQYskoMgpypoJTWerpVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@technote-space/doctoc": "2.4.7",
-        "commander": "^7.2.0",
-        "deepmerge": "^4.2.2",
-        "find-up": "^5.0.0",
-        "globby": "^10.0.2",
-        "is-local-path": "^0.1.6",
-        "json-alexander": "^0.1.8",
-        "mkdirp": "^1.0.4",
-        "sync-request": "^6.1.0"
-      },
-      "bin": {
-        "markdown": "cli.js",
-        "md-magic": "cli.js"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aurodesignsystem/auro-loader/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@aurodesignsystem/auro-menu": {
@@ -2111,9 +1602,9 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.0.tgz",
-      "integrity": "sha512-3jXgv11RFiUlU6DRBCUUUTKKSwtVPGpcvaWfZauLzNg8Hs6fdLq5BmPIsUkVm54hIGTjxtj2/R9Y+6XJSh9l8w==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.1.tgz",
+      "integrity": "sha512-eL3WJAroHWrkoRi/5h53auyFzNiS57mxfdjML8C6nf8wV+KtJvwiNU0oaGsLHPAzicLPxuptkEM04oTo+V8LQw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2265,14 +1756,14 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.3.tgz",
-      "integrity": "sha512-t9xVhJgh0tX/Yriyn/9kwIHmDNSYYNv2rHVHfJup+JbKpRHHk6uIB4ka7SRqpvYduTGjsi1XA43Qh0+MWaXGeA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.4.tgz",
+      "integrity": "sha512-hUAsrXCiUpOfwkMZ2gI+oKY9oQRNQfeC1Edbf7OBqfhAPaXLbZ3kEivoEYqyI9XOC7Bf0dOdObHXIXAdrOynXQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.3.2",
+        "@aurodesignsystem/design-tokens": "8.4.1",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -2280,21 +1771,6 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
-      }
-    },
-    "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.3.2.tgz",
-      "integrity": "sha512-aOLFKw5IRNrQlniUyGrHKtlKJdGygTHBL758UbaDJBf7i1rYoamE5WYac/IHzOvOhtZrntCWrKs/mIIfooYUmw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.6"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   },
   "devDependencies": {
     "@aurodesignsystem/auro-button": "^11.3.2",
+    "@aurodesignsystem/auro-library": "npm:@aurodesignsystem-dev/auro-library@0.0.0-pr192.0",
     "@aurodesignsystem/design-tokens": "^8.4.0",
     "@aurodesignsystem/eslint-config": "^1.3.5",
-    "@aurodesignsystem/auro-library": "^5.3.2",
     "@aurodesignsystem/webcorestylesheets": "^10.0.3",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "@rollup/rollup-linux-x64-gnu": "*"
   },
   "devDependencies": {
-    "@aurodesignsystem/auro-button": "^11.3.2",
-    "@aurodesignsystem/auro-library": "npm:@aurodesignsystem-dev/auro-library@0.0.0-pr192.0",
-    "@aurodesignsystem/design-tokens": "^8.4.0",
+    "@aurodesignsystem/auro-button": "^11.3.4",
+    "@aurodesignsystem/auro-library": "^5.5.0",
+    "@aurodesignsystem/design-tokens": "^8.4.1",
     "@aurodesignsystem/eslint-config": "^1.3.5",
-    "@aurodesignsystem/webcorestylesheets": "^10.0.3",
+    "@aurodesignsystem/webcorestylesheets": "^10.0.4",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@open-wc/testing": "^4.0.0",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Enable the feature that can shift the floating element to keep it in view when it is in danger of getting cut off by the viewport. This PR adds the feature to dropdown and enables the props in the consuming components.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce a new `shift` property across dropdown-based components to enable floating elements to adjust their position and avoid being clipped by the viewport, updating examples, documentation, and bumping related dev dependencies.

New Features:
- Add a boolean `shift` prop to auro-dropdown, auro-combobox, auro-counter-group, auro-datepicker, and auro-select components to shift floating elements when near the viewport edge.

Enhancements:
- Update API example HTML files for each component to demonstrate the new `shift` option in combination with placement, offset, and noFlip settings.

Build:
- Bump devDependencies (auro-button, auro-library, design-tokens, webcorestylesheets) and update buttonVersion files to match new versions.

Documentation:
- Document the `shift` prop in the API reference for dropdown, combobox, counter, datepicker, and select components.