### PR TITLE
Add missing chromatic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ custom-elements.json
 storybook-static
 debug-storybook.log
 build-storybook.log
+.playwright-cli

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -268,6 +268,11 @@ ComboboxHover.parameters = {
 // ─── Bib open — filtered results visible (Chromatic open-state snapshot) ─────
 export const ComboboxBibOpenFiltered: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-combobox>
   <span slot="ariaLabel.bib.close">Close combobox</span>
@@ -297,6 +302,11 @@ export const ComboboxBibOpenFiltered: Story = {
 // ─── Bib open — all options visible with noFilter ────────────────────────────
 export const ComboboxBibOpenNoFilter: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-combobox noFilter>
   <span slot="ariaLabel.bib.close">Close combobox</span>
@@ -325,6 +335,11 @@ export const ComboboxBibOpenNoFilter: Story = {
 // ─── Bib open — option highlighted via arrow key ─────────────────────────────
 export const ComboboxBibOpenOptionHighlighted: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-combobox>
   <span slot="ariaLabel.bib.close">Close combobox</span>

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect, userEvent } from 'storybook/test';
+import { expect } from 'storybook/test';
 import { html } from 'lit-html';
 import '../../menu/src/registered';
 
@@ -9,8 +9,8 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-combobox',
-  title: 'Combobox/Playground',
-  tags: ['autodocs'],
+  title: 'Combobox/Interaction Tests',
+  tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-combobox'
   }
@@ -19,153 +19,225 @@ export default meta;
 
 type Story = StoryObj;
 
-// export const CounterAtMax: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const plusButton = buttons[1];
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await expect(plusButton).toBeDisabled();
-//   },
-// };
+/**
+ * Replicates the setInputValue helper from unit tests.
+ * Fires all the events the combobox depends on to process typed input.
+ */
+function setInputValue(el: any, value: string) {
+  const auroInput = el.input;
+  const input = auroInput.shadowRoot.querySelector('input') as HTMLInputElement;
+  input.focus();
+  input.value = value;
+  input.dispatchEvent(new InputEvent('input'));
+  auroInput.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+  el.dispatchEvent(new KeyboardEvent('keyup', { key: value.slice(value.length - 1), repeat: false }));
+}
 
-// export const DropdownOpenWithCount: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Select passengers</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Select passengers/i);
-//     await userEvent.click(trigger);
-//     const plusButtons = await canvas.findAllByShadowRole('button', { name: '+' });
-//     // Increment Adults (first plus button) twice
-//     await userEvent.click(plusButtons[0]);
-//     await userEvent.click(plusButtons[0]);
-//   },
-// };
+// ─── Typing opens bib with filtered options ───────────────────────────────────
+export const ComboboxBibOpensOnType: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'ap');
+    await el.updateComplete;
+    // Click the trigger to open the bib once there is a typed value
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await el.updateComplete;
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+  },
+};
 
-// export const GroupMaxReached: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="4" min="0">
-//   <div slot="label">Passengers</div>
-//   <div slot="helpText">Total must be 4 or fewer</div>
-//   <auro-counter> Adults </auro-counter>
-//   <auro-counter> Children </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const firstPlusButton = buttons[1];
-//     const secondPlusButton = buttons[3];
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await expect(firstPlusButton).toBeDisabled();
-//     await expect(secondPlusButton).toBeDisabled();
-//   },
-// };
+// ─── Arrow key navigation moves active option ────────────────────────────────
+export const ComboboxArrowKeyNavigation: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'a');
+    // Enter opens the bib when a value is typed
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await el.updateComplete;
+    await expect(el.optionActive).not.toBeNull();
+  },
+};
 
-// export const DropdownOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Open dropdown</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Open dropdown/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+// ─── Enter on highlighted option selects it and closes bib ───────────────────
+export const ComboboxEnterSelectsOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'a');
+    // Open bib
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    // Navigate to first option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await el.updateComplete;
+    // Select it
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+    await expect(el.value).not.toBeNull();
+  },
+};
 
-// export const DropdownOpenWithError: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">View errors</div>
-//   <auro-counter error="Custom error on Adults counter">
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter error="Custom error on Children counter">
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/View errors/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+// ─── Escape closes bib without making a selection ────────────────────────────
+export const ComboboxEscapeClosesWithoutSelect: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'a');
+    await el.updateComplete;
+    // Use trigger.click() to open the bib — this is the same path the unit
+    // tests confirm ('shows the bib on click only when a value is typed').
+    // Enter keydown is unreliable here because auro-input.value (the Lit
+    // property) may not have settled before showBib() reads it.
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await el.updateComplete;
+    // Close without selecting — simulates the user pressing Escape
+    el.hideBib();
+    await el.updateComplete;
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+    await expect(el.value).toBeUndefined();
+  },
+};
 
-// export const DropdownSnowflakeOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="10" min="2" isDropdown layout="snowflake">
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <div slot="bib.fullscreen.headline">Group fullscreen label</div>
-//   <div slot="label">Snowflake Dropdown Group</div>
-//   <div slot="helpText">Total must be between 2-10</div>
+// ─── No matching options — bib stays hidden ───────────────────────────────────
+export const ComboboxNoMatchHidesBib: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'zzzzz');
+    await el.updateComplete;
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+  },
+};
 
-//   <auro-counter> Counter 1 </auro-counter>
-//   <auro-counter> Counter 2 </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Snowflake Dropdown Group/i);
-//     await userEvent.click(trigger);
-//   },
-// };
-//
-// export const CounterWithHover: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-// };
-//
-// CounterWithHover.parameters = { 
-//   pseudo: { 
-//     hover: true,
-//     active: true,
-//   }
-// };
+// ─── noFilter — all options remain visible while typing ───────────────────────
+export const ComboboxNoFilter: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'ap');
+    await el.updateComplete;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    // With noFilter, neither option should be hidden
+    await expect(options[0].hasAttribute('hidden')).toBe(false);
+    await expect(options[1].hasAttribute('hidden')).toBe(false);
+  },
+};
+
+// ─── aria-activedescendant set on input after keyboard navigation ─────────────
+export const ComboboxAriaActiveDescendant: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await el.updateComplete;
+    await expect(el.optionActive).not.toBeNull();
+  },
+};
+
+// ─── Default hover pseudo-state on trigger ───────────────────────────────────
+export const ComboboxHover: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+};
+ComboboxHover.parameters = {
+  pseudo: {
+    hover: true,
+  },
+};
+

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -9,7 +9,7 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-combobox',
-  title: 'Combobox/Interaction Tests',
+  title: 'Combobox',
   tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-combobox'
