### PR TITLE
Update label handling for datepicker a11y compliance

### DIFF
--- a/components/datepicker/apiExamples/alert-value.html
+++ b/components/datepicker/apiExamples/alert-value.html
@@ -1,5 +1,5 @@
 <auro-datepicker id="datePickerValueAlert">
   <span slot="bib.fullscreen.headline">Alert Value Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/appearance-inverse-range.html
+++ b/components/datepicker/apiExamples/appearance-inverse-range.html
@@ -2,5 +2,6 @@
   <span slot="bib.fullscreen.headline">Datepicker Range Headline</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Roundtrip</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/appearance-inverse.html
+++ b/components/datepicker/apiExamples/appearance-inverse.html
@@ -2,5 +2,5 @@
   <span slot="ariaLabel.bib.close">Close Calendar</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/aria-label-input-clear.html
+++ b/components/datepicker/apiExamples/aria-label-input-clear.html
@@ -2,6 +2,6 @@
   <span slot="ariaLabel.bib.close">Close Calendar</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   <span slot="ariaLabel.input.clear">Custom Clear Input Button</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/basic.html
+++ b/components/datepicker/apiExamples/basic.html
@@ -2,5 +2,5 @@
   <span slot="ariaLabel.bib.close">Close Calendar</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/calendar-focus-date.html
+++ b/components/datepicker/apiExamples/calendar-focus-date.html
@@ -1,5 +1,5 @@
 <auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="12/01/2023" calendarFocusDate="11/01/2022">
   <span slot="bib.fullscreen.headline">calendarFocusDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/calendar-start-and-end-date.html
+++ b/components/datepicker/apiExamples/calendar-start-and-end-date.html
@@ -1,5 +1,5 @@
 <auro-datepicker calendarStartDate="01/01/2022" calendarEndDate="06/01/2022">
   <span slot="bib.fullscreen.headline">calendarStartDate & calendarEndDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/central-date.html
+++ b/components/datepicker/apiExamples/central-date.html
@@ -1,5 +1,5 @@
 <auro-datepicker centralDate="06/16/1980">
   <span slot="bib.fullscreen.headline">centralDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/custom.html
+++ b/components/datepicker/apiExamples/custom.html
@@ -1,5 +1,5 @@
 <custom-datepicker>
     <span slot="bib.fullscreen.headline">custom-datepicker Example</span>
     <span slot="fromLabel">Choose a date</span>
-    <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+    <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </custom-datepicker>

--- a/components/datepicker/apiExamples/date-slot.html
+++ b/components/datepicker/apiExamples/date-slot.html
@@ -1,7 +1,7 @@
 <auro-datepicker centralDate="12/03/2023" minDate="12/04/2023" maxDate="12/09/2023">
   <span slot="bib.fullscreen.headline">dateSlot Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   <span slot="date_12_03_2023">Sold</span>
   <span highlight slot="date_12_04_2023">$89</span>
   <span slot="date_12_05_2023">$100</span>

--- a/components/datepicker/apiExamples/disabled.html
+++ b/components/datepicker/apiExamples/disabled.html
@@ -1,4 +1,4 @@
 <auro-datepicker disabled>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/dynamic-slot.html
+++ b/components/datepicker/apiExamples/dynamic-slot.html
@@ -2,5 +2,5 @@
   <span slot="bib.fullscreen.headline">dynamic slot Example</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/error.html
+++ b/components/datepicker/apiExamples/error.html
@@ -4,5 +4,5 @@
 <auro-datepicker error="Custom error message" id="errorExample">
   <span slot="bib.fullscreen.headline">Error Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/floater-config.html
+++ b/components/datepicker/apiExamples/floater-config.html
@@ -2,19 +2,19 @@
   <auro-datepicker offset="20" placement="bottom-start" noFlip>
     <span slot="bib.fullscreen.headline">Datepicker Headline</span>
     <span slot="fromLabel">bottom-start with 20px offset and noFlip</span>
-    <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+    <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   </auro-datepicker>
   <br/>
   <auro-datepicker offset="20" placement="bottom-start">
     <span slot="bib.fullscreen.headline">Datepicker Headline</span>
     <span slot="fromLabel">bottom-start with 20px offset and flip</span>
