### PR TITLE
fix: ensure changing zoom level doesn't cause parts of elements to be cut off

### DIFF
--- a/components/layoutElement/src/styles/shapeSize.scss
+++ b/components/layoutElement/src/styles/shapeSize.scss
@@ -54,10 +54,6 @@ $xs: 24px;
   @include parentBorder($size);
 }
 
-.wrapper {
-  overflow: hidden;
-}
-
 .shape-classic-xl,
 .shape-classic-lg,
 .shape-classic-md,


### PR DESCRIPTION
# Alaska Airlines Pull Request

Removed unnecessary overflow:hidden on AuroElement in style.scss

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Remove overflow:hidden from the shape wrapper to prevent elements from being clipped at different zoom levels