### PR TITLE
chore: try to implement fix for menu a11y

### DIFF
--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -45,11 +45,12 @@ The `auro-dropdown` element provides a way to place content in a bib that can be
 
 ## Events
 
-| Event                       | Type                                 | Description                                      |
-|-----------------------------|--------------------------------------|--------------------------------------------------|
-| `auroDropdown-idAdded`      | `Object<key  : 'id', value: string>` | Notifies consumers that the unique ID for the dropdown bib has been generated. |
-| `auroDropdown-toggled`      |                                      | Notifies that the visibility of the dropdown bib has changed. |
-| `auroDropdown-triggerClick` | `CustomEvent<any>`                   | Notifies that the trigger has been clicked.      |
+| Event                       | Type                                             | Description                                      |
+|-----------------------------|--------------------------------------------------|--------------------------------------------------|
+| `auroDropdown-idAdded`      | `Object<key  : 'id', value: string>`             | Notifies consumers that the unique ID for the dropdown bib has been generated. |
+| `auroDropdown-ready`        | `Object<key  : 'dropdown', value: AuroDropdown>` | Notifies that the dropdown is fully initialized and ready for external modification. |
+| `auroDropdown-toggled`      |                                                  | Notifies that the visibility of the dropdown bib has changed. |
+| `auroDropdown-triggerClick` | `CustomEvent<any>`                               | Notifies that the trigger has been clicked.      |
 
 ## Slots
 

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -54,6 +54,7 @@ import { AuroElement } from '../../layoutElement/src/auroElement.js';
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  * @event auroDropdown-idAdded - Notifies consumers that the unique ID for the dropdown bib has been generated.
+ * @event auroDropdown-ready - Notifies that the dropdown is fully initialized and ready for external modification.
  */
 export class AuroDropdown extends AuroElement {
   constructor() {
@@ -212,8 +213,10 @@ export class AuroDropdown extends AuroElement {
   focus() {
     if (this.isPopoverVisible && this.focusTrap) {
       this.focusTrap.focusFirstElement();
+      // console.log("focus trap enabled", document.activeElement);
     } else {
       this.trigger.focus();
+      // console.log("trigger focus", document.activeElement);
     }
   }
 
@@ -586,6 +589,7 @@ export class AuroDropdown extends AuroElement {
       this.dropdownId = this.floater.element.id;
     }
 
+    this.trigger = this.shadowRoot.querySelector('#trigger');
     this.bibContent = this.floater.element.bib;
 
     // Add the tag name as an attribute if it is different than the component name
@@ -597,6 +601,17 @@ export class AuroDropdown extends AuroElement {
         composed: true
       }));
     });