-    <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+    <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   </auro-datepicker>
   <br/>
   <auro-datepicker offset="20" placement="right" autoPlacement noFlip>
     <span slot="bib.fullscreen.headline">Datepicker Headline</span>
     <span slot="fromLabel">right with 20px offset, noFlip and autoPlacement</span>
-    <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+    <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   </auro-datepicker>
 </div>
 
@@ -25,6 +25,7 @@
     <span slot="bib.fullscreen.headline">Datepicker Range Headline</span>
     <span slot="fromLabel">Departure</span>
     <span slot="toLabel">Return</span>
-    <span slot="bib.fullscreen.dateLabel">Roundtrip</span>
+    <span slot="bib.fullscreen.fromLabel">Departure</span>
+    <span slot="bib.fullscreen.toLabel">Return</span>
   </auro-datepicker>
 </div>

--- a/components/datepicker/apiExamples/focus.html
+++ b/components/datepicker/apiExamples/focus.html
@@ -5,5 +5,6 @@
   <span slot="bib.fullscreen.headline">Focus Example</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
+  <span slot="bib.fullscreen.toLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/format.html
+++ b/components/datepicker/apiExamples/format.html
@@ -1,5 +1,5 @@
 <auro-datepicker format="yyyy/mm/dd">
   <span slot="bib.fullscreen.headline">Format Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/fullscreen-breakpoint.html
+++ b/components/datepicker/apiExamples/fullscreen-breakpoint.html
@@ -2,5 +2,5 @@
   <span slot="ariaLabel.bib.close">Close Calendar</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/help-text.html
+++ b/components/datepicker/apiExamples/help-text.html
@@ -1,6 +1,6 @@
 <auro-datepicker>
   <span slot="bib.fullscreen.headline">helpText Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   <span slot="helpText">Choose a date must be today or earlier.</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/inputmode.html
+++ b/components/datepicker/apiExamples/inputmode.html
@@ -1,5 +1,5 @@
 <auro-datepicker inputmode="numeric">
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/localization.html
+++ b/components/datepicker/apiExamples/localization.html
@@ -1,5 +1,5 @@
 <auro-datepicker format="yyyy/mm/dd" id="localizationExample">
   <span slot="bib.fullscreen.headline">Localization Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/max-date.html
+++ b/components/datepicker/apiExamples/max-date.html
@@ -1,5 +1,5 @@
 <auro-datepicker maxDate="03/25/2023" setCustomValidityRangeOverflow="Selected date is later than maximum date.">
   <span slot="bib.fullscreen.headline">maxDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/min-date.html
+++ b/components/datepicker/apiExamples/min-date.html
@@ -1,5 +1,5 @@
 <auro-datepicker minDate="03/25/2028" setCustomValidityRangeUnderflow="Selected date is earlier than the minimum date.">
   <span slot="bib.fullscreen.headline">minDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/no-validate.html
+++ b/components/datepicker/apiExamples/no-validate.html
@@ -1,5 +1,5 @@
 <auro-datepicker required noValidate>
   <span slot="bib.fullscreen.headline">noValidate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/popover-slot.html
+++ b/components/datepicker/apiExamples/popover-slot.html
@@ -1,7 +1,7 @@
 <auro-datepicker centralDate="12/03/2023" minDate="12/04/2023" maxDate="12/09/2023">
   <span slot="bib.fullscreen.headline">Popover Slot Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   <span slot="popover_12_03_2023">Tickets for this day are sold out</span>
   <span slot="popover_12_04_2023">Tickets for this day are $89</span>
   <span slot="popover_12_05_2023">Tickets for this day are $100</span>

--- a/components/datepicker/apiExamples/range.html
+++ b/components/datepicker/apiExamples/range.html
@@ -3,5 +3,6 @@
   <span slot="bib.fullscreen.headline">Datepicker Range Headline</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Roundtrip</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/reference-dates.html
+++ b/components/datepicker/apiExamples/reference-dates.html
@@ -2,5 +2,5 @@
   <span slot="ariaLabel.bib.close">Close Calendar</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/required.html