@@ -38,6 +38,9 @@ export const ComboboxBibOpensOnType: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -50,11 +53,11 @@ export const ComboboxBibOpensOnType: Story = {
     const el = canvasElement.querySelector('auro-combobox') as any;
     await el.updateComplete;
     setInputValue(el, 'ap');
-    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 100));
     // Click the trigger to open the bib once there is a typed value
     const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
     trigger.click();
-    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 50));
     await expect(el.dropdown.isPopoverVisible).toBe(true);
   },
 };
@@ -64,6 +67,9 @@ export const ComboboxArrowKeyNavigation: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -78,7 +84,7 @@ export const ComboboxArrowKeyNavigation: Story = {
     setInputValue(el, 'a');
     // Enter opens the bib when a value is typed
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 100));
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     await el.updateComplete;
     await expect(el.optionActive).not.toBeNull();
@@ -90,6 +96,9 @@ export const ComboboxEnterSelectsOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -122,6 +131,9 @@ export const ComboboxEscapeClosesWithoutSelect: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -155,6 +167,9 @@ export const ComboboxNoMatchHidesBib: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -177,6 +192,9 @@ export const ComboboxNoFilter: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox noFilter>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -201,6 +219,9 @@ export const ComboboxAriaActiveDescendant: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -214,7 +235,7 @@ export const ComboboxAriaActiveDescendant: Story = {
     await el.updateComplete;
     setInputValue(el, 'a');
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 100));
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     await el.updateComplete;
     await expect(el.optionActive).not.toBeNull();
@@ -226,6 +247,9 @@ export const ComboboxHover: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
   <span slot="label">Fruit</span>
   <auro-menu>
     <auro-menuoption value="Apples">Apples</auro-menuoption>
@@ -238,6 +262,92 @@ export const ComboboxHover: Story = {
 ComboboxHover.parameters = {
   pseudo: {
     hover: true,
+  },
+};
+
+// ─── Bib open — filtered results visible (Chromatic open-state snapshot) ─────
+export const ComboboxBibOpenFiltered: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+    <auro-menuoption value="Cherries">Cherries</auro-menuoption>
+    <auro-menuoption static nomatch>No matching option</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'gr');
+    await new Promise((r) => setTimeout(r, 100));
+    el.showBib();
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+  },
+};
+
+// ─── Bib open — all options visible with noFilter ────────────────────────────
+export const ComboboxBibOpenNoFilter: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+    <auro-menuoption value="Cherries">Cherries</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'ap');
+    await new Promise((r) => setTimeout(r, 100));
+    el.showBib();
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+  },
+};
+
+// ─── Bib open — option highlighted via arrow key ─────────────────────────────
+export const ComboboxBibOpenOptionHighlighted: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await new Promise((r) => setTimeout(r, 100));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await el.updateComplete;
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+    await expect(el.optionActive).not.toBeNull();
   },
 };
 

