### PR TITLE
fix: remove extra bottom space after first time in focus #1155

### DIFF
--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -31,6 +31,12 @@
 :host {
   display: inline-block;
   text-align: left;
+  
+  /**
+    * By default, inline-blocks align to the text baseline, leaving a small gap below.
+    * This fixes the "extra space" below inline-block elements.
+    * see more: https://css-tricks.com/fighting-the-space-between-inline-block-elements
+    */
   vertical-align: top;
 }
 

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -31,6 +31,7 @@
 :host {
   display: inline-block;
   text-align: left;
+  vertical-align: top;
 }
 
 :host([layout*='emphasized']),


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Remove extra bottom space after first focus on the select component by aligning its host to the top