+
+    /**
+     * @description Let subscribers know that the dropdown is fully initialized and ready for external modification.
+     * @event auroDropdown-ready
+     * @type {Object<key: 'dropdown', value: AuroDropdown>} - The dropdown component instance.
+     */
+    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
+      detail: { dropdown: this },
+      bubbles: true,
+      composed: true
+    }));
   }
 
   /**
@@ -648,7 +663,12 @@ export class AuroDropdown extends AuroElement {
     // If the dropdown is open, create a focus trap and focus the first element
     if (this.isPopoverVisible && !this.disableFocusTrap) {
       this.focusTrap = new FocusTrap(this.bibContent);
-      this.focusTrap.focusFirstElement();
+      // console.log("focus trap created", document.activeElement);
+      // this.focusTrap.focusFirstElement();
+      this.trigger.focus();
+      // console.log("trigger focused", document.activeElement);
+
+      // console.log("first elem focused", document.activeElement);
       return;
     }
 
@@ -767,7 +787,7 @@ export class AuroDropdown extends AuroElement {
     this.floater.handleTriggerTabIndex();
 
     // Get the trigger
-    const trigger = this.shadowRoot.querySelector('#trigger');
+    // const trigger = this.shadowRoot.querySelector('#trigger');
 
     // Get the trigger slot
     const triggerSlot = this.shadowRoot.querySelector('.triggerContentWrapper slot');
@@ -791,11 +811,10 @@ export class AuroDropdown extends AuroElement {
           this.clearTriggerA11yAttributes(trigger);
 
           // Remove the tabindex from the trigger so it doesn't interrupt focus flow
-          trigger.removeAttribute('tabindex');
+          this.trigger.removeAttribute('tabindex');
         } else {
-
           // Add the tabindex to the trigger so that it's in the focus flow
-          trigger.setAttribute('tabindex', '0');
+          this.trigger.setAttribute('tabindex', '0');
         }
       }
     }
@@ -856,6 +875,18 @@ export class AuroDropdown extends AuroElement {
   renderBasicHtml(helpTextClasses) {
     return html`
       <div>
+        <div class="combo-menu"
+          role="listbox"
+          id="listbox1"
+          aria-labelledby="trigger"
+          tabindex="-1">
+          <div role="option" id="combo1-0" class="combo-option" aria-selected="false">Orange</div>
+          <div role="option" id="combo1-1" class="combo-option" aria-selected="false">Apple</div>
+          <div role="option" id="combo1-2" class="combo-option" aria-selected="false">Banana</div>
+          <div role="option" id="combo1-3" class="combo-option" aria-selected="false">Pear</div>
+          <div role="option" id="combo1-4" class="combo-option" aria-selected="false">Blueberry</div>
+          <div role="option" id="combo1-5" class="combo-option" aria-selected="false">Dragon Fruit</div>
+        </div>
         <div
           id="trigger"
           class="${classMap(this.commonWrapperClasses)}" part="wrapper"

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -419,6 +419,11 @@ export class AuroMenu extends AuroElement {
   connectedCallback() {
     super.connectedCallback();
 
+    // Ensure the menu has a unique ID for aria-activedescendant
+    if (!this.id) {
+      this.id = `auro-menu-${Math.random().toString(36).substr(2, 9)}`;
+    }
+
     this.provideContext();
 
     this.addEventListener('keydown', this.handleKeyDown);

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -196,6 +196,11 @@ export class AuroMenuOption extends AuroElement {
     // Add this step soon as this node gets attached to the DOM to avoid racing condition with menu's value setting logic.
     this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
 
+    // Ensure the menuoption has a unique ID for aria-activedescendant
+    if (!this.id) {
+      this.id = `auro-menuoption-${Math.random().toString(36).substr(2, 9)}`;
+    }
+
     // Set up context consumption in connectedCallback
     this._contextConsumer = new ContextConsumer(this, {
       context: MenuContext,

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -42,6 +42,7 @@ The `auro-select` element is a wrapper for auro-dropdown and auro-menu to create
 
 | Method         | Type                                   | Description                                      |
 |----------------|----------------------------------------|--------------------------------------------------|
+| `focus`        | `(): void`                             |                                                  |
 | `hideBib`      | `(): void`                             | Hides the dropdown bib if its open.              |
 | `reset`        | `(): void`                             | Resets component to initial state.               |
 | `setMenuValue` | `(value: any): void`                   |                                                  |

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -10,6 +10,8 @@ import { css } from "lit";
 import { classMap } from 'lit/directives/class-map.js';
 import { html } from 'lit/static-html.js';
 
+import { FocusTrap } from "@aurodesignsystem/auro-library/scripts/runtime/FocusTrap/index.mjs";
+
 import { AuroElement } from '../../layoutElement/src/auroElement.js';
 
 import shapeSizeCss from "./styles/shapeSize-css.js";
@@ -532,6 +534,19 @@ export class AuroSelect extends AuroElement {
     return this.placeholder || (this.value && this.value.length > 0); // eslint-disable-line no-extra-parens
   }
 
+  // select
+  //   shadowRoot
+  //     dropdown
+  //       shadowRoot
+  //         trigger
+  //           aria-controls=slot.menu
+  //         dialog
+  //           shadowRoot
+  //             slot.menu (aria-role=listbox)
+  //              option1
+  //                aria-label="${this.innerText} (1 of ${this.options.length})"
+  //              option2
+
   /**
    * Binds all behavior needed to the dropdown after rendering.
    * @private
@@ -539,9 +554,38 @@ export class AuroSelect extends AuroElement {
    */
   configureDropdown() {
     this.dropdown = this.shadowRoot.querySelector(this.dropdownTag._$litStatic$);
+    // Listen for when the dropdown is completely ready for external modification
+    this.dropdown.addEventListener('auroDropdown-ready', () => {
+      this.configureSelectAccessibility();
+
+      this.addEventListener('focusin', () => {
+        this.focus();
+      });
+
+      this.dropdown.trigger.addEventListener('focusin', () => {
+        console.log('focused on dropdown trigger');
+      });
+    });
 
     this.dropdown.addEventListener('auroDropdown-toggled', () => {
       this.isPopoverVisible = this.dropdown.isPopoverVisible;
+
+      // Update aria-expanded on the trigger for screen reader accessibility
+      if (this.dropdown.trigger) {
+        this.dropdown.trigger.setAttribute('aria-expanded', this.dropdown.isPopoverVisible.toString());
+      }
+      
+      // Also update aria-expanded on the select component for additional accessibility support
+      this.setAttribute('aria-expanded', this.dropdown.isPopoverVisible);
+
+      // Manage menu visibility for screen readers
+      if (this.menu) {
+        if (this.dropdown.isPopoverVisible) {
+          this.menu.removeAttribute('aria-hidden');
+        } else {
+          this.menu.setAttribute('aria-hidden', 'true');
+        }
+      }
 
       if (this.dropdown.isPopoverVisible) {
         this.updateMenuShapeSize();
@@ -698,7 +742,6 @@ export class AuroSelect extends AuroElement {
     }
 
     this.options = this.menu.options;
-    this.menu.setAttribute('aria-hidden', 'true');
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));
     this.menu.addEventListener('auroMenu-selectedOption', (event) => {
 
@@ -713,6 +756,64 @@ export class AuroSelect extends AuroElement {
         this.dropdown.hide();
       }
     });
+
+    // Listen for menu active option changes to update aria-activedescendant on trigger
+    this.menu.addEventListener('auroMenu-activatedOption', (event) => {
+      this.dropdown.trigger.focus();
+      this.updateSelectAriaActivedescendant(event.detail);
+    });
+  }
+
+  /**
+   * Configures accessibility attributes for both trigger and select components.
+   * The trigger needs combobox attributes for bib functionality, while the select manages aria-activedescendant.
+   * @private
+   * @returns {void}
+   */
+  configureSelectAccessibility() {
+    // Configure select component as the primary accessibility interface
+    this.dropdown.trigger.setAttribute('role', 'combobox'); // Essential for aria-activedescendant to work
+    this.dropdown.trigger.setAttribute('aria-haspopup', 'listbox');
+    this.dropdown.trigger.setAttribute('aria-expanded', 'false');
+    
+    // this.dropdown.trigger.setAttribute('aria-labelledby', 'label');
+    // this.dropdown.trigger.setAttribute('tabindex', '0'); // Make select focusable for keyboard access
+    
+    if (this.menu) {
+      this.dropdown.trigger.setAttribute('aria-controls', "listbox1");
+    }
+
+    // Ensure menu starts hidden from screen readers
+    if (this.menu) {
+      this.menu.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  /**
+   * Updates the aria-activedescendant attribute on the select component.
+   * This enables screen readers to announce the currently active menu option.
+   * @private
+   * @param {HTMLElement} activeOption - The currently active menu option element.
+   * @returns {void}
+   */
+
+  /**
+   * Updates the aria-activedescendant attribute on the select component.
+   * This provides accessibility for screen readers to announce active menu options.
+   * @private
+   * @param {HTMLElement} activeOption - The currently active menu option element.
+   * @returns {void}
+   */
+  updateSelectAriaActivedescendant(activeOption) {
+    if (activeOption && activeOption.id && this.dropdown.isPopoverVisible) {
+      // Set aria-activedescendant on the select component
+
+      const nodes = Array.from(this.menu.children);
+      const index = nodes.indexOf(activeOption);
+
+      // this.dropdown.trigger.setAttribute('aria-activedescendant', activeOption.id);
+      this.dropdown.trigger.setAttribute('aria-activedescendant', `combo1-${index}`);
+    }
   }
 
   /**
@@ -769,9 +870,13 @@ export class AuroSelect extends AuroElement {
           if (this.dropdown.shadowRoot.activeElement === this.dropdown.trigger) {
             // `dropdown.focus` will move focus to the first focusable element in bib when it's open,
             // when bib it not open, it will focus onto trigger.
+
+            // console.log("call focus to dropdown");
             this.dropdown.focus();
           } else {
             // when close button has the focus, move focus back to the trigger
+
+            // console.log("call focus to trigger");
             this.dropdown.trigger.focus();
           }
         } else {
@@ -882,9 +987,16 @@ export class AuroSelect extends AuroElement {
    * @return {void}
    */
   handleFocusin() {
-
     this.hasFocus = true;
     this.touched = true;
+
+    // this.focusTrap = new FocusTrap(this.dropdown.trigger);
+    // this.focusTrap.focusFirstElement();
+
+    // console.log("hmmm", this.dropdown.trigger)
+
+    // this.dropdown.trigger.focus();
+    // console.log("dropdown trigger focused from focusin", document.activeElement);
   }
 
   /**
@@ -955,6 +1067,10 @@ export class AuroSelect extends AuroElement {
     this.menu.value = value;
   }
 
+  focus() {
+    this.dropdown.trigger.focus();
+  }
+
   updated(changedProperties) {
     if (changedProperties.has('multiSelect') && !changedProperties.has('value')) {
       this.clearSelection();
@@ -966,7 +1082,7 @@ export class AuroSelect extends AuroElement {
       this._updateNativeSelect();
       this.validate();
       this.hideBib();
-      this.focus();
+      // this.focus();
 
       // LEGACY EVENT
       this.dispatchEvent(new CustomEvent('auroSelect-valueSet', {
@@ -1009,6 +1125,25 @@ export class AuroSelect extends AuroElement {
       this.menu.setAttribute('size', this.layout !== 'emphasized' ? 'md' : this.defaultMenuSize || this.size);
     }
   }
+
+  /**
+   * auro-select itself does not get focus
+   *   auro-dropdown
+   *     trigger gets focus 
+   *        label/value gets read
+   *     bib === role=popover | dialog
+   *     open bib
+   *        Announces list box open
+   *        support changing menu options via arrow key and voiceover swipes and hover
+   *        while bib is open announce active menu option when it changes
+   *     close bib
+   *        Announces list box closed
+   *     If value changes announce new value
+   * 
+   * 
+   *    
+   * 
+   */
 
   /**
    * Resets component to initial state.
@@ -1362,7 +1497,6 @@ export class AuroSelect extends AuroElement {
             </div>
             <div class="accents right"></div>
           </div>
-          <div class="menuWrapper"></div>
           <${this.bibtemplateTag} ?large="${this.largeFullscreenHeadline}" @close-click="${this.hideBib}">
             <slot name="ariaLabel.bib.close" slot="ariaLabel.close">Close</slot>
             <slot></slot>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve accessibility and focus management for auro-select and auro-dropdown by integrating menu state with ARIA attributes and announcing active options correctly.

Bug Fixes:
- Ensure auro-select and its dropdown trigger correctly expose expanded state and menu visibility to assistive technologies.
- Guarantee auro-menu and auro-menuoption elements have stable IDs so aria-activedescendant can reliably reference active options.

Enhancements:
- Add a ready lifecycle event to auro-dropdown so consumers can safely modify the trigger and bib once initialization is complete.
- Wire auro-select to listen to auro-menu activation events and update aria-activedescendant on the dropdown trigger for accurate screen reader announcements.
- Refine focus behavior so auro-select delegates focus to the dropdown trigger and dropdown open/close logic avoids trapping focus prematurely.

Documentation:
- Document the new auroDropdown-ready event in the dropdown API reference.
- Expose the new focus() method on auro-select in its API documentation.