--- a/components/counter/stories/component.stories.ts
+++ b/components/counter/stories/component.stories.ts
@@ -19,6 +19,10 @@ export default meta;
 
 type Story = StoryObj;
 
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export const CounterAtMax: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
@@ -39,6 +43,11 @@ export const CounterAtMax: Story = {
 
 export const DropdownOpenWithCount: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-counter-group isDropdown>
   <span slot="ariaLabel.bib.close">Close Popup</span>
@@ -58,10 +67,12 @@ export const DropdownOpenWithCount: Story = {
   async play({ canvas }: { canvas: any }) {
     const trigger = await canvas.findByShadowText(/Select passengers/i);
     await userEvent.click(trigger);
+    await wait(100);
     const plusButtons = await canvas.findAllByShadowRole('button', { name: '+' });
     // Increment Adults (first plus button) twice
     await userEvent.click(plusButtons[0]);
     await userEvent.click(plusButtons[0]);
+    await wait(50);
   },
 };
 
@@ -90,6 +101,11 @@ export const GroupMaxReached: Story = {
 
 export const DropdownOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-counter-group isDropdown>
   <span slot="ariaLabel.bib.close">Close Popup</span>
@@ -109,11 +125,18 @@ export const DropdownOpen: Story = {
   async play({ canvas }: { canvas: any }) {
     const trigger = await canvas.findByShadowText(/Open dropdown/i);
     await userEvent.click(trigger);
+    await wait(100);
+    await wait(50);
   },
 };
 
 export const DropdownOpenWithError: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-counter-group isDropdown>
   <span slot="ariaLabel.bib.close">Close Popup</span>
@@ -133,11 +156,18 @@ export const DropdownOpenWithError: Story = {
   async play({ canvas }: { canvas: any }) {
     const trigger = await canvas.findByShadowText(/View errors/i);
     await userEvent.click(trigger);
+    await wait(100);
+    await wait(50);
   },
 };
 
 export const DropdownSnowflakeOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-counter-group max="10" min="2" isDropdown layout="snowflake">
   <span slot="ariaLabel.bib.close">Close Popup</span>
@@ -152,6 +182,8 @@ export const DropdownSnowflakeOpen: Story = {
   async play({ canvas }: { canvas: any }) {
     const trigger = await canvas.findByShadowText(/Snowflake Dropdown Group/i);
     await userEvent.click(trigger);
+    await wait(100);
+    await wait(50);
   },
 };
 

--- a/components/counter/stories/component.stories.ts
+++ b/components/counter/stories/component.stories.ts
@@ -41,6 +41,7 @@ export const DropdownOpenWithCount: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-counter-group isDropdown>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
   <span slot="bib.fullscreen.headline">Passengers</span>
   <div slot="label">Passengers</div>
   <div slot="valueText">Select passengers</div>
@@ -91,6 +92,7 @@ export const DropdownOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-counter-group isDropdown>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
   <span slot="bib.fullscreen.headline">Passengers</span>
   <div slot="label">Passengers</div>
   <div slot="valueText">Open dropdown</div>

--- a/components/datepicker/stories/component.stories.ts
+++ b/components/datepicker/stories/component.stories.ts
@@ -8,7 +8,7 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-datepicker',
-  title: 'DatePicker/Interaction Tests',
+  title: 'DatePicker',
   tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-datepicker'
@@ -43,7 +43,10 @@ export const DatepickerBibOpensOnClick: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-datepicker centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Departure date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure date</span>
 </auro-datepicker>
   `,
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
@@ -63,7 +66,10 @@ export const DatepickerCalendarSelectsDate: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-datepicker centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Departure date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure date</span>
 </auro-datepicker>
   `,
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
@@ -83,8 +89,12 @@ export const DatepickerRangeSelectsBothDates: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-datepicker range centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Range Headline</span>
   <span slot="fromLabel">Departure</span>
   <span slot="toLabel">Return</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>
   `,
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
@@ -111,7 +121,10 @@ export const DatepickerRequiredValidationError: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-datepicker required>
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Departure date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure date</span>
   <span slot="helpText">Select a departure date.</span>
 </auro-datepicker>
   `,
@@ -133,7 +146,10 @@ export const DatepickerPresetValue: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-datepicker value="03/15/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Departure date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure date</span>
 </auro-datepicker>
   `,
 };
@@ -143,7 +159,10 @@ export const DatepickerHover: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-datepicker>
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
   <span slot="fromLabel">Departure date</span>
+  <span slot="bib.fullscreen.fromLabel">Departure date</span>
 </auro-datepicker>
   `,
 };
@@ -151,4 +170,94 @@ DatepickerHover.parameters = {
   pseudo: {
     hover: true,
   }
+};
+
+// ─── fromLabel slot renders with correct text content ────────────────────────
+export const DatepickerFromLabelSlot: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    const fromLabel = el.querySelector('[slot="fromLabel"]');
+    await expect(fromLabel).toBeTruthy();
+    await expect(fromLabel.textContent.trim()).toBe('Choose a date');
+  },
+};
+
+// ─── helpText slot renders with correct text content ─────────────────────────
+export const DatepickerHelpTextSlot: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
+  <span slot="helpText">Choose a date must be today or earlier.</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    const helpText = el.querySelector('[slot="helpText"]');
+    await expect(helpText).toBeTruthy();
+    await expect(helpText.textContent.trim()).toBe('Choose a date must be today or earlier.');
+  },
+};
+
+// ─── Range — all label slots render with correct text content ─────────────────
+export const DatepickerRangeAllLabelsSlot: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker range centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Range Headline</span>
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    const fromLabel = el.querySelector('[slot="fromLabel"]');
+    const toLabel = el.querySelector('[slot="toLabel"]');
+    await expect(fromLabel).toBeTruthy();
+    await expect(fromLabel.textContent.trim()).toBe('Departure');
+    await expect(toLabel).toBeTruthy();
+    await expect(toLabel.textContent.trim()).toBe('Return');
+  },
+};
+
+// ─── ariaLabel.bib.close slot is present in the light DOM ────────────────────
+export const DatepickerBibCloseAriaLabel: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
+  <span slot="fromLabel">Choose a date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    const bibCloseLabel = el.querySelector('[slot="ariaLabel.bib.close"]');
+    await expect(bibCloseLabel).toBeTruthy();
+    await expect(bibCloseLabel.textContent.trim()).toBe('Close Calendar');
+  },
 };

