### PR TITLE
fix(counter): expose value as spinbutton input for a11y AB#1516613

### DIFF
--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -314,6 +314,11 @@ export class AuroCounter extends LitElement {
   firstUpdated() {
     this.initValue();
     this.setTagAttribute("auro-counter");
+    const spinbutton = this.shadowRoot.querySelector('[role="spinbutton"]');
+
+    this.shadowRoot.querySelectorAll("[data-spinbutton-operation]").forEach((button) => {
+      button.ariaControlsElements = [spinbutton];
+    });
   }
 
   /**
@@ -338,25 +343,6 @@ export class AuroCounter extends LitElement {
     const assignedNodes = event.target.assignedNodes();
     if (assignedNodes.length > 0) {
       this.defaultSlot = assignedNodes[0].textContent.trim();
-    }
-  }
-
-  /**
-   * Sets ariaDescribedByElements on the spinbutton to the slotted description elements,
-   * bridging the shadow DOM boundary for screen readers.
-   * @param {Event} event - The slotchange event.
-   * @private
-   */
-  onDescriptionSlotChange(event) {
-    const assignedNodes = event.target.assignedElements();
-    const spinbutton = this.shadowRoot.querySelector('[role="spinbutton"]');
-
-    if (spinbutton) {
-      if (assignedNodes.length > 0) {
-        spinbutton.ariaDescribedByElements = assignedNodes;
-      } else {
-        spinbutton.ariaDescribedByElements = [];
-      }
     }
   }
 
@@ -411,46 +397,56 @@ export class AuroCounter extends LitElement {
 
       <div class="counterWrapper">
         <div class="counter">
-          <div class="content" >
-            <label id="counter-label" class="label">
+          <div id="counter-label" class="content">
+            <label class="label">
               <slot @slotchange="${this.onDefaultSlotChange}"></slot>
             </label>
-            <slot name="description" class="body-xs" @slotchange="${this.onDescriptionSlotChange}"></slot>
+            <slot name="description" class="body-xs"></slot>
           </div>
           <div 
             part="counterControl" 
-            aria-disabled="${ifDefined(this.disabled ? 'true' : undefined)}" 
-            aria-labelledby="counter-label" 
-            aria-valuemax="${this.max}" 
-            aria-valuemin="${this.min}" 
-            aria-valuenow="${this.value}"
-            aria-valuetext="${this.value !== undefined ? this.value : this.min}"
-            role="spinbutton" 
-            tabindex="${this.disabled ? '-1' : '0'}" 
           >
             <auro-counter-button
               aria-label="${this.runtimeUtils.getSlotText(this, 'ariaLabel.minus') || '−'}"
               .tabindex="${'-1'}"
+              data-spinbutton-operation="decrement" 
               appearance="${this.onDark ? 'inverse' : this.appearance}"
               part="controlMinus"
               @click="${() => this.decrement()}"
+              ?aria-disabled="${this.disabled || this.disableMin || this.isIncrementDisabled(this.min) ? 'true' : undefined}"
               ?disabled="${this.disabled || this.disableMin || this.isIncrementDisabled(this.min)}"
             >
-              <${this.iconTag} class="controlIcon" customSvg> ${IconUtil.generateSvgHtml(minusIcon)} </${this.iconTag}>
+              <${this.iconTag} class="controlIcon" customSvg aria-hidden="true"> ${IconUtil.generateSvgHtml(minusIcon)} </${this.iconTag}>
             </auro-counter-button>
 
             <div class="quantityWrapper body-lg">
-              <div>${this.value !== undefined ? this.value : this.min}</div>
+              <!-- adding quote characters in aria-valuetext to ensure that screen readers read the value as a string, preventing mispronunciation of numbers -->
+              <input
+                aria-labelledby="counter-label"
+                readonly
+                aria-disabled="${ifDefined(this.disabled ? 'true' : undefined)}"
+                aria-valuemax="${this.max}" 
+                aria-valuemin="${this.min}" 
+                aria-valuenow="${this.value}"
+                aria-valuetext="'${this.value !== undefined ? this.value : this.min}'"
+                role="spinbutton" 
+                tabindex="${this.disabled ? '-1' : '0'}" 
+                value="${this.value !== undefined ? this.value : this.min}"
+                autocomplete="off"
+                >
+            </input>
             </div>
             <auro-counter-button
               aria-label="${this.runtimeUtils.getSlotText(this, 'ariaLabel.plus') || '+'}"
               .tabindex="${'-1'}"
               appearance="${this.onDark ? 'inverse' : this.appearance}"
+              data-spinbutton-operation="increment" 
               part="controlPlus"
               @click="${() => this.increment()}"
+              ?aria-disabled="${this.disabled || this.disableMax || this.isIncrementDisabled(this.max) ? 'true' : undefined}"
               ?disabled="${this.disabled || this.disableMax || this.isIncrementDisabled(this.max)}"
             >
-              <${this.iconTag} class="controlIcon" customSvg> ${IconUtil.generateSvgHtml(plusIcon)} </${this.iconTag}>
+              <${this.iconTag} class="controlIcon" customSvg aria-hidden="true"> ${IconUtil.generateSvgHtml(plusIcon)} </${this.iconTag}>
             </auro-counter-button>
           </div>
         </div>

--- a/components/counter/src/styles/color.scss
+++ b/components/counter/src/styles/color.scss
@@ -29,7 +29,7 @@
 }
 
 :host::part(counterControl) {
-  &:focus-visible {
+  &:focus-within {
     outline-color: var(--ds-auro-counter-control-border-color);
   }
 }

--- a/components/counter/src/styles/style.scss
+++ b/components/counter/src/styles/style.scss
@@ -15,6 +15,20 @@
   align-items: center;
   justify-content: space-between;
   column-gap: var(--ds-size-150, vac.$ds-size-150);
+
+
+  input {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: none;
+    margin: 0;
+    background: transparent;
+    color: inherit;
+    font-size: 1em;
+    outline: none;
+    text-align: center;
+  }
 }
 
 .content {
@@ -47,7 +61,7 @@
     // prevent double-tap zoom on iOS (included in button for enabled state behaving differently)
     touch-action: manipulation;
 
-    &:focus-visible {
+    &:focus-within {
       outline-offset: 0;
       outline-style: solid;
       outline-width: var(--ds-size-25, vac.$ds-size-25);

--- a/components/counter/test/auro-counter.test.js
+++ b/components/counter/test/auro-counter.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions, no-undef, no-magic-numbers */
 
-import { fixture, html, expect, oneEvent } from '@open-wc/testing';
+import { fixture, html, expect } from '@open-wc/testing';
 import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
 import '../src/registered.js';
 
@@ -88,70 +88,62 @@ describe('auro-counter: isIncrementDisabled', () => {
   });
 });
 
-describe('auro-counter: description slot / ariaDescribedByElements', () => {
-  it('sets ariaDescribedByElements on the spinbutton when a description element is slotted', async () => {
-    const el = await fixture(html`
-      <auro-counter>
-        Counter
-        <span slot="description">Description text</span>
-      </auro-counter>
-    `);
-
-    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
-    const descriptionEl = el.querySelector('[slot="description"]');
-
-    expect(spinbutton.ariaDescribedByElements).to.deep.equal([descriptionEl]);
-  });
-
-  it('clears ariaDescribedByElements on the spinbutton when the description element is removed', async () => {
-    const el = await fixture(html`
-      <auro-counter>
-        Counter
-        <span slot="description">Description text</span>
-      </auro-counter>
-    `);
-
-    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
-    const descriptionEl = el.querySelector('[slot="description"]');
-
-    expect(spinbutton.ariaDescribedByElements).to.deep.equal([descriptionEl]);
-
-    const descSlot = el.shadowRoot.querySelector('slot[name="description"]');
-    const slotChangePromise = oneEvent(descSlot, 'slotchange');
-    el.removeChild(descriptionEl);
-    await slotChangePromise;
-
-    // Per spec, setting ariaDescribedByElements to an empty sequence unsets it (returns null)
-    expect(spinbutton.ariaDescribedByElements.length).to.equal(0);
-  });
-
-  it('sets ariaDescribedByElements when a description element is added dynamically', async () => {
+describe('auro-counter: spinbutton input', () => {
+  it('renders the spinbutton as an input element', async () => {
     const el = await fixture(html`<auro-counter>Counter</auro-counter>`);
-
     const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
-    const descSlot = el.shadowRoot.querySelector('slot[name="description"]');
-
-    const desc = document.createElement('span');
-    desc.setAttribute('slot', 'description');
-    desc.textContent = 'Added description';
-
-    const slotChangePromise = oneEvent(descSlot, 'slotchange');
-    el.appendChild(desc);
-    await slotChangePromise;
-
-    expect(spinbutton.ariaDescribedByElements).to.deep.equal([desc]);
+    expect(spinbutton.tagName.toLowerCase()).to.equal('input');
   });
 
-  it('does not use the aria-describedby attribute on the spinbutton', async () => {
-    const el = await fixture(html`
-      <auro-counter>
-        Counter
-        <span slot="description">Description text</span>
-      </auro-counter>
-    `);
-
+  it('spinbutton input is readonly', async () => {
+    const el = await fixture(html`<auro-counter>Counter</auro-counter>`);
     const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
+    expect(spinbutton.hasAttribute('readonly')).to.be.true;
+  });
 
-    expect(spinbutton.getAttribute('aria-describedby') === "" || !spinbutton.hasAttribute('aria-describedby')).to.be.true;
+  it('spinbutton input has autocomplete set to off', async () => {
+    const el = await fixture(html`<auro-counter>Counter</auro-counter>`);
+    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
+    expect(spinbutton.getAttribute('autocomplete')).to.equal('off');
+  });
+
+  it('spinbutton input is labelled by the counter-label element', async () => {
+    const el = await fixture(html`<auro-counter>Counter</auro-counter>`);
+    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
+    expect(spinbutton.getAttribute('aria-labelledby')).to.equal('counter-label');
+  });
+
+  it('spinbutton value attribute reflects the counter value', async () => {
+    const el = await fixture(html`<auro-counter value="3">Counter</auro-counter>`);
+    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
+    expect(spinbutton.getAttribute('value')).to.equal('3');
+  });
+
+  // This is to ensure that screen readers read the value as a string, preventing mispronunciation with percentage values
+  it('spinbutton aria-valuetext wraps value in single quotes', async () => {
+    const el = await fixture(html`<auro-counter value="5">Counter</auro-counter>`);
+    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
+    expect(spinbutton.getAttribute('aria-valuetext')).to.equal("'5'");
+  });
+
+  it('spinbutton aria-valuetext uses min when value is undefined', async () => {
+    const el = await fixture(html`<auro-counter min="1">Counter</auro-counter>`);
+    const spinbutton = el.shadowRoot.querySelector('[role="spinbutton"]');
+    expect(spinbutton.getAttribute('aria-valuetext')).to.equal("'1'");
   });
 });
+
+describe('auro-counter: button ariaControlsElements wiring', () => {
+  it('decrement button has data-spinbutton-operation="decrement"', async () => {
+    const el = await fixture(html`<auro-counter>Counter</auro-counter>`);
+    const decrementBtn = el.shadowRoot.querySelector('[part="controlMinus"]');
+    expect(decrementBtn.getAttribute('data-spinbutton-operation')).to.equal('decrement');
+  });
+
+  it('increment button has data-spinbutton-operation="increment"', async () => {
+    const el = await fixture(html`<auro-counter>Counter</auro-counter>`);
+    const incrementBtn = el.shadowRoot.querySelector('[part="controlPlus"]');
+    expect(incrementBtn.getAttribute('data-spinbutton-operation')).to.equal('increment');
+  });
+});
+


### PR DESCRIPTION
# Alaska Airlines Pull Request
[AB#1516613](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1516613)

- make the value text to be input element with spinbutton role to match with w3c practice https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/examples/quantity-spinbutton/
- remove aria-desciption as spinbutton does not support that attribute https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/spinbutton_role

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve the counter component’s spinbutton accessibility and focus behavior for assistive technologies.

New Features:
- Expose the counter value as a readonly input with spinbutton role to align with ARIA quantity spinbutton guidance.

Bug Fixes:
- Ensure counter increment/decrement controls are properly associated with the spinbutton value field for screen reader interaction.

Enhancements:
- Adjust focus styling to use focus-within so the counter’s visual focus follows keyboard interaction with the internal input.
- Hide decorative counter icons from assistive technologies and normalize the visual styling of the new input field.

Tests:
- Update counter accessibility tests to validate the new description and spinbutton behavior.

## Summary by Sourcery

Improve the counter component’s accessibility by exposing its value as a proper ARIA spinbutton input and aligning keyboard and assistive tech behavior with WAI-ARIA guidance.

New Features:
- Render the counter value as a readonly input element with role="spinbutton" whose value and aria-valuetext reflect the current counter value.

Bug Fixes:
- Ensure increment and decrement buttons are programmatically associated with the spinbutton value field for assistive technologies via control wiring attributes.
- Prevent screen readers from mispronouncing numeric values (e.g., percentages) by providing a string-based aria-valuetext for the spinbutton.

Enhancements:
- Align focus styling with interaction on the internal input by switching counter control focus handling to :focus-within.
- Hide decorative counter icons from assistive technologies and normalize styling of the embedded input to match the existing visual design.
- Remove unsupported ARIA description handling for the spinbutton role to conform to current ARIA specifications.

Tests:
- Update counter tests to validate the new spinbutton input rendering, labelling, aria-valuetext behavior, and button wiring for accessibility.