### PR TITLE
fix(datepicker): clicking bib no longer breaks on safari/firefox

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -806,7 +806,6 @@ export class AuroDatePicker extends AuroElement {
 
       if (!this.contains(document.activeElement)) {
         this.validate();
-        this.dropdown.hide();
       }
     });
 
@@ -1246,7 +1245,7 @@ export class AuroDatePicker extends AuroElement {
     const targetIsInput = initTarget.tagName === 'INPUT';
     const isFocusAlreadyOnInput = this.inputList.includes(this.shadowRoot.activeElement);
 
-    if (layoutRequiresHandling && !targetIsInput && !isFocusAlreadyOnInput) {
+    if (layoutRequiresHandling && !targetIsInput && !isFocusAlreadyOnInput && !event.composedPath().includes(this.dropdown.bibContent)) {
       // Focus the first input
       this.inputList[0].focus();
     }

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -819,6 +819,16 @@ export class AuroDatePicker extends AuroElement {
   }
 
   /**
+   * Blurs the datepicker and hides the dropdown as part of blur action.
+   * @private
+   * @returns {void}
+   */
+  blur() {
+    super.blur();
+    this.hideBib();
+  }
+
+  /**
    * Hides the dropdown bib if its open.
    * @returns {void}
    */


### PR DESCRIPTION
# Alaska Airlines Pull Request

Safari and Firefox were both having issues where clicking on the dropdown bib would close the bib, no matter what. Turns out this is an issue with BOTH browsers where they fire `focusout` when they shouldn't be. Our code was rightfully checking to see if the event target was the datepicker itself, but because they don't follow what Chrome does (and contain/not bubble up) we were getting a false positive and closing the datepicker. 

We also don't _need_ to update the datepicker dropdown manually as the bib takes care of closing itself when it's blurred.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix datepicker closing unexpectedly on Safari and Firefox when interacting with the bib dropdown handle by removing an unnecessary hide call and refining focus logic to ignore clicks inside the bib content.

Bug Fixes:
- Remove explicit dropdown.hide() call on focusout to prevent premature closure.
- Add a check to skip focus-handling when clicks originate within the bibContent in Safari/Firefox.