### PR TITLE
# fix: a11y bug fixes across multiple components AB#1510745

### DIFF
--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -15,6 +15,10 @@ export const comboboxKeyboardStrategy = {
       evt.stopPropagation();
       component.setClearBtnFocus();
     } else {
+      // Prevent the keypress from bubbling to parent containers (e.g., forms)
+      // which could interpret Enter as a submit or trigger other unintended behavior.
+      // This is safe because showBib() opens the dialog programmatically,
+      // not via event propagation.
       evt.preventDefault();
       evt.stopPropagation();
       component.showBib();

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -2,11 +2,13 @@ import { navigateArrow } from '../../dropdown/src/keyboardUtils.js';
 
 export const comboboxKeyboardStrategy = {
   async Enter(component, evt) {
-    // If the clear button has focus, let the browser activate it normally
-    // but prevent the native form-submit behavior that Enter would trigger.
+    // If the clear button has focus, let the browser activate it normally.
+    // stopPropagation prevents parent containers (e.g., forms) from treating
+    // Enter as a submit, but we must NOT call preventDefault — that would
+    // block the browser's built-in "Enter activates focused button" behavior.
     const clearBtn = component.input.shadowRoot.querySelector('.clearBtn');
     if (clearBtn && clearBtn.shadowRoot && clearBtn.shadowRoot.activeElement !== null) {
-      evt.preventDefault();
+      evt.stopPropagation();
       return;
     }
 

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -2,9 +2,11 @@ import { navigateArrow } from '../../dropdown/src/keyboardUtils.js';
 
 export const comboboxKeyboardStrategy = {
   async Enter(component, evt) {
-    // If the clear button has focus, let the browser activate it normally.
+    // If the clear button has focus, let the browser activate it normally
+    // but prevent the native form-submit behavior that Enter would trigger.
     const clearBtn = component.input.shadowRoot.querySelector('.clearBtn');
     if (clearBtn && clearBtn.shadowRoot && clearBtn.shadowRoot.activeElement !== null) {
+      evt.preventDefault();
       return;
     }
 

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -15,6 +15,8 @@ export const comboboxKeyboardStrategy = {
       evt.stopPropagation();
       component.setClearBtnFocus();
     } else {
+      evt.preventDefault();
+      evt.stopPropagation();
       component.showBib();
     }
   },

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -6,7 +6,18 @@ export const comboboxKeyboardStrategy = {
     // stopPropagation prevents parent containers (e.g., forms) from treating
     // Enter as a submit, but we must NOT call preventDefault — that would
     // block the browser's built-in "Enter activates focused button" behavior.
-    const clearBtn = component.input.shadowRoot.querySelector('.clearBtn');
+    const isBibFullscreenActive =
+      component.dropdown &&
+      component.dropdown.isBibFullscreen &&
+      component.dropdown.isPopoverVisible;
+    const activeInput =
+      isBibFullscreenActive && component.inputInBib
+        ? component.inputInBib
+        : component.input;
+    const clearBtn =
+      activeInput && activeInput.shadowRoot
+        ? activeInput.shadowRoot.querySelector('.clearBtn')
+        : null;
     if (clearBtn && clearBtn.shadowRoot && clearBtn.shadowRoot.activeElement !== null) {
       evt.stopPropagation();
       return;

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -4,10 +4,14 @@ import { setViewport } from '@web/test-runner-commands';
 import '../src/registered.js';
 import '../../menu/src/registered.js';
 
-// describe('auro-combobox', () => {
-//   runFulltest(false);
-// });
+// Desktop Test Suite
+// "false" means mobileview = false
+describe('auro-combobox', () => {
+  runFulltest(false);
+});
 
+// Mobile Test Suite
+// "true" means mobileview = true (full screen dialog)
 describe('auro-combobox in mobile screen', () => {
   runFulltest(true);
 });
@@ -247,65 +251,68 @@ function runFulltest(mobileview) {
   //   await expect(el.dropdown.isPopoverVisible).to.be.false;
   // });
 
-  it('focuses input in bib when fullscreen dialog opens', async () => {
-    const el = await defaultFixture(mobileview);
+  // These tests require fullscreen (mobile) mode
+  if (mobileview) {
+    it('focuses input in bib when fullscreen dialog opens', async () => {
+      const el = await defaultFixture(mobileview);
 
-    setInputValue(el, 'a');
-    await elementUpdated(el);
+      setInputValue(el, 'a');
+      await elementUpdated(el);
 
-    // inputInBib should exist in fullscreen mode
-    expect(el.inputInBib).to.exist;
+      // inputInBib should exist in fullscreen mode
+      expect(el.inputInBib).to.exist;
 
-    // Follow existing mobile pattern: explicitly focus inputInBib
-    el.inputInBib.focus();
-    await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
-    expect(el.shadowRoot.activeElement).to.equal(el.inputInBib);
-  });
+      // Follow existing mobile pattern: explicitly focus inputInBib
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+      expect(el.shadowRoot.activeElement).to.equal(el.inputInBib);
+    });
 
-  it('Tab key closes fullscreen dialog', async () => {
-    const el = await defaultFixture(mobileview);
+    it('Tab key closes fullscreen dialog', async () => {
+      const el = await defaultFixture(mobileview);
 
-    el.focus();
-    setInputValue(el, 'a');
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    await elementUpdated(el);
-    await expect(el.dropdown.isPopoverVisible).to.be.true;
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await expect(el.dropdown.isPopoverVisible).to.be.true;
 
-    el.inputInBib.focus();
-    await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
 
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
 
-    // Wait for dialog close + rAF focus restoration
-    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-    await elementUpdated(el);
+      // Wait for dialog close + rAF focus restoration
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      await elementUpdated(el);
 
-    await expect(el.dropdown.isPopoverVisible).to.be.false;
-  });
+      await expect(el.dropdown.isPopoverVisible).to.be.false;
+    });
 
-  it('restores trigger inert and focus after fullscreen dialog closes', async () => {
-    const el = await defaultFixture(mobileview);
+    it('restores trigger inert and focus after fullscreen dialog closes', async () => {
+      const el = await defaultFixture(mobileview);
 
-    el.focus();
-    setInputValue(el, 'a');
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    await elementUpdated(el);
-    await expect(el.dropdown.isPopoverVisible).to.be.true;
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await expect(el.dropdown.isPopoverVisible).to.be.true;
 
-    el.inputInBib.focus();
-    await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
 
-    // Trigger should be inert while fullscreen is open
-    expect(el.dropdown.trigger.inert).to.be.true;
+      // Trigger should be inert while fullscreen is open
+      expect(el.dropdown.trigger.inert).to.be.true;
 
-    // Close the dialog
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-    await elementUpdated(el);
+      // Close the dialog
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      await elementUpdated(el);
 
-    expect(el.dropdown.trigger.inert).to.be.false;
-    expect(el.dropdown.isPopoverVisible).to.be.false;
-  });
+      expect(el.dropdown.trigger.inert).to.be.false;
+      expect(el.dropdown.isPopoverVisible).to.be.false;
+    });
+  }
 
   it('hides the bib when selecting an option with a custom event', async () => {
     const el = await customEventFixture(mobileview);
@@ -800,6 +807,106 @@ function runFulltest(mobileview) {
       expect(el._inFullscreenTransition).to.be.false;
     });
   });
+
+  it('hitting Enter on clear button clears the input', async () => {
+    const el = await defaultFixture(mobileview);
+
+    el.focus();
+    setInputValue(el, 'a');
+    await elementUpdated(el);
+
+    if (mobileview) {
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+    }
+
+    // Navigate to the clear button via Tab
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+    await elementUpdated(el);
+
+    const activeInput = mobileview ? el.inputInBib : el.input;
+    const clearBtn = activeInput.shadowRoot.querySelector('.clearBtn');
+    expect(clearBtn).to.exist;
+
+    // Hit Enter on the clear button
+    clearBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    clearBtn.click();
+    await elementUpdated(el);
+
+    expect(activeInput.value).to.not.be.ok;
+  });
+
+  it('clicking clear button clears the input', async () => {
+    const el = await defaultFixture(mobileview);
+
+    el.focus();
+    setInputValue(el, 'a');
+    await elementUpdated(el);
+
+    if (mobileview) {
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+    }
+
+    const activeInput = mobileview ? el.inputInBib : el.input;
+    const clearBtn = activeInput.shadowRoot.querySelector('.clearBtn');
+    expect(clearBtn).to.exist;
+
+    clearBtn.click();
+    await elementUpdated(el);
+
+    expect(activeInput.value).to.not.be.ok;
+  });
+
+  // The close button only exists in fullscreen (mobile) mode
+  if (mobileview) {
+    it('hitting Enter on close button closes the dialog', async () => {
+      const el = await defaultFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+
+      // Find the close button in the bibtemplate and activate it with Enter
+      const closeBtn = el.bibtemplate.shadowRoot.querySelector('#closeButton');
+      expect(closeBtn).to.exist;
+      closeBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+      closeBtn.click();
+
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      await elementUpdated(el);
+
+      await expect(el.dropdown.isPopoverVisible).to.be.false;
+    });
+
+    it('clicking close button closes the dialog', async () => {
+      const el = await defaultFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+
+      // Click the close button in the bibtemplate
+      const closeBtn = el.bibtemplate.shadowRoot.querySelector('#closeButton');
+      expect(closeBtn).to.exist;
+      closeBtn.click();
+
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      await elementUpdated(el);
+
+      await expect(el.dropdown.isPopoverVisible).to.be.false;
+    });
+  }
 
   it('selects label slot content', async () => {
     const el = await fixture(html`

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -163,6 +163,26 @@ function runFulltest(mobileview) {
     await expect(el.dropdown.isPopoverVisible).to.be.true;
   });
 
+  it('Enter key does not propagate when opening the bib', async () => {
+    const el = await defaultFixture(mobileview);
+
+    el.focus();
+    setInputValue(el, 'a');
+
+    let propagated = false;
+    const listener = () => { propagated = true; };
+    // Listen on the parent to detect if the event bubbles past the combobox
+    el.parentElement.addEventListener('keydown', listener);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    await elementUpdated(el);
+
+    el.parentElement.removeEventListener('keydown', listener);
+
+    await expect(propagated).to.be.false;
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+  });
+
   it('hides the bib when there are no available options', async () => {
     const el = await defaultFixture(mobileview);
 
@@ -662,7 +682,9 @@ function runFulltest(mobileview) {
     await expect(el.getAttribute('validity')).to.be.equal('valid');
   });
 
-  describe('announceToScreenReader', () => {
+  describe('announceToScreenReader', function() {
+    this.timeout(5000);
+
     it('populates the live region when an option is activated', async () => {
       const el = await noFilterFixture(mobileview);
       await elementUpdated(el);
@@ -700,8 +722,10 @@ function runFulltest(mobileview) {
       const liveRegion = el.shadowRoot.querySelector('#srAnnouncement');
       expect(liveRegion.textContent).to.not.equal('');
 
-      // Wait for the 1000ms cleanup timeout
-      await new Promise((resolve) => setTimeout(resolve, 1100));
+      // Multiple announcements can chain (e.g., active-option followed by selection),
+      // each resetting the 1000ms cleanup timer. Wait long enough for the final
+      // announcement's timer to expire.
+      await new Promise((resolve) => setTimeout(resolve, 2200));
       expect(liveRegion.textContent).to.equal('');
     });
   });

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -836,6 +836,46 @@ function runFulltest(mobileview) {
     expect(activeInput.value).to.not.be.ok;
   });
 
+  it('Enter on component while clear button is focused does not call preventDefault or showBib', async () => {
+    const el = await defaultFixture(mobileview);
+
+    el.focus();
+    setInputValue(el, 'a');
+    await elementUpdated(el);
+
+    if (mobileview) {
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+    }
+
+    const activeInput = mobileview ? el.inputInBib : el.input;
+    const clearBtn = activeInput.shadowRoot.querySelector('.clearBtn');
+    expect(clearBtn).to.exist;
+
+    // Programmatically focus the native button inside auro-button's shadow root
+    // since synthetic Tab events don't reliably move focus through shadow DOM.
+    const nativeBtn = clearBtn.shadowRoot.querySelector('button');
+    expect(nativeBtn).to.exist;
+    nativeBtn.focus();
+    await elementUpdated(el);
+
+    // Verify clear button has focus
+    expect(clearBtn.shadowRoot.activeElement).to.not.be.null;
+
+    const bibWasVisible = el.dropdown.isPopoverVisible;
+
+    // Dispatch Enter on the component — this goes through the keyboard strategy
+    const enterEvt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    el.dispatchEvent(enterEvt);
+    await elementUpdated(el);
+
+    // The strategy should NOT have called preventDefault (allow browser to activate the button)
+    expect(enterEvt.defaultPrevented).to.be.false;
+
+    // The bib visibility should not have changed (showBib should not have been called)
+    expect(el.dropdown.isPopoverVisible).to.equal(bibWasVisible);
+  });
+
   it('clicking clear button clears the input', async () => {
     const el = await defaultFixture(mobileview);
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -820,17 +820,31 @@ function runFulltest(mobileview) {
       await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
     }
 
-    // Navigate to the clear button via Tab
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
-    await elementUpdated(el);
-
     const activeInput = mobileview ? el.inputInBib : el.input;
     const clearBtn = activeInput.shadowRoot.querySelector('.clearBtn');
     expect(clearBtn).to.exist;
 
-    // Hit Enter on the clear button
-    clearBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
-    clearBtn.click();
+    // Programmatically focus the native button inside auro-button's shadow root
+    // since synthetic Tab events don't reliably move focus through shadow DOM.
+    const nativeBtn = clearBtn.shadowRoot.querySelector('button');
+    expect(nativeBtn).to.exist;
+    nativeBtn.focus();
+    await elementUpdated(el);
+
+    // Verify clear button has focus
+    expect(clearBtn.shadowRoot.activeElement).to.not.be.null;
+
+    // Dispatch Enter on the combobox — the keyboard strategy should not preventDefault,
+    // allowing the browser's native behavior to activate the focused clear button.
+    const enterEvt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    el.dispatchEvent(enterEvt);
+    await elementUpdated(el);
+
+    // Verify the strategy did not prevent default (browser will natively click the focused button)
+    expect(enterEvt.defaultPrevented).to.be.false;
+
+    // Simulate the native button activation that the browser performs on Enter
+    nativeBtn.click();
     await elementUpdated(el);
 
     expect(activeInput.value).to.not.be.ok;

--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -406,7 +406,7 @@ export class AuroCounter extends LitElement {
             aria-valuemax="${this.max}" 
             aria-valuemin="${this.min}" 
             aria-valuenow="${this.value}"
-            aria-valuetext="'${this.value !== undefined ? this.value : this.min}'"
+            aria-valuetext="${this.value !== undefined ? this.value : this.min}"
             role="spinbutton" 
             tabindex="${this.disabled ? '-1' : '0'}" 
           >

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -407,7 +407,7 @@ export class AuroDropdownBib extends LitElement {
 
     return html`
       <dialog class="${classMap(classes)}" part="bibContainer" role="${ifDefined(this.dialogRole)}" aria-labelledby="${ifDefined(this.dialogLabel ? 'dialogLabel' : undefined)}">
-        ${this.dialogLabel ? html`<span id="dialogLabel" class="util_displayHiddenVisually" aria-hidden="true">${this.dialogLabel}</span>` : ''}
+        ${this.dialogLabel ? html`<span id="dialogLabel" class="util_displayHiddenVisually">${this.dialogLabel}</span>` : ''}
         <slot></slot>
       </dialog>
     `;

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -367,9 +367,11 @@ export class AuroDropdownBib extends LitElement {
         const prevOverflow = documentElement.style.overflow;
         documentElement.style.overflow = 'hidden';
 
-        dialog.showModal();
-
-        documentElement.style.overflow = prevOverflow;
+        try {
+          dialog.showModal();
+        } finally {
+          documentElement.style.overflow = prevOverflow;
+        }
 
         this._lockTouchScroll();
 

--- a/components/form/demo/working.html
+++ b/components/form/demo/working.html
@@ -58,7 +58,7 @@
 
   <h2>auro-form Testing</h2>
 
-  <auro-form class="p-4 border border-gray-800 rounded-2xl space-y-6"">
+  <auro-form class="p-4 border border-gray-800 rounded-2xl space-y-6">
     <h3 class="mt-0 mb-4 text-xl">Text Inputs</h3>
     <auro-input id="first-name" name="firstName" required>
       <span slot="label">First Name</span>

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -87,7 +87,7 @@ export class AuroForm extends LitElement {
      * @type {HTMLButtonElement[]}
      * @private
      */
-    this._submitelements = [];
+    this._submitElements = [];
 
     /**
      * @type {HTMLButtonElement[]}
@@ -219,7 +219,7 @@ export class AuroForm extends LitElement {
    * @private
    */
   get submitElements() {
-    return this._submitelements;
+    return this._submitElements;
   }
 
   /**
@@ -301,7 +301,7 @@ export class AuroForm extends LitElement {
       }
     });
 
-    this._submitelements.forEach((element) => {
+    this._submitElements.forEach((element) => {
       if (this.isInitialState || this.validity !== "valid") {
         element.setAttribute("disabled", "");
       } else {
@@ -365,7 +365,7 @@ export class AuroForm extends LitElement {
    */
   initializeState() {
     this.formState = {};
-    this._submitelements = [];
+    this._submitElements = [];
     this._resetElements = [];
     this._elements = [];
 
@@ -379,7 +379,7 @@ export class AuroForm extends LitElement {
         element.addEventListener('click', this.submit);
 
         // Keep record of this element, so we can enable/disable as needed
-        this._submitelements.push(element);
+        this._submitElements.push(element);
       }
 
       if (this.isButtonElement(element) && element.getAttribute('type') === 'reset') {

--- a/components/form/test/auro-form.test.js
+++ b/components/form/test/auro-form.test.js
@@ -372,6 +372,20 @@ describe('auro-form', () => {
       await expect(button.hasAttribute("disabled")).to.be.false;
     });
 
+    it('uses the reactive _submitElements property declared in properties', async () => {
+      const el = await fixture(html`
+        <auro-form>
+          <auro-input name="tester" value="some value"></auro-input>
+          <auro-button type="submit">Submit</auro-button>
+        </auro-form>
+      `);
+
+      await elementUpdated(el);
+
+      // Verify submitElements returns the button via the reactive property
+      expect(el.submitElements).to.have.length(1);
+    });
+
     it('attaches submit click handler to submit elements', async () => {
       const el = await fixture(html`
         <auro-form>

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -457,6 +457,14 @@ export class AuroMenu extends AuroElement {
     if (changedProperties.has('loading')) {
       this.setLoadingState(this.loading);
     }
+
+    if (changedProperties.has('multiSelect') && this.rootMenu) {
+      if (this.multiSelect) {
+        this.setAttribute('aria-multiselectable', 'true');
+      } else {
+        this.removeAttribute('aria-multiselectable');
+      }
+    }
   }
 
   /**

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -238,6 +238,25 @@ describe('auro-menu', () => {
 });
 
 describe('multiSelect', () => {
+  it('should set aria-multiselectable on the menu when multiSelect is enabled', async () => {
+    const el = await multiSelectFixture();
+    const menuEl = el.querySelector('auro-menu');
+
+    expect(menuEl.getAttribute('aria-multiselectable')).to.equal('true');
+  });
+
+  it('should remove aria-multiselectable when multiSelect is disabled', async () => {
+    const el = await multiSelectFixture();
+    const menuEl = el.querySelector('auro-menu');
+
+    expect(menuEl.getAttribute('aria-multiselectable')).to.equal('true');
+
+    menuEl.multiSelect = false;
+    await elementUpdated(menuEl);
+
+    expect(menuEl.hasAttribute('aria-multiselectable')).to.be.false;
+  });
+
   it('should allow multiple options to be selected', async () => {
     const el = await multiSelectFixture();
     const menuEl = el.querySelector('auro-menu');

--- a/components/radio/stories/individual-api-examples.stories.ts
+++ b/components/radio/stories/individual-api-examples.stories.ts
@@ -2,7 +2,7 @@
 
 import { Meta, StoryObj } from '@storybook/web-components-vite';
 import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
-const { args, argTypes } = getStorybookHelpers("auro-checkbox-group");
+const { args, argTypes } = getStorybookHelpers("auro-radio-group");
 import { generateStoriesFromGlobData } from '@aurodesignsystem/utils';
 
 import '../src/registered';

--- a/components/radio/stories/playground/radio.stories.ts
+++ b/components/radio/stories/playground/radio.stories.ts
@@ -22,6 +22,6 @@ export default meta;
 
 type Story = StoryObj<AuroRadio & typeof args>;
 
-export const Checkbox: Story = {
+export const Radio: Story = {
   render: (args) => template(args)
 };

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -649,7 +649,8 @@ function runTest(mobileView) {
     });
   });
 
-  describe('announceToScreenReader', () => {
+  describe('announceToScreenReader', function() {
+    this.timeout(5000);
     it('populates the live region when an option is activated', async () => {
       const el = await defaultFixture();
       await elementUpdated(el);
@@ -677,8 +678,10 @@ function runTest(mobileView) {
       const liveRegion = el.shadowRoot.querySelector('#srAnnouncement');
       expect(liveRegion.textContent).to.not.equal('');
 
-      // Wait for the 1000ms cleanup timeout
-      await new Promise((resolve) => setTimeout(resolve, 1100));
+      // Multiple announcements can chain (e.g., active-option followed by selection),
+      // each resetting the 1000ms cleanup timer. Wait long enough for the final
+      // announcement's timer to expire.
+      await new Promise((resolve) => setTimeout(resolve, 2200));
       expect(liveRegion.textContent).to.equal('');
     });
   });

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -12,15 +12,20 @@
 
 const ANNOUNCEMENT_DURATION_MS = 1000;
 
-// Tracks the clear-after-announce timeout so rapid successive calls can cancel the previous one.
-let pendingClearTimeout = 0;
+// Tracks the clear-after-announce timeout per shadowRoot so simultaneous
+// announcements from different components don't cancel each other.
+// A Map (rather than a single module-level variable) is needed because
+// ES modules are singletons — a shared variable would let a rapid call from
+// one component cancel another component's pending clear, leaving stale text
+// in the first component's live region.
+const pendingClearTimeouts = new Map();
 
 export function announceToScreenReader(shadowRoot, text) {
   const liveRegion = shadowRoot.querySelector('#srAnnouncement');
   if (liveRegion) {
     // Cancel any pending clear so a previous announcement's timeout
     // doesn't blank this one before the screen reader can read it.
-    clearTimeout(pendingClearTimeout);
+    clearTimeout(pendingClearTimeouts.get(shadowRoot));
 
     // Clear and re-set to ensure the announcement fires even with same text
     liveRegion.textContent = '';
@@ -28,9 +33,9 @@ export function announceToScreenReader(shadowRoot, text) {
       liveRegion.textContent = text;
 
       // Clear after the announcement so VoiceOver cannot swipe to stale text
-      pendingClearTimeout = setTimeout(() => {
+      pendingClearTimeouts.set(shadowRoot, setTimeout(() => {
         liveRegion.textContent = '';
-      }, ANNOUNCEMENT_DURATION_MS);
+      }, ANNOUNCEMENT_DURATION_MS));
     });
   }
 }

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -12,11 +12,14 @@
 
 const ANNOUNCEMENT_DURATION_MS = 1000;
 
+// Tracks the clear-after-announce timeout so rapid successive calls can cancel the previous one.
 let pendingClearTimeout = 0;
 
 export function announceToScreenReader(shadowRoot, text) {
   const liveRegion = shadowRoot.querySelector('#srAnnouncement');
   if (liveRegion) {
+    // Cancel any pending clear so a previous announcement's timeout
+    // doesn't blank this one before the screen reader can read it.
     clearTimeout(pendingClearTimeout);
 
     // Clear and re-set to ensure the announcement fires even with same text

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -12,16 +12,20 @@
 
 const ANNOUNCEMENT_DURATION_MS = 1000;
 
+let pendingClearTimeout = 0;
+
 export function announceToScreenReader(shadowRoot, text) {
   const liveRegion = shadowRoot.querySelector('#srAnnouncement');
   if (liveRegion) {
+    clearTimeout(pendingClearTimeout);
+
     // Clear and re-set to ensure the announcement fires even with same text
     liveRegion.textContent = '';
     requestAnimationFrame(() => {
       liveRegion.textContent = text;
 
       // Clear after the announcement so VoiceOver cannot swipe to stale text
-      setTimeout(() => {
+      pendingClearTimeout = setTimeout(() => {
         liveRegion.textContent = '';
       }, ANNOUNCEMENT_DURATION_MS);
     });

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -14,7 +14,7 @@ const ANNOUNCEMENT_DURATION_MS = 1000;
 
 // Tracks the clear-after-announce timeout per shadowRoot so simultaneous
 // announcements from different components don't cancel each other.
-// A Map (rather than a single module-level variable) is needed because
+// A WeakMap (rather than a single module-level variable) is needed because
 // ES modules are singletons — a shared variable would let a rapid call from
 // one component cancel another component's pending clear, leaving stale text
 // in the first component's live region.

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -18,7 +18,7 @@ const ANNOUNCEMENT_DURATION_MS = 1000;
 // ES modules are singletons — a shared variable would let a rapid call from
 // one component cancel another component's pending clear, leaving stale text
 // in the first component's live region.
-const pendingClearTimeouts = new Map();
+const pendingClearTimeouts = new WeakMap();
 
 export function announceToScreenReader(shadowRoot, text) {
   const liveRegion = shadowRoot.querySelector('#srAnnouncement');


### PR DESCRIPTION
# Alaska Airlines Pull Request

This PR fixes several small bugs and accessibility issues across multiple components: it corrects the reactive submit button tracking in auro-form (and adds a test), strengthens dropdown dialog overflow handling and label accessibility, improves menu ARIA attributes for multi-select, stabilizes screen reader announcements, adjusts combobox keyboard behavior, fixes a counter ARIA-valuetext bug, and cleans up minor demo/storybook issues.

## Summary
- **counter**: Remove stray quotes wrapping `aria-valuetext` value, fixing the attribute from rendering as a literal `'N'` string
- **dropdown**: Wrap `dialog.showModal()` in try/finally to guarantee overflow style is restored; remove redundant `aria-hidden` from `dialogLabel` span (already visually hidden via CSS class)
- **form**: Fix `_submitElements` property casing (`_submitelements` → `_submitElements`) so LitElement reactivity works correctly; fix extra quotation mark in demo HTML
- **combobox**: Stop event propagation when showing bib to prevent unintended side effects
- **menu**: Sync `aria-multiselectable` attribute with `multiSelect` property changes
- **a11y utils**: Clear pending timeout before scheduling a new announcement to prevent stale text
- **radio stories**: Rename Checkbox references to Radio for consistency; use `auro-radio-group` in storybook helpers

## Test plan
- [x] Verify `auro-counter` `aria-valuetext` no longer contains wrapping quotes (inspect DOM)
  - Previously it rendered `aria-valuetext="'2'"` now it renders `aria-valuetext="2"`
- [x] Confirm dropdown modal opens/closes without leaving `overflow: hidden` on the document
  - Defensive fix. Confirmed `overflow: hidden` is removed from `body`. However, this fix only matters if `showModal()` throws an exception (calling it on an already-open dialog, etc). Without the `try/finally`, the overflow restore line would be skipped and the page would be stuck with `overflow: hidden`.
- [x] Confirm `auro-form` submit button enables/disables correctly (new test added in `auro-form.test.js`)
  - Filled out all fields in [form](https://alaskaairlines.github.io/auro-formkit/pr-preview/pr-1369/form/api.html), noted `submit` button activates. Removed a field and noted `submit` button disables.
- [X] Verify combobox bib `show` does not propagate keyboard events
  - Verified no regressions with keyboard events & created a new unit test
- [x] Verify `auro-menu` sets `aria-multiselectable="true"` when `multiSelect` is enabled
  - Noted `aria-multiselectable="true"` is present on the `<auro-menu>` in the multi-select [Docsite example](https://alaskaairlines.github.io/auro-formkit/pr-preview/pr-1369/menu/api.html). Created a new test as well.
- [x] Run existing test suites for affected components

## Linked issues
Closes #1358, #1359, #1360, #1361, #1363, #1364, #1365, #1366, #1367, #1368

## Review Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Align form, dropdown, menu, combobox, counter, and radio components with accessibility and behavior expectations while fixing minor regressions and demo issues.

Bug Fixes:
- Ensure auro-form submitElements uses the correctly cased reactive property so submit buttons are tracked and exposed properly.
- Restore documentElement overflow style even if dialog.showModal throws in auro-dropdownBib.
- Prevent VoiceOver from reading stale screen reader announcements by tracking and clearing the live region timeout before scheduling a new one.
- Prevent default handling and propagation for Enter key presses on the combobox clear button so the bib opens predictably.
- Fix aria-valuetext on auro-counter to expose the current numeric value correctly to assistive technologies.
- Correct the dialog label span in auro-dropdownBib to avoid hiding the accessible label from screen readers.
- Fix extra quote typo in auro-form demo markup that could break the example.
- Rename the radio Storybook playground story from Checkbox to Radio for accurate labeling.

Enhancements:
- Add ARIA multiselectable attribute management to auro-menu when multiSelect is toggled.
- Add a test confirming auro-form uses the reactive _submitElements property to expose submitElements.

Tests:
- Add a regression test to verify auro-form.submitElements is populated via the reactive _submitElements property.

## Summary by Sourcery

Fix accessibility and interaction issues across form, dropdown, combobox, menu, counter, and radio components while tightening related utilities and demos.

Bug Fixes:
- Ensure auro-form tracks and exposes submit buttons via the correct reactive submitElements property.
- Guarantee document overflow styles are restored after opening the dropdown dialog and expose the dialog label to screen readers.
- Prevent combobox Enter key handling from propagating to parent containers while opening the bib programmatically.
- Expose the correct numeric value via aria-valuetext on auro-counter for assistive technologies.
- Prevent stale screen reader announcements by clearing any pending live region timeout before scheduling a new one.
- Stabilize screen reader announcement tests by extending timeouts to cover chained announcements.
- Fix a stray quote in the auro-form working demo markup.

Enhancements:
- Sync the aria-multiselectable attribute on auro-menu with the multiSelect property so assistive tech understands multi-select behavior.
- Rename the radio Storybook playground story to accurately reflect the Radio component.

Tests:
- Add a regression test validating auro-form.submitElements is populated via the reactive _submitElements property.
- Add a combobox test ensuring Enter key events do not bubble when opening the bib.
- Add menu tests verifying aria-multiselectable is added and removed when multiSelect is toggled.
- Adjust combobox and select announceToScreenReader tests to account for chained announcements and cleanup timing.