### PR TITLE
chore: update auro-library to version 5.11.2 AB#1494298

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@aurodesignsystem/auro-accordion": "^6.1.1",
         "@aurodesignsystem/auro-button": "^12.3.2",
-        "@aurodesignsystem/auro-library": "^5.11.1",
+        "@aurodesignsystem/auro-library": "^5.11.2",
         "@aurodesignsystem/auro-loader": "^6.2.0",
         "@aurodesignsystem/build-tools": "*",
         "@aurodesignsystem/config": "*",
@@ -962,9 +962,9 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.11.1.tgz",
-      "integrity": "sha512-HsOlm5l4Sn2WLUFDiF23SOaAV0V6/U7VNsDnclGRNWf/uuEbyDbyD2S4zTeM5NpqixYrsYqo7CKwOsqFgfQDhQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.11.2.tgz",
+      "integrity": "sha512-IWGEgiRY+KPQM96Vh7MhbFirNVvOT1i+H4YYD8+CXQG44qEVyWse7oOWnDEEbiN1XjLu2TjdvbAoS19h9Gqq4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@aurodesignsystem/auro-accordion": "^6.1.1",
     "@aurodesignsystem/auro-button": "^12.3.2",
-    "@aurodesignsystem/auro-library": "^5.11.1",
+    "@aurodesignsystem/auro-library": "^5.11.2",
     "@aurodesignsystem/build-tools": "*",
     "@aurodesignsystem/config": "*",
     "@aurodesignsystem/design-tokens": "^8.15.1",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Relates to https://github.com/AlaskaAirlines/auro-library/pull/237

When a `noToggle` dropdown is open on a page with other dropdowns, interacting with the other dropdowns' triggers fails — they won't open or close. A second click is required.

## Summary

- Narrowed the `noToggle` guard in `hideBib()` so it only blocks click-triggered closes — Escape key, focus loss, mouse leave, and other-dropdown-opening still work
- Moved `document.expandedAuroFloater = null` inside the guard so the global reference is only cleared when the bib actually closes, preventing state corruption

### Root cause

Two bugs in `hideBib()`:

1. **The `noToggle` guard is too broad.** `!this.element.noToggle` blocks ALL hide attempts, but `noToggle` only means "the trigger click should not toggle the bib closed." Other close methods (Escape, focus loss, another dropdown opening) should still work.

2. **`document.expandedAuroFloater = null` runs unconditionally.** Even when `hideBib()` is blocked by the `noToggle` guard (the bib stays open), the global singleton reference is cleared. Subsequent dropdowns can't detect that the `noToggle` dropdown is still open, breaking coordination.

### Reproduction steps

1. Go to the [dropdown API docs page](https://auro.alaskaair.com/components/auro/dropdown/api)
2. Open the "No Toggle" example by clicking its trigger
3. Click the same trigger again (bib stays open — correct)
4. Click a different dropdown's trigger
5. **Bug:** The other dropdown receives focus but does not open — a second click is required

## Changes

Updates `auro-library`from https://github.com/AlaskaAirlines/auro-library/pull/237 which includes the change.

## Test plan

- [x] noToggle dropdown opens on first trigger click
- [x] noToggle dropdown stays open on second trigger click
- [x] noToggle dropdown closes on Escape key
- [x] noToggle dropdown closes on focus loss
- [x] noToggle dropdown does NOT prevent other dropdowns from opening/closing
- [x] Other dropdowns opening causes the noToggle dropdown to close
- [x] Standard (non-noToggle) dropdowns are unaffected

https://github.com/user-attachments/assets/f99f8b73-ec8f-45df-b0fa-3535d6a54558

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Align development dependencies with auro-library v5.11.2.

## Summary by Sourcery

Build:
- Bump @aurodesignsystem/auro-library devDependency from 5.11.1 to 5.11.2 to pick up the latest dropdown behavior fixes.