+++ b/components/datepicker/apiExamples/required.html
@@ -1,12 +1,13 @@
 <auro-datepicker required setCustomValidityValueMissing="Custom value missing message.">
   <span slot="bib.fullscreen.headline">Required Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>
 <br />
 <auro-datepicker required range setCustomValidityValueMissing="Custom value missing message.">
   <span slot="bib.fullscreen.headline">Required Example</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Roundtrip</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/reset-state.html
+++ b/components/datepicker/apiExamples/reset-state.html
@@ -4,5 +4,6 @@
   <span slot="bib.fullscreen.headline">Reset Example</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/snowflake/aria-label-input-clear.html
+++ b/components/datepicker/apiExamples/snowflake/aria-label-input-clear.html
@@ -3,6 +3,6 @@
   <span slot="label">Date</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
   <span slot="ariaLabel.input.clear">Snowflake Clear Input Button</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/snowflake/basic.html
+++ b/components/datepicker/apiExamples/snowflake/basic.html
@@ -3,5 +3,5 @@
   <span slot="label">Date</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/snowflake/range.html
+++ b/components/datepicker/apiExamples/snowflake/range.html
@@ -1,7 +1,9 @@
 <auro-datepicker range layout="snowflake" shape="snowflake" appearance="inverse" placeholder="MM/DD/YYYY">
   <span slot="ariaLabel.bib.close">Close Calendar</span>
-  <span slot="label">Dates</span>
+  <span slot="fromLabel">From Date Test</span>
+  <span slot="toLabel">To Date Test</span>
+  <span slot="label">Testing Date Label</span>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
-  <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a departing date</span>
+  <span slot="bib.fullscreen.toLabel">Choose a returning date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/stacked.html
+++ b/components/datepicker/apiExamples/stacked.html
@@ -1,5 +1,6 @@
 <auro-datepicker range stacked>
   <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/update-max-date.html
+++ b/components/datepicker/apiExamples/update-max-date.html
@@ -4,6 +4,6 @@
 <auro-datepicker id="maxDateExample" setCustomValidityRangeOverflow="Selected date is later than maximum date.">
   <span slot="bib.fullscreen.headline">maxDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>
 

--- a/components/datepicker/apiExamples/update-min-date.html
+++ b/components/datepicker/apiExamples/update-min-date.html
@@ -4,5 +4,5 @@
 <auro-datepicker id="minDateExample" setCustomValidityRangeUnderflow="Selected date is earlier than the minimum date.">
   <span slot="bib.fullscreen.headline">minDate Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/validity.html
+++ b/components/datepicker/apiExamples/validity.html
@@ -3,5 +3,5 @@
 <auro-datepicker required id="validityExample">
   <span slot="bib.fullscreen.headline">validity Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/value-end.html
+++ b/components/datepicker/apiExamples/value-end.html
@@ -2,5 +2,6 @@
   <span slot="bib.fullscreen.headline">valueEnd Example</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/apiExamples/value.html
+++ b/components/datepicker/apiExamples/value.html
@@ -1,5 +1,5 @@
 <auro-datepicker id="valueExample" value="02/02/2022">
   <span slot="bib.fullscreen.headline">value Example</span>
   <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
 </auro-datepicker>

--- a/components/datepicker/docs/api.md
+++ b/components/datepicker/docs/api.md
@@ -79,8 +79,10 @@ The `auro-datepicker` component provides users with a way to select a date or da
 |----------------------------|--------------------------------------------------|
 | `ariaLabel.bib.close`      | Sets aria-label on close button in fullscreen bib |
 | `ariaLabel.input.clear`    | Sets aria-label on clear button                  |
-| `bib.fullscreen.dateLabel` | Defines the content to display above selected dates in the mobile layout. |
+| `bib.fullscreen.dateLabel` | **DEPRECATED** - Use `bib.fullscreen.fromLabel` instead. |
+| `bib.fullscreen.fromLabel` | Defines the content to display above the first input in the mobile layout. |
 | `bib.fullscreen.headline`  | Defines the headline to display above bib.fullscreen.dateLabels in the mobile layout. |