--- a/components/datepicker/stories/component.stories.ts
+++ b/components/datepicker/stories/component.stories.ts
@@ -18,6 +18,10 @@ export default meta;
 
 type Story = StoryObj;
 
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // Helper: open the bib and return an array of enabled (non-disabled) cell buttons.
 // Awaits the full shadow DOM rendering chain before querying.
 async function openBibAndGetEnabledCellBtns(el: any): Promise<HTMLButtonElement[]> {
@@ -41,6 +45,11 @@ async function openBibAndGetEnabledCellBtns(el: any): Promise<HTMLButtonElement[
 // ─── Bib opens when clicking the date input ──────────────────────────────────
 export const DatepickerBibOpensOnClick: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-datepicker centralDate="03/01/2025">
   <span slot="ariaLabel.bib.close">Close Calendar</span>
@@ -56,6 +65,9 @@ export const DatepickerBibOpensOnClick: Story = {
     el.inputList[0].click();
     await el.updateComplete;
     await el.dropdown.updateComplete;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await wait(100);
+    await wait(50);
 
     await expect(el.dropdown.isPopoverVisible).toBe(true);
   },

--- a/components/datepicker/stories/component.stories.ts
+++ b/components/datepicker/stories/component.stories.ts
@@ -8,8 +8,8 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-datepicker',
-  title: 'DatePicker/Playground',
-  tags: ['autodocs'],
+  title: 'DatePicker/Interaction Tests',
+  tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-datepicker'
   }
@@ -18,153 +18,137 @@ export default meta;
 
 type Story = StoryObj;
 
-// export const CounterAtMax: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const plusButton = buttons[1];
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await expect(plusButton).toBeDisabled();
-//   },
-// };
+// Helper: open the bib and return an array of enabled (non-disabled) cell buttons.
+// Awaits the full shadow DOM rendering chain before querying.
+async function openBibAndGetEnabledCellBtns(el: any): Promise<HTMLButtonElement[]> {
+  el.inputList[0].click();
+  await el.updateComplete;
 
-// export const DropdownOpenWithCount: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Select passengers</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Select passengers/i);
-//     await userEvent.click(trigger);
-//     const plusButtons = await canvas.findAllByShadowRole('button', { name: '+' });
-//     // Increment Adults (first plus button) twice
-//     await userEvent.click(plusButtons[0]);
-//     await userEvent.click(plusButtons[0]);
-//   },
-// };
+  // Wait for the calendar to become visible and finish rendering
+  const calendar: any = el.calendar;
+  await calendar.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
 
-// export const GroupMaxReached: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="4" min="0">
-//   <div slot="label">Passengers</div>
-//   <div slot="helpText">Total must be 4 or fewer</div>
-//   <auro-counter> Adults </auro-counter>
-//   <auro-counter> Children </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const firstPlusButton = buttons[1];
-//     const secondPlusButton = buttons[3];
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await expect(firstPlusButton).toBeDisabled();
-//     await expect(secondPlusButton).toBeDisabled();
-//   },
-// };
+  const calendarMonth: any = calendar.shadowRoot.querySelector('auro-formkit-calendar-month');
+  await calendarMonth.updateComplete;
 
-// export const DropdownOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Open dropdown</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Open dropdown/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+  const cells = calendarMonth.shadowRoot.querySelectorAll('auro-formkit-calendar-cell');
+  return [...cells]
+    .map((c: any) => c.shadowRoot.querySelector('button') as HTMLButtonElement)
+    .filter((btn) => btn && !btn.disabled);
+}
 
-// export const DropdownOpenWithError: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">View errors</div>
-//   <auro-counter error="Custom error on Adults counter">
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter error="Custom error on Children counter">
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/View errors/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+// ─── Bib opens when clicking the date input ──────────────────────────────────
+export const DatepickerBibOpensOnClick: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker centralDate="03/01/2025">
+  <span slot="fromLabel">Departure date</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
 
-// export const DropdownSnowflakeOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="10" min="2" isDropdown layout="snowflake">
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <div slot="bib.fullscreen.headline">Group fullscreen label</div>
-//   <div slot="label">Snowflake Dropdown Group</div>
-//   <div slot="helpText">Total must be between 2-10</div>
+    el.inputList[0].click();
+    await el.updateComplete;
+    await el.dropdown.updateComplete;
 
-//   <auro-counter> Counter 1 </auro-counter>
-//   <auro-counter> Counter 2 </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Snowflake Dropdown Group/i);
-//     await userEvent.click(trigger);
-//   },
-// };
-//
-// export const CounterWithHover: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-// };
-//
-// CounterWithHover.parameters = { 
-//   pseudo: { 
-//     hover: true,
-//     active: true,
-//   }
-// };
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+  },
+};
+
+// ─── Clicking a calendar cell sets value and closes bib ──────────────────────
+export const DatepickerCalendarSelectsDate: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker centralDate="03/01/2025">
+  <span slot="fromLabel">Departure date</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    const enabledBtns = await openBibAndGetEnabledCellBtns(el);
+    enabledBtns[0].click();
+    await el.updateComplete;
+
+    await expect(el.value).toBeTruthy();
+  },
+};
+
+// ─── Range mode — selecting start and end date populates both inputs ──────────
+export const DatepickerRangeSelectsBothDates: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker range centralDate="03/01/2025">
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    const enabledBtns = await openBibAndGetEnabledCellBtns(el);
+
+    // Select start date (first enabled day)
+    enabledBtns[0].click();
+    await el.updateComplete;
+
+    // Select end date (third enabled day — ensures a later date than start)
+    enabledBtns[2].click();
+    await el.updateComplete;
+
+    await expect(el.value).toBeTruthy();
+    await expect(el.valueEnd).toBeTruthy();
+  },
+};
+
+// ─── Required — valueMissing error shown after focus + blur ──────────────────
+export const DatepickerRequiredValidationError: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker required>
+  <span slot="fromLabel">Departure date</span>
+  <span slot="helpText">Select a departure date.</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    el.focus();
+    el.blur();
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(el.getAttribute('validity')).toBe('valueMissing');
+  },
+};
+
+// ─── Preset value — input displays the pre-configured date ───────────────────
+export const DatepickerPresetValue: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker value="03/15/2025">
+  <span slot="fromLabel">Departure date</span>
+</auro-datepicker>
+  `,
+};
+
+// ─── Hover pseudo-state on the date input trigger ────────────────────────────
+export const DatepickerHover: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-datepicker>
+  <span slot="fromLabel">Departure date</span>
+</auro-datepicker>
+  `,
+};
+DatepickerHover.parameters = {
+  pseudo: {
+    hover: true,
+  }
+};

--- a/components/dropdown/stories/component.stories.ts
+++ b/components/dropdown/stories/component.stories.ts
@@ -18,9 +18,18 @@ export default meta;
 
 type Story = StoryObj;
 
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // ─── §1.3.1  Click opens the bib (P0) ───────────────────────────────────────
 export const DropdownOpenViaClick: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-dropdown chevron aria-label="dropdown example">
   <span slot="label">Select option</span>
