### PR TITLE
fix: hide extra icon from edge browser #1139

### DIFF
--- a/components/input/src/styles/classic/style.scss
+++ b/components/input/src/styles/classic/style.scss
@@ -48,6 +48,7 @@
       transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
     }
 
+    // Hide default eye icon from edge brwoser
     input[type="password"]::-ms-reveal {
       display: none;
     }

--- a/components/input/src/styles/classic/style.scss
+++ b/components/input/src/styles/classic/style.scss
@@ -47,6 +47,10 @@
       height: auto;
       transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
     }
+
+    input[type="password"]::-ms-reveal {
+      display: none;
+    }
   }
 
   .mainContent:has(input.util_displayHiddenVisually) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Add CSS to hide the ::-ms-reveal pseudo-element on password inputs in Edge