+| `bib.fullscreen.toLabel`   | Defines the content to display above the second input in the mobile layout when `range` is true. |
 | `date_MM_DD_YYYY`          | Defines the content to display in the auro-calendar-cell for the specified date. The content text is colored using the success state token when the `highlight` attribute is applied to the slot. |
 | `fromLabel`                | Defines the label content for the first input.   |
 | `helpText`                 | Defines the content of the helpText.             |

--- a/components/datepicker/docs/partials/api.md
+++ b/components/datepicker/docs/partials/api.md
@@ -558,10 +558,13 @@ Use the `ariaLabel.input.clear` slot to set the `aria-label` for the clear butto
 
 </auro-accordion>
 
-### Fullscreen Bib Date Label and Headline
+### Fullscreen Bib Date Labels and Headline
 
-Use the `bib.fullscreen.dateLabel` and `bib.fullscreen.headline` slots to set the the label at the top of the bib and headline when viewed in the mobile layout.
+Use the `bib.fullscreen.fromLabel`, `bib.fullscreen.toLabel`, and `bib.fullscreen.headline` slots to set the the labels at the top of the bib and headline when viewed in the mobile layout.
+
 To view this demo, set your window to a mobile screen size.
+
+**Note**: The previously supported `bib.fullscreen.dateLabel` slot is deprecated and will continue to work for backwards compatibility, but it is recommended to use the new `bib.fullscreen.fromLabel` and `bib.fullscreen.toLabel` slots to apply a label for each input when in mobile layout.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/basic.html) -->