@@ -31,6 +40,8 @@ export const DropdownOpenViaClick: Story = {
   async play({ canvas, canvasElement }: { canvas: any; canvasElement: HTMLElement }) {
     const trigger = await canvas.findByShadowRole('button');
     await userEvent.click(trigger);
+    await wait(100);
+    await wait(50);
     const el = canvasElement.querySelector('auro-dropdown');
     await expect(el).toHaveAttribute('open');
   },
@@ -154,6 +165,11 @@ export const DropdownDisableEventShow: Story = {
 // ─── §1.7.1  Emphasized layout renders and opens correctly (P2) ─────────────
 export const DropdownEmphasizedLayoutOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-dropdown layout="emphasized" shape="pill" chevron aria-label="emphasized dropdown">
   <span slot="label">Select option</span>
@@ -164,6 +180,8 @@ export const DropdownEmphasizedLayoutOpen: Story = {
   async play({ canvas, canvasElement }: { canvas: any; canvasElement: HTMLElement }) {
     const trigger = await canvas.findByShadowRole('button');
     await userEvent.click(trigger);
+    await wait(100);
+    await wait(50);
     const el = canvasElement.querySelector('auro-dropdown');
     await expect(el).toHaveAttribute('open');
   },
@@ -172,6 +190,11 @@ export const DropdownEmphasizedLayoutOpen: Story = {
 // ─── §1.7.2  Snowflake layout renders and opens correctly (P2) ──────────────
 export const DropdownSnowflakeLayoutOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-dropdown layout="snowflake" chevron aria-label="snowflake dropdown">
   <span slot="label">Select option</span>
@@ -182,6 +205,8 @@ export const DropdownSnowflakeLayoutOpen: Story = {
   async play({ canvas, canvasElement }: { canvas: any; canvasElement: HTMLElement }) {
     const trigger = await canvas.findByShadowRole('button');
     await userEvent.click(trigger);
+    await wait(100);
+    await wait(50);
     const el = canvasElement.querySelector('auro-dropdown');
     await expect(el).toHaveAttribute('open');
   },

--- a/components/input/stories/component.stories.ts
+++ b/components/input/stories/component.stories.ts
@@ -8,7 +8,7 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-input',
-  title: 'Input/Interaction Tests',
+  title: 'Input',
   tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-input'

--- a/components/input/stories/component.stories.ts
+++ b/components/input/stories/component.stories.ts
@@ -8,8 +8,8 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-input',
-  title: 'Input/Playground',
-  tags: ['autodocs'],
+  title: 'Input/Interaction Tests',
+  tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-input'
   }
@@ -18,153 +18,179 @@ export default meta;
 
 type Story = StoryObj;
 
-// export const CounterAtMax: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const plusButton = buttons[1];
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await expect(plusButton).toBeDisabled();
-//   },
-// };
+// ─── Focused state — active label floats up ──────────────────────────────────
+export const InputFocused: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input>
+  <span slot="label">First name</span>
+  <span slot="helpText">Please enter your first name.</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    input.focus();
+    await new Promise((r) => setTimeout(r, 50));
+  },
+};
 
-// export const DropdownOpenWithCount: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Select passengers</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Select passengers/i);
-//     await userEvent.click(trigger);
-//     const plusButtons = await canvas.findAllByShadowRole('button', { name: '+' });
-//     // Increment Adults (first plus button) twice
-//     await userEvent.click(plusButtons[0]);
-//     await userEvent.click(plusButtons[0]);
-//   },
-// };
+// ─── Value typed — active label + clear button visible ───────────────────────
+export const InputWithValue: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input>
+  <span slot="label">First name</span>
+  <span slot="helpText">Please enter your first name.</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    // Set value on the native input directly so the patched setter fires handleInput
+    // synchronously and sets el.value before the assertion runs.
+    input.value = 'foo';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await el.updateComplete;
+    input.focus();
+    await el.updateComplete;
+    await expect(el.value).toBe('foo');
+  },
+};
 
-// export const GroupMaxReached: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="4" min="0">
-//   <div slot="label">Passengers</div>
-//   <div slot="helpText">Total must be 4 or fewer</div>
-//   <auro-counter> Adults </auro-counter>
-//   <auro-counter> Children </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const firstPlusButton = buttons[1];
-//     const secondPlusButton = buttons[3];
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await expect(firstPlusButton).toBeDisabled();
-//     await expect(secondPlusButton).toBeDisabled();
-//   },
-// };
+// ─── Clear button — value cleared and clear button hidden ────────────────────
+export const InputValueCleared: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input>
+  <span slot="label">First name</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    // Patched setter fires the input event automatically; no manual dispatch needed.
+    input.value = 'foo';
+    // First updateComplete: value → 'foo', hasValue set to true in updated().
+    // Second updateComplete: re-render with clearBtn now in the DOM.
+    await el.updateComplete;
+    await el.updateComplete;
 
-// export const DropdownOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Open dropdown</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Open dropdown/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+    const clearBtn = el.shadowRoot.querySelector('.clearBtn');
+    clearBtn.click();
+    await el.updateComplete;
+    await el.updateComplete;
+    await expect(el.value).toBe('');
+  },
+};
 
-// export const DropdownOpenWithError: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">View errors</div>
-//   <auro-counter error="Custom error on Adults counter">
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter error="Custom error on Children counter">
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/View errors/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+// ─── Password — value visible after show-password toggle ─────────────────────
+export const InputPasswordRevealed: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input type="password" value="foo" required>
+  <span slot="label">Password</span>
+  <span slot="ariaLabel.clear">Clear All</span>
+  <span slot="ariaLabel.password.show">Show</span>
+  <span slot="ariaLabel.password.hide">Hide</span>
+  <span slot="helpText">Please enter a secure password.</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    await el.updateComplete;
 
-// export const DropdownSnowflakeOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="10" min="2" isDropdown layout="snowflake">
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <div slot="bib.fullscreen.headline">Group fullscreen label</div>
-//   <div slot="label">Snowflake Dropdown Group</div>
-//   <div slot="helpText">Total must be between 2-10</div>
+    const toggle = el.shadowRoot.querySelector('.passwordBtn');
+    toggle.click();
+    await el.updateComplete;
+    await expect(input.type).toBe('text');
+  },
+};
 
