### PR TITLE
fix(datepicker): open bib with Enter key AB#1518947

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -46,14 +46,15 @@ import iconVersion from './iconVersion.js';
 import { AuroButton } from "@aurodesignsystem/auro-button/class";
 import buttonVersion from './buttonVersion.js';
 
-import { doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose } from '@aurodesignsystem/utils';
+import { doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
+import { datepickerKeyboardStrategy } from './datepickerKeyboardStrategy.js';
 
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * The `auro-datepicker` component provides users with a way to select a date or date range from a calendar popup or fullscreen calendar on mobile.
  * @customElement auro-datepicker
- * 
+ *
  * @slot helpText - Defines the content of the helpText.
  * @slot ariaLabel.bib.close - Sets aria-label on close button in fullscreen bib
  * @slot ariaLabel.input.clear - Sets aria-label on clear button
@@ -857,11 +858,8 @@ export class AuroDatePicker extends AuroElement {
     // Tab closes the fullscreen dialog (same pattern as select).
     // The dialog event bridge intercepts Tab and re-dispatches it as a
     // composed keydown; this listener catches the re-dispatched event.
-    this.addEventListener('keydown', (evt) => {
-      if (evt.key === 'Tab' && this.dropdown.isPopoverVisible && this.dropdown.isBibFullscreen) {
-        this.dropdown.hide();
-      }
-    });
+    // Enter opens the bib when it is closed.
+    applyKeyboardStrategy(this, datepickerKeyboardStrategy);
 
     this.dropdown.addEventListener('auroDropdown-triggerClick', () => {
       if (!this.isPopoverVisible) {

--- a/components/datepicker/src/datepickerKeyboardStrategy.js
+++ b/components/datepicker/src/datepickerKeyboardStrategy.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Alaska Airlines. All right reserved. Licensed under the Apache-2.0 license
+// See LICENSE in the project root for license information.
+
+export const datepickerKeyboardStrategy = {
+  Enter(component, evt, ctx) {
+    if (!ctx.isExpanded) {
+      evt.preventDefault();
+      component.dropdown.show();
+    }
+  },
+
+  Tab(component, _evt, ctx) {
+    if (ctx.isExpanded && ctx.isModal) {
+      component.dropdown.hide();
+    }
+  },
+};

--- a/components/datepicker/stories/component.stories.ts
+++ b/components/datepicker/stories/component.stories.ts
@@ -273,3 +273,35 @@ export const DatepickerBibCloseAriaLabel: Story = {
     await expect(bibCloseLabel.textContent.trim()).toBe('Close Calendar');
   },
 };
+
+// ─── Bib opens when Enter key is pressed ─────────────────────────────────────
+export const DatepickerBibOpensOnEnter: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
+  render: () => html`
+<auro-datepicker centralDate="03/01/2025">
+  <span slot="ariaLabel.bib.close">Close Calendar</span>
+  <span slot="bib.fullscreen.headline">Datepicker Headline</span>
+  <span slot="fromLabel">Departure date</span>
+  <span slot="bib.fullscreen.fromLabel">Choose a departure date</span>
+</auro-datepicker>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-datepicker') as any;
+    await el.updateComplete;
+
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await el.updateComplete;
+    await el.dropdown.updateComplete;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await wait(100);
+
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+  },
+};

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -1088,6 +1088,43 @@ describe('auro-datepicker', () => {
       'Wednesday, October 22nd, 2025'
     ]);
   });
+
+  it('opens the bib when Enter key is pressed and bib is closed', async () => {
+    const el = await fixture(html`<auro-datepicker></auro-datepicker>`);
+
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    await elementUpdated(el);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+  });
+
+  it('does not close the bib when Enter key is pressed and bib is already open', async () => {
+    const el = await fixture(html`<auro-datepicker></auro-datepicker>`);
+
+    const input = el.shadowRoot.querySelector('[auro-input]');
+    input.click();
+    await elementUpdated(el);
+
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    await elementUpdated(el);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+  });
+
+  it('does not open the bib when a key other than Enter is pressed', async () => {
+    const el = await fixture(html`<auro-datepicker></auro-datepicker>`);
+
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Space', bubbles: true }));
+
+    await elementUpdated(el);
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
+  });
 });
 
 describe('auro-datepicker with format', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Enter will open datepicker's bib

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure the datepicker bib opens with the Enter key while preserving existing keyboard behavior and coverage.

New Features:
- Allow users to open the datepicker bib by pressing the Enter key when it is closed.

Bug Fixes:
- Prevent the Enter key from toggling or closing the datepicker bib once it is already open.
- Ignore non-Enter key presses for bib open behavior to avoid unintended opening.

Tests:
- Add unit tests verifying that Enter opens the bib when closed, does not close it when already open, and that other keys do not open it.