### PR TITLE
test(combobox): add tests for active index when bib opens

### DIFF
--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -342,6 +342,23 @@ function runFulltest(mobileview) {
     await expect(el.dropdown.isPopoverVisible).to.be.false;
   });
 
+  it('sets first menu option as active when dropdown opens without a selection', async () => {
+    const el = await defaultFixture(mobileview);
+    const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
+
+    // Simulate dropdown opening with no value set
+    el.dropdown.dispatchEvent(new CustomEvent('auroDropdown-toggled', {
+      detail: { expanded: true }
+    }));
+
+    // Wait for the 150ms expandedDelay to elapse
+    await new Promise((r) => setTimeout(r, 200));
+    await elementUpdated(el);
+
+    await expect(el.optionActive).to.equal(menuOptions[0]);
+    await expect(el.menu.index).to.equal(0);
+  });
+
   it('navigates menu with up and down arrow keys', async () => {
     const el = await defaultFixture(mobileview);
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add test coverage for combobox active option behavior when the dropdown opens with and without a preselected value.

Tests:
- Add a test asserting the first menu option becomes active when the dropdown opens without an existing selection.
- Add a test asserting no option becomes active when the dropdown opens with an existing selected value.