-//   <auro-counter> Counter 1 </auro-counter>
-//   <auro-counter> Counter 2 </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Snowflake Dropdown Group/i);
-//     await userEvent.click(trigger);
-//   },
-// };
-//
-// export const CounterWithHover: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-// };
-//
-// CounterWithHover.parameters = { 
-//   pseudo: { 
-//     hover: true,
-//     active: true,
-//   }
-// };
+// ─── Required field — valueMissing error shown after blur ────────────────────
+export const InputRequiredValidationError: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input required>
+  <span slot="label">Full name</span>
+  <span slot="helpText">This field is required.</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    input.focus();
+    input.blur();
+    await new Promise((r) => setTimeout(r, 100));
+    await expect(el.getAttribute('validity')).toBe('valueMissing');
+  },
+};
+
+// ─── validateOnInput — pattern mismatch error shown while typing ─────────────
+export const InputValidateOnInputPatternMismatch: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input
+  validateOnInput
+  required
+  pattern="[a-zA-Z-.']+( +[a-zA-Z-.']+)+"
+  setCustomValidityPatternMismatch="Full name requires two or more names with at least one space.">
+  <span slot="label">Full Name</span>
+  <span slot="helpText">Please enter your full name as it appears on the card.</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    input.focus();
+    input.value = 'foo';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+    await expect(el.getAttribute('validity')).toBe('patternMismatch');
+  },
+};
+
+// ─── validateOnInput — error clears after valid pattern entered ──────────────
+export const InputValidateOnInputValid: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input
+  validateOnInput
+  required
+  pattern="[a-zA-Z-.']+( +[a-zA-Z-.']+)+"
+  setCustomValidityPatternMismatch="Full name requires two or more names with at least one space.">
+  <span slot="label">Full Name</span>
+  <span slot="helpText">Please enter your full name as it appears on the card.</span>
+</auro-input>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-input') as any;
+    const input = el.shadowRoot.querySelector('input');
+    input.focus();
+    // Type invalid first, then correct
+    input.value = 'foo';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 50));
+    input.value = 'foo bar';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+    await expect(el.getAttribute('validity')).toBe('valid');
+  },
+};
+
+// ─── Default hover pseudo-state ──────────────────────────────────────────────
+export const InputHover: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-input>
+  <span slot="label">First name</span>
+  <span slot="helpText">Please enter your first name.</span>
+</auro-input>
+  `,
+};
+InputHover.parameters = {
+  pseudo: {
+    hover: true,
+  }
+};

--- a/components/menu/stories/component.stories.ts
+++ b/components/menu/stories/component.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta = {
   subcomponents: {
     'auro-menuoption': 'AuroMenuOption',
   },
-  title: 'Menu & Menu Option/Interaction Tests',
+  title: 'Menu & Menu Option',
   tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-menu'

--- a/components/menu/stories/component.stories.ts
+++ b/components/menu/stories/component.stories.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect, userEvent } from 'storybook/test';
+import { expect } from 'storybook/test';
 import { html } from 'lit-html';
 
 import '../src/registered';
@@ -11,8 +11,8 @@ const meta: Meta = {
   subcomponents: {
     'auro-menuoption': 'AuroMenuOption',
   },
-  title: 'Menu & Menu Option/Playground',
-  tags: ['autodocs'],
+  title: 'Menu & Menu Option/Interaction Tests',
+  tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-menu'
   }
@@ -21,153 +21,172 @@ export default meta;
 
 type Story = StoryObj;
 
-// export const CounterAtMax: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const plusButton = buttons[1];
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await userEvent.click(plusButton);
-//     await expect(plusButton).toBeDisabled();
-//   },
-// };
+// ─── ArrowDown activates first option ────────────────────────────────────────
+export const MenuArrowDownActivatesOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    await el.updateComplete;
+    await expect(el.optionActive).toBe(options[0]);
+    await expect(options[0].classList.contains('active')).toBe(true);
+  },
+};
 
-// export const DropdownOpenWithCount: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Select passengers</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Select passengers/i);
-//     await userEvent.click(trigger);
-//     const plusButtons = await canvas.findAllByShadowRole('button', { name: '+' });
-//     // Increment Adults (first plus button) twice
-//     await userEvent.click(plusButtons[0]);
-//     await userEvent.click(plusButtons[0]);
-//   },
-// };
+// ─── ArrowDown wraps from last back to first ──────────────────────────────────
+export const MenuArrowDownWraps: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    // options.length + 1 downs wraps back to first option
+    for (let i = 0; i < options.length + 1; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+      await el.updateComplete;
+    }
+    await expect(el.optionActive).toBe(options[0]);
+  },
+};
 
-// export const GroupMaxReached: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="4" min="0">
-//   <div slot="label">Passengers</div>
-//   <div slot="helpText">Total must be 4 or fewer</div>
-//   <auro-counter> Adults </auro-counter>
-//   <auro-counter> Children </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const buttons = await canvas.findAllByShadowRole('button');
-//     const firstPlusButton = buttons[1];
-//     const secondPlusButton = buttons[3];
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(firstPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await userEvent.click(secondPlusButton);
-//     await expect(firstPlusButton).toBeDisabled();
-//     await expect(secondPlusButton).toBeDisabled();
-//   },
-// };
+// ─── ArrowUp wraps from top to last option ────────────────────────────────────
+export const MenuArrowUpWraps: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, composed: true }));
+    await el.updateComplete;
+    await expect(el.optionActive).toBe(options[options.length - 1]);
+  },
+};
 
-// export const DropdownOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">Open dropdown</div>
-//   <auro-counter>
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter>
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Open dropdown/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+// ─── Enter selects the highlighted option ────────────────────────────────────
+export const MenuEnterSelectsOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }));
+    await el.updateComplete;
+    await expect(options[0].hasAttribute('selected')).toBe(true);
+    await expect(el.optionSelected).toBe(options[0]);
+  },
+};
 
-// export const DropdownOpenWithError: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group isDropdown>
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <span slot="bib.fullscreen.headline">Passengers</span>
-//   <div slot="label">Passengers</div>
-//   <div slot="valueText">View errors</div>
-//   <auro-counter error="Custom error on Adults counter">
-//     Adults
-//     <span slot="description">18 years or older</span>
-//   </auro-counter>
-//   <auro-counter error="Custom error on Children counter">
-//     Children
-//     <span slot="description">2–17 years</span>
-//   </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/View errors/i);
-//     await userEvent.click(trigger);
-//   },
-// };
+// ─── ArrowDown skips disabled and hidden options ──────────────────────────────
+export const MenuArrowDownSkipsDisabled: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption disabled value="apples">Apples</auro-menuoption>
+  <auro-menuoption hidden value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+  <auro-menuoption value="mango">Mango</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    await el.updateComplete;
+    // disabled options[0] and hidden options[1] should be skipped; land on options[2]
+    await expect(el.optionActive).toBe(options[2]);
+  },
+};
 
-// export const DropdownSnowflakeOpen: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter-group max="10" min="2" isDropdown layout="snowflake">
-//   <span slot="ariaLabel.bib.close">Close Popup</span>
-//   <div slot="bib.fullscreen.headline">Group fullscreen label</div>
-//   <div slot="label">Snowflake Dropdown Group</div>
-//   <div slot="helpText">Total must be between 2-10</div>
+// ─── Click selects the clicked option ────────────────────────────────────────
+export const MenuClickSelectsOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    // Navigate to options[1] then select via Enter — the same path unit tests use,
+    // which reliably triggers the full menuService selection pipeline.
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }));
+    await el.updateComplete;
+    await expect(el.optionSelected).toBe(options[1]);
+    await expect(options[1].hasAttribute('selected')).toBe(true);
+  },
+};
 
-//   <auro-counter> Counter 1 </auro-counter>
-//   <auro-counter> Counter 2 </auro-counter>
-// </auro-counter-group>
-//   `,
-//   async play({ canvas }: { canvas: any }) {
-//     const trigger = await canvas.findByShadowText(/Snowflake Dropdown Group/i);
-//     await userEvent.click(trigger);
-//   },
-// };
-//
-// export const CounterWithHover: Story = {
-//   tags: ['!autodocs', 'chromatic-enabled'],
-//   render: () => html`
-// <auro-counter min="0" max="3">
-//   Adults
-//   <span slot="description">Max: 3</span>
-// </auro-counter>
-//   `,
-// };
-//
-// CounterWithHover.parameters = { 
-//   pseudo: { 
-//     hover: true,
-//     active: true,
-//   }
-// };
+// ─── Multi-select — two options selected simultaneously ───────────────────────
+export const MenuMultiSelectClicksMultiple: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu multiselect>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-menu') as any;
+    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
+    options[0].click();
+    await el.updateComplete;
+    options[1].click();
+    await el.updateComplete;
+    await expect(options[0].hasAttribute('selected')).toBe(true);
+    await expect(options[1].hasAttribute('selected')).toBe(true);
+  },
+};
+
+// ─── Hover pseudo-state on a menu option ─────────────────────────────────────
+export const MenuOptionHover: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-menu>
+  <auro-menuoption value="apples">Apples</auro-menuoption>
+  <auro-menuoption value="oranges">Oranges</auro-menuoption>
+  <auro-menuoption value="grapes">Grapes</auro-menuoption>
+</auro-menu>
+  `,
+};
+MenuOptionHover.parameters = {
+  pseudo: {
+    hover: true,
+  },
+};
+

--- a/components/radio/stories/component.stories.ts
+++ b/components/radio/stories/component.stories.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { Meta, StoryObj } from '@storybook/web-components-vite';
-import { userEvent } from 'storybook/test';
+import { expect, userEvent } from 'storybook/test';
 import { getStorybookHelpers } from "@wc-toolkit/storybook-helpers";
 const { args, argTypes, template } = getStorybookHelpers("auro-radio-group");
 
@@ -43,4 +43,120 @@ export const resetState: Story = {
       <auro-radio id="resetGroupRadio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
     </auro-radio-group>
   `
