### PR TITLE
fix(combobox): prevent ArrowUp and ArrowDown actions when clear butto…

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -75,6 +75,7 @@ export class AuroCombobox extends AuroElement {
     this.value = undefined;
     this.typedValue = undefined;
     this.behavior = "suggestion";
+    this.clearBtnFocused = false;
 
     // Defaults that effect the overall layout of the combobox
     this.checkmark = false;
@@ -1032,6 +1033,21 @@ export class AuroCombobox extends AuroElement {
     this.addEventListener('focusout', () => {
       if (!this.componentHasFocus && !this._inFullscreenTransition) {
         this.validate();
+      }
+    });
+
+    /**
+     * Track focus on the clear button within the input.
+     * This is used to prevent unwanted interactions when the clear button is focused.
+     *
+     * Use event delegation on the shadow root so the listener works regardless
+     * of when .clearBtn is rendered (it only exists after a value is set).
+     */
+    this.input.shadowRoot.addEventListener('focusin', (event) => {
+      if (event.target.closest('.clearBtn')) {
+        this.clearBtnFocused = true;
+      } else {
+        this.clearBtnFocused = false;
       }
     });
   }

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -97,6 +97,11 @@ export const comboboxKeyboardStrategy = {
   },
 
   ArrowUp(component, evt) {
+    // If the clear button has focus, let the browser handle ArrowUp normally
+    if (component.clearBtnFocused) {
+      return;
+    }
+
     if (component.availableOptions.length > 0) {
       component.showBib();
     }
@@ -107,6 +112,11 @@ export const comboboxKeyboardStrategy = {
   },
 
   ArrowDown(component, evt) {
+    // If the clear button has focus, let the browser handle ArrowDown normally
+    if (component.clearBtnFocused) {
+      return;
+    }
+
     if (component.availableOptions.length > 0) {
       component.showBib();
     }


### PR DESCRIPTION
…n is focused [AB#1516624](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1516624)

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Prevent combobox keyboard navigation from triggering when the input’s clear button is focused.

Bug Fixes:
- Ignore ArrowUp and ArrowDown combobox behaviors when the clear button inside the input has focus to avoid unintended option navigation.

Enhancements:
- Track focus state of the input’s clear button via delegated focus handling on the shadow root to support context-aware keyboard behavior.