### PR TITLE
feat: auto supply datepicker displayValue slot content #1117

### DIFF
--- a/components/datepicker/apiExamples/snowflake/ondark-range.html
+++ b/components/datepicker/apiExamples/snowflake/ondark-range.html
@@ -1,8 +1,7 @@
-<auro-datepicker range layout="snowflake" shape="snowflake" ondark placeholder="MM/DD/YYYY">
+<auro-datepicker range layout="snowflake" shape="snowflake" ondark placeholder="MM/DD/YYYY" dvInputOnly>
   <span slot="ariaLabel.bib.close">Close Calendar</span>
   <span slot="label">Dates</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
   <span slot="bib.fullscreen.dateLabel">Choose a date</span>
-  <span slot="displayValue">Aug 01–Aug 06</span>
 </auro-datepicker>

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -147,7 +147,7 @@ export class AuroDatePicker extends AuroElement {
     /**
      * @private
      */
-    this.hasDisplayValueContent = false;
+    this.hasDisplayValueContent = true;
 
     /**
      * @private
@@ -1467,7 +1467,11 @@ export class AuroDatePicker extends AuroElement {
             ${this.renderHtmlInputs()}
           </div>
           <div class="${classMap(this.commonDisplayValueWrapperClasses)}">
-            <slot name="displayValue" @slotchange=${this.checkDisplayValueSlotChange}></slot>
+            <slot name="displayValue" @slotchange=${this.checkDisplayValueSlotChange}>
+              <span>
+                ${this.formatShortDate(this.value)}${this.range ? html`–${this.formatShortDate(this.valueEnd)}` : undefined}
+              </span>
+            </slot>
           </div>
         </div>
         <div class="accents right ${classMap(accentsClassMap)}">


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Provide automatic fallback content for the AuroDatePicker displayValue slot to render the selected date when no custom slot content is supplied, and update example usage to leverage the new behavior.

New Features:
- Automatically supply default content for the datepicker’s displayValue slot to render the formatted date or date range when no custom slot content is provided.

Enhancements:
- Set the hasDisplayValueContent flag to true by default to enable fallback rendering.

Documentation:
- Update the Snowflake range example by removing the manual displayValue slot and adding the dvInputOnly attribute to reflect the new default behavior.