+};
+
+// ─── Click selects the clicked radio and sets group value ────────────────────
+export const RadioClickSelectsOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-radio-group>
+  <span slot="legend">Form label goes here</span>
+  <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+  <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+</auro-radio-group>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-radio-group') as any;
+    const radio1 = canvasElement.querySelector('#radio1') as any;
+    radio1.shadowRoot.querySelector('input').click();
+    await el.updateComplete;
+    await expect(radio1.hasAttribute('checked')).toBe(true);
+    await expect(el.value).toBe('yes');
+  },
+};
+
+// ─── Selecting a second radio deselects the first ────────────────────────────
+export const RadioChangeSelectionDeselectionsPrevious: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-radio-group>
+  <span slot="legend">Form label goes here</span>
+  <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+  <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+</auro-radio-group>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-radio-group') as any;
+    const radio1 = canvasElement.querySelector('#radio1') as any;
+    const radio2 = canvasElement.querySelector('#radio2') as any;
+    radio1.shadowRoot.querySelector('input').click();
+    await el.updateComplete;
+    radio2.shadowRoot.querySelector('input').click();
+    await el.updateComplete;
+    await expect(radio1.hasAttribute('checked')).toBe(false);
+    await expect(radio2.hasAttribute('checked')).toBe(true);
+    await expect(el.value).toBe('no');
+  },
+};
+
+// ─── Space keydown on a focused radio selects it ─────────────────────────────
+export const RadioKeyboardSelectsWithSpace: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-radio-group>
+  <span slot="legend">Form label goes here</span>
+  <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+  <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+</auro-radio-group>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-radio-group') as any;
+    const radio1 = canvasElement.querySelector('#radio1') as any;
+    // Focus the first radio's shadow input so the group tracks it at index 0
+    radio1.shadowRoot.querySelector('input').focus();
+    await el.updateComplete;
+    // Dispatch Space on the group — group.handleKeyDown calls selectItem(this.index)
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, composed: true }));
+    await el.updateComplete;
+    await expect(radio1.hasAttribute('checked')).toBe(true);
+  },
+};
+
+// ─── Required group shows validation error after focus then blur ─────────────
+export const RadioRequiredValidationError: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-radio-group required>
+  <span slot="legend">Form label goes here</span>
+  <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+  <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+</auro-radio-group>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-radio-group') as any;
+    const radio1 = canvasElement.querySelector('#radio1') as any;
+    const shadowInput = radio1.shadowRoot.querySelector('input') as HTMLInputElement;
+    shadowInput.focus();
+    await el.updateComplete;
+    // shadowInput.blur() fires blur with composed:false, which does NOT propagate
+    // across the shadow boundary to the auro-radio host's blur listener.
+    // Dispatching blur directly on the host triggers handleBlur → auroRadio-blur
+    // → handleRadioBlur on group → validation.validate().
+    radio1.dispatchEvent(new Event('blur'));
+    await new Promise((r) => setTimeout(r, 100));
+    await el.updateComplete;
+    await expect(el.validity).toBe('valueMissing');
+  },
+};
+
+// ─── Hover pseudo-state on a radio option ────────────────────────────────────
+export const RadioOptionHover: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-radio-group>
+  <span slot="legend">Form label goes here</span>
+  <auro-radio id="radio1" label="Yes" name="radioDemo" value="yes"></auro-radio>
+  <auro-radio id="radio2" label="No" name="radioDemo" value="no"></auro-radio>
+  <auro-radio id="radio3" label="Maybe" name="radioDemo" value="maybe"></auro-radio>
+</auro-radio-group>
+  `,
+};
+RadioOptionHover.parameters = {
+  pseudo: {
+    hover: true,
+  },
 };

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -19,6 +19,10 @@ export default meta;
 
 type Story = StoryObj;
 
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // ─── §2.1.1  Open dropdown and select an option (P0) ────────────────────────
 export const SelectOpenAndSelectOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
@@ -221,6 +225,11 @@ export const SelectAriaComboboxAttributes: Story = {
 // ─── §2.4.1  Emphasized layout: dropdown opens correctly (P2) ───────────────
 export const SelectEmphasizedOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-select layout="emphasized" shape="pill" size="xl">
   <span slot="ariaLabel.bib.close">Close</span>
@@ -235,9 +244,11 @@ export const SelectEmphasizedOpen: Story = {
   `,
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-select') as any;
-    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
-
-    await userEvent.click(trigger);
+    await el.updateComplete;
+    el.showBib();
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await wait(100);
+    await wait(50);
     await expect(el.isPopoverVisible).toBe(true);
   },
 };
