### PR TITLE
fix(datepicker): remove readonly attr on inputs AB#1516622

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -912,7 +912,7 @@ export class AuroDatePicker extends AuroElement {
           guardTouchPassthrough(this.shadowRoot.querySelector('.calendarWrapper'));
         }
       } else {
-        restoreTriggerAfterClose(this.dropdown, this.dropdown.trigger);
+        restoreTriggerAfterClose(this.dropdown, this.inputList[0]);
       }
 
       // If on mobile, and the calendar is opened, scroll the focus date into view if the flag is set
@@ -966,12 +966,10 @@ export class AuroDatePicker extends AuroElement {
 
     this.inputList = [...this.dropdown.querySelectorAll(this.inputTag._$litStatic$)];
 
-    this.handleReadOnly();
-
     this.inputList.forEach((input, index) => {
       // auto-show bib when manually editing the input value
       input.addEventListener('keyup', (evt) => {
-        if (evt.key.length === 1 || evt.key === 'Delete' || evt.key === 'Backspace') {
+        if (evt.key === " ") {
           this.dropdown.show();
         }
       });
@@ -1100,28 +1098,6 @@ export class AuroDatePicker extends AuroElement {
     if (this.dropdown && !this.dropdown.isPopoverVisible) {
       this.dropdown.show();
     }
-  }
-
-  /**
-   * Sets the readonly attribute on the inputs based on the window width.
-   * @private
-   * @returns {void}
-   */
-  handleReadOnly() {
-    // --ds-grid-breakpoint-sm
-    const docStyle = getComputedStyle(document.documentElement);
-
-    // We need to store this so that we can pass it to calendar
-    this.mobileBreakpoint = Number(docStyle.getPropertyValue('--ds-grid-breakpoint-sm').replace("px", ""));
-    const isMobile = window.innerWidth < this.mobileBreakpoint;
-
-    this.inputList.forEach((input) => {
-      if (isMobile) {
-        input.setAttribute('readonly', true);
-      } else {
-        input.removeAttribute('readonly');
-      }
-    });
   }
 
   /**
@@ -1543,10 +1519,6 @@ export class AuroDatePicker extends AuroElement {
     this.configureCalendar();
     this.configureDatepicker();
     this.configureClickHandler();
-
-    window.addEventListener('resize', () => {
-      this.handleReadOnly();
-    });
   }
 
   connectedCallback() {

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -811,7 +811,7 @@ describe('auro-datepicker', () => {
     await expect(centralAfterAgain).to.contain('01/01/2024');
   });
 
-  it('shows dropdown when user is typing in input', async () => {
+  it('does not show dropdown when user is typing in input', async () => {
     const el = await fixture(html`
       <auro-datepicker></auro-datepicker>
     `);
@@ -819,6 +819,20 @@ describe('auro-datepicker', () => {
     const input = getInput(el, 0);
 
     input.dispatchEvent(new KeyboardEvent('keyup', { key: '0' }));
+
+    await elementUpdated(el);
+
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
+  });
+
+  it('shows dropdown when user press space', async () => {
+    const el = await fixture(html`
+      <auro-datepicker></auro-datepicker>
+    `);
+
+    const input = getInput(el, 0);
+
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
 
     await elementUpdated(el);
 

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -101,11 +101,9 @@ export function guardTouchPassthrough(element) {
 export function restoreTriggerAfterClose(dropdown, focusTarget) {
   dropdown.trigger.inert = false;
 
-  if (dropdown.isBibFullscreen) {
-    requestAnimationFrame(() => {
-      if (!dropdown.isPopoverVisible) {
-        focusTarget.focus();
-      }
-    });
-  }
+  requestAnimationFrame(() => {
+    if (!dropdown.isPopoverVisible) {
+      focusTarget.focus();
+    }
+  });
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Not to make inputs readonly on mobile width [AB#1516622](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1516622)
Only Space key opens bib [AB#1516622](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1516622)

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adjust datepicker input behavior and focus management to improve accessibility and interaction on both mobile and desktop.

Bug Fixes:
- Ensure focus is restored to the appropriate datepicker input after the dropdown closes, regardless of fullscreen mode.
- Stop automatically focusing the input when clicking within the datepicker layout if the event occurs inside the dropdown content.

Enhancements:
- Allow users to open the datepicker dropdown from the input using the Space key instead of triggering on any typing, reducing unintended openings.
- Remove responsive logic that set datepicker inputs to readonly on smaller viewports so inputs remain editable on mobile devices.

Tests:
- Update and extend datepicker keyboard-interaction tests to cover the new Space-key behavior and ensure the dropdown does not open on arbitrary typing.