### PR TITLE
fix(combobox): handle trailing whitespace in filter AB#1520589

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -31,6 +31,19 @@ import { AuroElement } from '../../layoutElement/src/auroElement.js';
 import { AuroHelpText } from "@aurodesignsystem/auro-helptext";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+/**
+ * Strips only trailing whitespace from an input value so residual spaces
+ * from cursor editing don't break filtering or highlighting.  Whitespace-only
+ * values are preserved as-is to prevent a lone space from being treated as
+ * empty input.
+ * @param {string} value - Raw input value.
+ * @returns {string} Normalized value.
+ */
+function normalizeFilterValue(value) {
+  const raw = value || '';
+  return raw.trim() ? raw.trimEnd() : raw;
+}
+
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * The `auro-combobox` element provides users with a way to select an option from a list of filtered or suggested options based on user input.
@@ -49,20 +62,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
  * @event inputValue - Notifies that the components internal HTML5 input value has changed.
  * @event auroFormElement-validated - Notifies that the component value(s) have been validated.
  */
-
-/**
- * Strips only trailing whitespace from an input value so residual spaces
- * from cursor editing don't break filtering or highlighting.  Whitespace-only
- * values are preserved as-is to prevent a lone space from being treated as
- * empty input.
- * @param {string} value - Raw input value.
- * @returns {string} Normalized value.
- */
-function normalizeFilterValue(value) {
-  const raw = value || '';
-  return raw.trim() ? raw.trimEnd() : raw;
-}
-
 export class AuroCombobox extends AuroElement {
 
   constructor() {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -49,6 +49,20 @@ import { ifDefined } from "lit/directives/if-defined.js";
  * @event inputValue - Notifies that the components internal HTML5 input value has changed.
  * @event auroFormElement-validated - Notifies that the component value(s) have been validated.
  */
+
+/**
+ * Strips only trailing whitespace from an input value so residual spaces
+ * from cursor editing don't break filtering or highlighting.  Whitespace-only
+ * values are preserved as-is to prevent a lone space from being treated as
+ * empty input.
+ * @param {string} value - Raw input value.
+ * @returns {string} Normalized value.
+ */
+function normalizeFilterValue(value) {
+  const raw = value || '';
+  return raw.trim() ? raw.trimEnd() : raw;
+}
+
 export class AuroCombobox extends AuroElement {
 
   constructor() {
@@ -544,12 +558,7 @@ export class AuroCombobox extends AuroElement {
 
     this.noMatchOption = undefined;
 
-    // Remove trailing whitespace only when the input contains
-    // non-whitespace characters, so residual spaces from cursor
-    // editing don't break matching. Whitespace-only input is
-    // preserved as-is so a lone space doesn't show all options.
-    const raw = this.input.value || '';
-    const filterValue = (raw.trim() ? raw.trimEnd() : raw).toLowerCase();
+    const filterValue = normalizeFilterValue(this.input.value).toLowerCase();
 
     this.options.forEach((option) => {
       let matchString = option.textContent.toLowerCase();
@@ -603,7 +612,7 @@ export class AuroCombobox extends AuroElement {
   syncValuesAndStates() {
     // Only sync matchWord, don't set menu.value here since setMenuValue should handle that
     if (this.menu) {
-      this.menu.matchWord = (this.input.value || '').trimEnd();
+      this.menu.matchWord = normalizeFilterValue(this.input.value);
     }
     const label = this.menu.currentLabel;
     this.updateTriggerTextDisplay(label || this.value);
@@ -967,7 +976,7 @@ export class AuroCombobox extends AuroElement {
       this.updateTriggerTextDisplay(event.detail.label || event.detail.value);
 
       // Update match word for filtering
-      const trimmedInput = (this.input.value || '').trimEnd();
+      const trimmedInput = normalizeFilterValue(this.input.value);
       if (this.menu.matchWord !== trimmedInput) {
         this.menu.matchWord = trimmedInput;
       }
@@ -1107,7 +1116,7 @@ export class AuroCombobox extends AuroElement {
       });
 
       // Run filtering inline — the re-entrant event won't reach this code.
-      this.menu.matchWord = (this.inputInBib.value || '').trimEnd();
+      this.menu.matchWord = normalizeFilterValue(this.inputInBib.value);
       this.optionActive = null;
       this.handleMenuOptions();
       this.dispatchEvent(new CustomEvent('inputValue', { detail: { value: this.inputValue } }));
@@ -1121,7 +1130,7 @@ export class AuroCombobox extends AuroElement {
 
     this.inputInBib.value = this.input.value;
 
-    this.menu.matchWord = (this.input.value || '').trimEnd();
+    this.menu.matchWord = normalizeFilterValue(this.input.value);
     this.optionActive = null;
 
     if (!this.input.value) {
@@ -1335,7 +1344,7 @@ export class AuroCombobox extends AuroElement {
 
       // Sync the input and match word, but don't directly set menu.value again
       if (this.menu) {
-        this.menu.matchWord = (this.input.value || '').trimEnd();
+        this.menu.matchWord = normalizeFilterValue(this.input.value);
       }
 
       this.dispatchEvent(new CustomEvent('input', {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -544,6 +544,13 @@ export class AuroCombobox extends AuroElement {
 
     this.noMatchOption = undefined;
 
+    // Remove trailing whitespace only when the input contains
+    // non-whitespace characters, so residual spaces from cursor
+    // editing don't break matching. Whitespace-only input is
+    // preserved as-is so a lone space doesn't show all options.
+    const raw = this.input.value || '';
+    const filterValue = (raw.trim() ? raw.trimEnd() : raw).toLowerCase();
+
     this.options.forEach((option) => {
       let matchString = option.textContent.toLowerCase();
 
@@ -560,12 +567,12 @@ export class AuroCombobox extends AuroElement {
       }
 
       // If input is empty, show all options (except static ones)
-      if (!this.input.value || this.input.value.length === 0) {
+      if (!filterValue) {
         if (!option.hasAttribute('static')) {
           option.removeAttribute('hidden');
           this.availableOptions.push(option);
         }
-      } else if (matchString.includes(this.input.value.toLowerCase()) && !option.hasAttribute('static')) {
+      } else if (matchString.includes(filterValue) && !option.hasAttribute('static')) {
         // only count options that match the typed input value AND are not static
         option.removeAttribute('hidden');
         this.availableOptions.push(option);
@@ -596,7 +603,7 @@ export class AuroCombobox extends AuroElement {
   syncValuesAndStates() {
     // Only sync matchWord, don't set menu.value here since setMenuValue should handle that
     if (this.menu) {
-      this.menu.matchWord = this.input.value;
+      this.menu.matchWord = (this.input.value || '').trimEnd();
     }
     const label = this.menu.currentLabel;
     this.updateTriggerTextDisplay(label || this.value);
@@ -960,8 +967,9 @@ export class AuroCombobox extends AuroElement {
       this.updateTriggerTextDisplay(event.detail.label || event.detail.value);
 
       // Update match word for filtering
-      if (this.menu.matchWord !== this.input.value) {
-        this.menu.matchWord = this.input.value;
+      const trimmedInput = (this.input.value || '').trimEnd();
+      if (this.menu.matchWord !== trimmedInput) {
+        this.menu.matchWord = trimmedInput;
       }
 
       // Update available options based on selection
@@ -1099,7 +1107,7 @@ export class AuroCombobox extends AuroElement {
       });
 
       // Run filtering inline — the re-entrant event won't reach this code.
-      this.menu.matchWord = this.inputInBib.value;
+      this.menu.matchWord = (this.inputInBib.value || '').trimEnd();
       this.optionActive = null;
       this.handleMenuOptions();
       this.dispatchEvent(new CustomEvent('inputValue', { detail: { value: this.inputValue } }));
@@ -1113,7 +1121,7 @@ export class AuroCombobox extends AuroElement {
 
     this.inputInBib.value = this.input.value;
 
-    this.menu.matchWord = this.input.value;
+    this.menu.matchWord = (this.input.value || '').trimEnd();
     this.optionActive = null;
 
     if (!this.input.value) {
@@ -1327,7 +1335,7 @@ export class AuroCombobox extends AuroElement {
 
       // Sync the input and match word, but don't directly set menu.value again
       if (this.menu) {
-        this.menu.matchWord = this.input.value;
+        this.menu.matchWord = (this.input.value || '').trimEnd();
       }
 
       this.dispatchEvent(new CustomEvent('input', {

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -449,15 +449,20 @@ function runFulltest(mobileview) {
 
     // First get baseline with "a"
     setInputValue(el, 'a');
+    await elementUpdated(el);
+    await elementUpdated(menu);
     const baselineVisible = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
     const baselineValues = baselineVisible.map((o) => o.getAttribute('value'));
 
     // Reset
     setInputValue(el, '');
     await elementUpdated(el);
+    await elementUpdated(menu);
 
     // Now test "a " (trailing space)
     setInputValue(el, 'a ');
+    await elementUpdated(el);
+    await elementUpdated(menu);
     const trailingSpaceVisible = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
     const trailingSpaceValues = trailingSpaceVisible.map((o) => o.getAttribute('value'));
 
@@ -470,6 +475,8 @@ function runFulltest(mobileview) {
     const menuOptions = menu.querySelectorAll('auro-menuoption');
 
     setInputValue(el, ' ');
+    await elementUpdated(el);
+    await elementUpdated(menu);
 
     const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
 
@@ -482,6 +489,8 @@ function runFulltest(mobileview) {
     const menuOptions = menu.querySelectorAll('auro-menuoption');
 
     setInputValue(el, ' ');
+    await elementUpdated(el);
+    await elementUpdated(menu);
 
     const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
 
@@ -498,6 +507,8 @@ function runFulltest(mobileview) {
     const menuOptions = menu.querySelectorAll('auro-menuoption');
 
     setInputValue(el, ' a');
+    await elementUpdated(el);
+    await elementUpdated(menu);
 
     const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -424,6 +424,107 @@ function runFulltest(mobileview) {
     await expect(visibleMenuOptions[0].querySelector("strong")).to.exist;
   });
 
+  it('typing "a" matches options containing "a" with bold highlighting', async () => {
+    const el = await defaultFixture(mobileview);
+    const menu = el.querySelector('auro-menu');
+    const menuOptions = menu.querySelectorAll('auro-menuoption');
+
+    setInputValue(el, 'a');
+    await elementUpdated(el);
+    await elementUpdated(menu);
+
+    const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+
+    await expect(visibleMenuOptions.length).to.be.greaterThan(0);
+    for (const opt of visibleMenuOptions) {
+      expect(opt.textContent.toLowerCase()).to.include('a');
+      expect(opt.querySelector('strong')).to.exist;
+    }
+  });
+
+  it('trailing space is stripped — "a " matches same options as "a"', async () => {
+    const el = await defaultFixture(mobileview);
+    const menu = el.querySelector('auro-menu');
+    const menuOptions = menu.querySelectorAll('auro-menuoption');
+
+    // First get baseline with "a"
+    setInputValue(el, 'a');
+    const baselineVisible = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+    const baselineValues = baselineVisible.map((o) => o.getAttribute('value'));
+
+    // Reset
+    setInputValue(el, '');
+    await elementUpdated(el);
+
+    // Now test "a " (trailing space)
+    setInputValue(el, 'a ');
+    const trailingSpaceVisible = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+    const trailingSpaceValues = trailingSpaceVisible.map((o) => o.getAttribute('value'));
+
+    await expect(trailingSpaceValues).to.deep.equal(baselineValues);
+  });
+
+  it('space alone does not match any options', async () => {
+    const el = await defaultFixture(mobileview);
+    const menu = el.querySelector('auro-menu');
+    const menuOptions = menu.querySelectorAll('auro-menuoption');
+
+    setInputValue(el, ' ');
+
+    const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+
+    await expect(visibleMenuOptions.length).to.be.equal(0);
+  });
+
+  it('space alone filters options by space substring', async () => {
+    const el = await noMatchFixture(mobileview);
+    const menu = el.querySelector('auro-menu');
+    const menuOptions = menu.querySelectorAll('auro-menuoption');
+
+    setInputValue(el, ' ');
+
+    const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+
+    // Options whose text contains a space will match (e.g. "No Matching Option").
+    // Options without spaces in their text will be hidden.
+    for (const opt of visibleMenuOptions) {
+      expect(opt.textContent).to.include(' ');
+    }
+  });
+
+  it('leading space is preserved — " a" does not match options', async () => {
+    const el = await defaultFixture(mobileview);
+    const menu = el.querySelector('auro-menu');
+    const menuOptions = menu.querySelectorAll('auro-menuoption');
+
+    setInputValue(el, ' a');
+
+    const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+
+    await expect(visibleMenuOptions.length).to.be.equal(0);
+  });
+
+  it('cursor-editing sequence with residual trailing space still matches "a"', async () => {
+    const el = await defaultFixture(mobileview);
+    const menu = el.querySelector('auro-menu');
+    const menuOptions = menu.querySelectorAll('auro-menuoption');
+
+    // Simulate the end result of the cursor-editing sequence:
+    // space, a, space, ←, ←, backspace, →, backspace, a
+    // which produces "a " (a with trailing space)
+    setInputValue(el, 'a ');
+    await elementUpdated(el);
+    await elementUpdated(menu);
+
+    const visibleMenuOptions = [...menuOptions].filter((o) => !o.hasAttribute('hidden'));
+
+    await expect(visibleMenuOptions.length).to.be.greaterThan(0);
+    for (const opt of visibleMenuOptions) {
+      expect(opt.textContent.toLowerCase()).to.include('a');
+      expect(opt.querySelector('strong')).to.exist;
+    }
+  });
+
   it('fired `auroCombobox-valueSet` event on value update', async () => {
     const el = await defaultFixture(mobileview);
 


### PR DESCRIPTION
Alaska Airlines Pull Request

## Summary
- When users edit combobox input using cursor keys and backspace, residual trailing whitespace can remain in the input value (e.g. `"a "` instead of `"a"`), causing the substring filter to fail to match options
- `updateFilter()` now uses `trimEnd()` on the input value before matching, removing only trailing whitespace while preserving leading and internal spaces for intentional multi-word narrowing
- Whitespace-only input (e.g. a lone space) is preserved as-is so it doesn't falsely show all options — consistent with the HTML5 combobox pattern where space is a regular filter character
- All `matchWord` assignments also use `trimEnd()` to keep bold text highlighting in sync with the filter

## Reproduction steps
1. Focus the combobox input
2. Press: `space`, `a`, `space`, `left arrow`, `left arrow`, `backspace`, `right arrow`, `backspace`, `a`
3. Expected: options matching "a" appear with bold highlighting
4. Actual (before fix): no options appear because the input value is `"a "` (with trailing space) and the filter searches for the literal substring `"a "` which doesn't match option text like `"Alaska"`

**Before:**

https://github.com/user-attachments/assets/31f6a95e-3f33-470e-b726-f95cbd8fbbd8

**After (fix applied):**

https://github.com/user-attachments/assets/ff7baade-29fe-42fb-bd61-0296b311c3e1

## Design decisions

### Why `trimEnd()` and not `trim()`
Leading whitespace is intentional user input. Typing `" a"` (space then "a") should narrow results because `" a"` as a substring won't match most option text. Only trailing whitespace is an artifact of cursor editing.

### Why whitespace-only input is preserved
`" ".trimEnd()` produces `""`, which would make the filter treat it as empty input and show all options. Per the HTML5 combobox pattern, pressing space alone should not open the dropdown. The fix checks `raw.trim()` first — if the entire input is whitespace, the original value is used as-is for filtering.

### Why `matchWord` is also trimmed
The menu uses `matchWord` to build a regex for bold highlighting. Without trimming, `matchWord` would be `"a "` while the filter uses `"a"`, causing options to match but not highlight the matching text.

## Test plan
- [x] Type `a` — options matching "a" appear with bold "a"
- [x] Type `a`, `space` — trailing space is stripped by `trimEnd()`, results stay the same as typing `a` alone
- [x] Press `space` alone — no options match; if a `nomatch` option is configured, dropdown opens with "no matching option" message, otherwise dropdown stays closed
- [x] Reproduce the cursor-editing sequence above — options matching "a" appear with bold highlighting
- [x] Type `space`, `a` — no options appear (leading space makes `" a"` not match most options)
- [x] Verify fullscreen/mobile bib input behaves the same

### Unit tests

New unit tests added:


  1. "typing 'a' matches options containing 'a' with bold highlighting" — verifies basic filter + <strong> highlighting
  2. "trailing space is stripped — 'a ' matches same options as 'a'" — confirms trimEnd() makes trailing space irrelevant
  3. "space alone does not match any options" — verifies whitespace-only input is preserved (not treated as empty)
  4. "space alone filters options by space substring" — with nomatch fixture, options containing spaces in their text still match " "
  5. "leading space is preserved — ' a' does not match options" — confirms leading whitespace is significant
  6. "cursor-editing sequence with residual trailing space still matches 'a'" — the original bug scenario

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Handle trailing whitespace in combobox input filtering and keep option highlighting in sync with the applied filter.

Bug Fixes:
- Prevent residual trailing spaces from cursor-edited combobox input from breaking option substring matching.

Enhancements:
- Normalize combobox matchWord values by trimming trailing whitespace across standard and fullscreen/mobile inputs to align highlighting with filtering behavior.

## Summary by Sourcery

Adjust combobox filtering and highlighting to ignore trailing whitespace in user input while preserving meaningful leading and internal spaces.

Bug Fixes:
- Prevent trailing whitespace from cursor-edited combobox input from suppressing valid option matches in both standard and fullscreen/mobile modes.

Tests:
- Add combobox tests covering basic filtering and highlighting, behavior with trailing and leading spaces, whitespace-only input, and the cursor-editing regression scenario.