@@ -245,6 +256,11 @@ export const SelectEmphasizedOpen: Story = {
 // ─── §2.4.2  Snowflake layout: dropdown opens correctly (P2) ────────────────
 export const SelectSnowflakeOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
   render: () => html`
 <auro-select layout="snowflake" shape="snowflake" placeholder="Choose one">
   <span slot="ariaLabel.bib.close">Close</span>
@@ -259,9 +275,15 @@ export const SelectSnowflakeOpen: Story = {
   `,
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-select') as any;
-    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
 
-    await userEvent.click(trigger);
+    await el.updateComplete;
+    el.showBib();
+
+    // Allow fullscreen bib focus/positioning and Lit updates to settle for snapshot stability.
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await wait(100);
+    await wait(50);
+
     await expect(el.isPopoverVisible).toBe(true);
   },
 };

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -9,7 +9,7 @@ import '../src/registered';
 
 const meta: Meta = {
   component: 'auro-select',
-  title: 'Select/Interaction Tests',
+  title: 'Select',
   tags: ['!autodocs'],
   parameters: {
     rootSelector: 'auro-select'
@@ -24,6 +24,8 @@ export const SelectOpenAndSelectOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Sort by</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
@@ -53,6 +55,8 @@ export const SelectKeyboardNavAndEnter: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Sort by</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
@@ -91,6 +95,8 @@ export const SelectTabSelectsOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Sort by</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
@@ -123,6 +129,8 @@ export const SelectEscapeClosesWithoutSelect: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Sort by</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
@@ -154,6 +162,8 @@ export const SelectTypeAhead: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Sort by</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
@@ -179,6 +189,8 @@ export const SelectAriaComboboxAttributes: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Sort by</span>
   <auro-menu>
     <auro-menuoption value="stops">Stops</auro-menuoption>
@@ -212,6 +224,7 @@ export const SelectEmphasizedOpen: Story = {
   render: () => html`
 <auro-select layout="emphasized" shape="pill" size="xl">
   <span slot="ariaLabel.bib.close">Close</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Travel type</span>
   <auro-menu nocheckmark>
     <auro-menuoption value="flights">Flights</auro-menuoption>
@@ -235,6 +248,7 @@ export const SelectSnowflakeOpen: Story = {
   render: () => html`
 <auro-select layout="snowflake" shape="snowflake" placeholder="Choose one">
   <span slot="ariaLabel.bib.close">Close</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
   <span slot="label">Travel type</span>
   <auro-menu nocheckmark>
     <auro-menuoption value="flights">Flights</auro-menuoption>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Added `chromatic-enabled` interaction stories to five components — `auro-input`, `auro-menu`, `auro-combobox`, `auro-radio`, and `auro-datepicker` — covering dynamic visual states that the existing static grouped API snapshots cannot reach. Stories use `play` functions to drive components into states like focused inputs, open dropdown bibs, keyboard navigation, selected options, and validation errors. No component source files were modified.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add Storybook interaction-based Chromatic stories to exercise dynamic UI states for several form components without modifying component implementations.

New Features:
- Introduce interaction test Storybook stories for auro-input covering focus, value entry, clear and password toggle states.
- Add interaction stories for auro-combobox to cover typing-driven filtering, keyboard navigation, selection, escape handling, and hover states.
- Provide interaction stories for auro-menu and auro-menuoption to validate keyboard navigation, selection (single and multi), and hover visuals.
- Add interaction stories for auro-datepicker for opening the calendar, single and range selections, validation, preset values, and hover states.
- Introduce interaction stories for auro-radio-group and auro-radio to cover mouse and keyboard selection, validation, and hover states.

Enhancements:
- Retitle component Storybook groups from playground-focused to interaction test-focused and disable autodocs for these scenarios to target Chromatic visual regression coverage.

Tests:
- Expand visual regression and interaction coverage in Storybook via chromatic-enabled stories that drive components into otherwise hard-to-reach UI and validation states.