--- a/components/datepicker/src/auro-calendar.js
+++ b/components/datepicker/src/auro-calendar.js
@@ -384,31 +384,34 @@ export class AuroCalendar extends RangeDatepicker {
       @close-click="${this.utilCal.requestDismiss}">
       <span slot="ariaLabel.close">${this.slots["ariaLabel.bib.close"]}</span>
 
-      <span slot="header">${this.slots["bib.fullscreen.headline"]}</span>
+      ${this.slots["bib.fullscreen.headline"] ? html`<span slot="header">${this.slots["bib.fullscreen.headline"]}</span>` : ''}
 
       <div slot="subheader" class="mobileHeader">
         <div class="headerDateFrom">
-          <span class="mobileDateLabel body-xs">${this.slots["bib.fullscreen.dateLabel"]}</span>
+          ${this.slots["bib.fullscreen.dateLabel"] ? html`<span class="mobileDateLabel body-xs">${this.slots["bib.fullscreen.dateLabel"]}</span>` : ''}
+          ${this.slots["bib.fullscreen.fromLabel"] ? html`<span class="mobileDateLabel body-xs">${this.slots["bib.fullscreen.fromLabel"]}</span>` : ''}
           <slot name="bib.fullscreen.fromStr"></slot>
         </div>
-        <div class="headerDateTo"><slot name="mobileDateToStr"></slot></div>
+        <div class="headerDateTo">
+          ${this.slots["bib.fullscreen.toLabel"] ? html`<span class="mobileDateLabel body-xs">${this.slots["bib.fullscreen.toLabel"]}</span>` : ''}
+          <slot name="bib.fullscreen.toStr"></slot>
+        </div>
       </div>
 
       <div class="calendarWrapper">
-
         <div class="calendars">
           ${this.renderAllCalendars()}
         </div>
         <div class="calendarNavButtons">
           ${this.showPrevMonthBtn ? html`
-            <button class="calendarNavBtn prevMonth" @click="${this.handlePrevMonth}">
-              ${this.util.generateIconHtml(chevronLeft)}
-            </button>
+          <button class="calendarNavBtn prevMonth" @click="${this.handlePrevMonth}">
+            ${this.util.generateIconHtml(chevronLeft)}
+          </button>
           ` : undefined}
           ${this.showNextMonthBtn ? html`
-            <button class="calendarNavBtn nextMonth" @click="${this.handleNextMonth}">
-              ${this.util.generateIconHtml(chevronRight)}
-            </button>
+          <button class="calendarNavBtn nextMonth" @click="${this.handleNextMonth}">
+            ${this.util.generateIconHtml(chevronRight)}
+          </button>
           ` : undefined}
         </div>
       </div>

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -57,7 +57,9 @@ import { LitElement } from 'lit';
  * @slot ariaLabel.bib.close - Sets aria-label on close button in fullscreen bib
  * @slot ariaLabel.input.clear - Sets aria-label on clear button
  * @slot bib.fullscreen.headline - Defines the headline to display above bib.fullscreen.dateLabels in the mobile layout.
- * @slot bib.fullscreen.dateLabel - Defines the content to display above selected dates in the mobile layout.
+ * @slot bib.fullscreen.dateLabel - **DEPRECATED** - Use `bib.fullscreen.fromLabel` instead.
+ * @slot bib.fullscreen.fromLabel - Defines the content to display above the first input in the mobile layout.
+ * @slot bib.fullscreen.toLabel - Defines the content to display above the second input in the mobile layout when `range` is true.
  * @slot label - Defines the label content for the entire datepicker when `layout="snowflake"`.
  * @slot toLabel - Defines the label content for the second input when the `range` attribute is used.
  * @slot fromLabel - Defines the label content for the first input.
@@ -1640,6 +1642,7 @@ export class AuroDatePicker extends AuroElement {
           appearance="${this.onDark ? 'inverse' : this.appearance}"
           ?disabled="${this.disabled}"
           ?required="${this.required}"
+          ?hideLabelVisually="${this.layout !== 'classic'}"
           .format="${this.format}"
           .max="${this.maxDate}"
           .min="${this.minDate}"
@@ -1683,6 +1686,7 @@ export class AuroDatePicker extends AuroElement {
             appearance="${this.onDark ? 'inverse' : this.appearance}"
             ?disabled="${this.disabled}"
             ?required="${this.required}"
+            ?hideLabelVisually="${this.layout !== 'classic'}"
             .format="${this.format}"
             .max="${this.maxDate}"
             .min="${this.minDate}"
@@ -1847,8 +1851,10 @@ export class AuroDatePicker extends AuroElement {
         <slot name="ariaLabel.bib.close" slot="ariaLabel.close" @slotchange="${this.handleSlotToSlot}">Close</slot>
         <slot slot="bib.fullscreen.headline" name="bib.fullscreen.headline" @slotchange="${this.handleSlotToSlot}"></slot>
         <slot slot="bib.fullscreen.dateLabel" name="bib.fullscreen.dateLabel" @slotchange="${this.handleSlotToSlot}"></slot>
+        <slot slot="bib.fullscreen.toLabel" name="bib.fullscreen.toLabel" @slotchange="${this.handleSlotToSlot}"></slot>
+        <slot slot="bib.fullscreen.fromLabel" name="bib.fullscreen.fromLabel" @slotchange="${this.handleSlotToSlot}"></slot>
         <span slot="bib.fullscreen.fromStr">${this.value || html`<span class="placeholderDate">${this.format.toUpperCase()}</span>`}</span>
-        ${this.range ? html`<span slot="mobileDateToStr">${this.valueEnd || html`<span class="placeholderDate">${this.format.toUpperCase()}</span>`}</span>` : undefined}
+        ${this.range ? html`<span slot="bib.fullscreen.toStr">${this.valueEnd || html`<span class="placeholderDate">${this.format.toUpperCase()}</span>`}</span>` : undefined}
       </auro-formkit-calendar>
     `;
   }

--- a/components/datepicker/src/styles/snowflake/style.scss
+++ b/components/datepicker/src/styles/snowflake/style.scss
@@ -5,7 +5,6 @@
     flex: 1;
     text-align: center;
 
-    &::part(label),
     &::part(accent-left),
     &::part(accent-right) {
       display: none;

--- a/components/datepicker/src/styles/style-auro-calendar.scss
+++ b/components/datepicker/src/styles/style-auro-calendar.scss
@@ -74,7 +74,8 @@
   flex-direction: row;
 }
 
-.headerDateFrom {
+.headerDateFrom,
+.headerDateTo {
   display: flex;
   height: var(--mobile-header-height);
 
@@ -88,37 +89,6 @@
 .mobileDateLabel {
   // padding to make up for body-xs line height
   padding: var(--ds-size-25, vac.$ds-size-25) 0;
-}
-
-.headerDateTo {
-  height: calc(var(--mobile-header-height) - var(--ds-size-300, vac.$ds-size-300));
-
-  padding: var(--ds-size-300, vac.$ds-size-300) var(--ds-size-100, vac.$ds-size-100) 0 var(--ds-size-200, vac.$ds-size-200);
-}
-
-:host(:not([noRange])) {
-  .headerDateTo {
-    position: relative;
-
-    display: flex;
-
-    flex: 1;
-    flex-direction: column;
-    justify-content: center;
-
-    &:after {
-      position: absolute;
-      top: calc(50% + 10px);
-      left: 0;
-
-      display: block;
-      width: 1px;
-      height: var(--ds-size-300, vac.$ds-size-300);
-
-      content: '';
-      transform: translateY(-50%);
-    }
-  }
 }
 
 .mobileFooter {

--- a/components/form/apiExamples/column-layout.html
+++ b/components/form/apiExamples/column-layout.html
@@ -37,7 +37,8 @@
         <auro-datepicker id="date-range" name="dateRange" required range>
           <span slot="fromLabel">Start</span>
           <span slot="toLabel">End</span>
-          <span slot="bib.fullscreen.dateLabel">Choose a range</span>
+          <span slot="bib.fullscreen.fromLabel">Start</span>
+          <span slot="bib.fullscreen.toLabel">End</span>
         </auro-datepicker>
       </div>
 

--- a/components/form/apiExamples/complex.html
+++ b/components/form/apiExamples/complex.html
@@ -45,7 +45,7 @@
     <h4>Pick a cool date</h4>
     <auro-datepicker id="date-example" name="dateExample" required>
       <span slot="fromLabel">Choose a date</span>
-      <span slot="bib.fullscreen.dateLabel">Choose a date</span>
+      <span slot="bib.fullscreen.fromLabel">Choose a date</span>
     </auro-datepicker>
   </div>
 
@@ -54,7 +54,8 @@
     <auro-datepicker id="date-range" name="dateRange" required range>
       <span slot="fromLabel">Start</span>
       <span slot="toLabel">End</span>
-      <span slot="bib.fullscreen.dateLabel">Choose a range</span>
+      <span slot="bib.fullscreen.fromLabel">Start</span>
+      <span slot="bib.fullscreen.toLabel">End</span>
     </auro-datepicker>
   </div>
 

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -214,7 +214,7 @@ export class AuroInput extends BaseInput {
     return {
       'is-disabled': this.disabled,
       'withValue': this.hasValue,
-      'util_displayHiddenVisually': this.labelHidden,
+      'util_displayHiddenVisually': this.labelHidden || this.hideLabelVisually,
       [this.labelFontClass]: true,
     };
   }

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -40,6 +40,7 @@ export default class BaseInput extends AuroElement {
     this.icon = false;
     this.disabled = false;
     this.dvInputOnly = false;
+    this.hideLabelVisually = false;
     this.max = undefined;
     this.maxLength = undefined;
     this.min = undefined;
@@ -252,6 +253,16 @@ export default class BaseInput extends AuroElement {
         reflect: false,
         attribute: false
       },
+
+      /**
+       * If set, the label will be hidden visually but still accessible to assistive technologies.
+       * @private
+       */
+      hideLabelVisually: {
+        type: Boolean,
+        reflect: true
+      },
+
 
       /**
        * If set, will render an icon inside the input to the left of the value. Support is limited to auro-input instances with credit card format.


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update datepicker labeling and mobile fullscreen header structure to improve accessibility and support separate labels for start and end dates.

New Features:
- Add separate `bib.fullscreen.fromLabel` and `bib.fullscreen.toLabel` slots for configuring mobile fullscreen labels in range mode.
- Introduce a `hideLabelVisually` option on base inputs to visually hide labels while keeping them available to assistive technologies.

Enhancements:
- Adjust mobile fullscreen calendar header layout and styling to support distinct from/to labels and simplify header date styling.
- Update snowflake datepicker styling to stop forcibly hiding the internal label part, relying instead on the new label-hiding mechanism.

Documentation:
- Revise datepicker API documentation to deprecate `bib.fullscreen.dateLabel` in favor of `bib.fullscreen.fromLabel` and document the new label slots.