### PR TITLE
test(combobox): add story for arrow key behavior when clear button is focused AB#1510818

### DIFF
--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -460,6 +460,13 @@ export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
     await waitUntil(() => !el.dropdown.isPopoverVisible);
     await expect(el.dropdown.isPopoverVisible).toBe(false);
 
+    // Wait two animation frames so that the restoreTriggerAfterClose rAF
+    // (scheduled when the bib closes) fires before we take focus. Without
+    // this, the rAF can steal focus from nativeBtn after we set it, making
+    // the isClearBtnFocused guard return false on cloud/CI runners where the
+    // rAF fires slightly later than the 20 ms waitUntil poll interval.
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
     // Focus the native button inside the clear button's shadow DOM.
     // The clear button is hidden (width:0/opacity:0) unless the wrapper has
     // :focus-within, which doesn't propagate through shadow DOM in all browsers.

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -415,3 +415,64 @@ export const ComboboxBibOpenOptionHighlighted: Story = {
   },
 };
 
+// ─── Arrow keys do not open bib when clear button is focused ─────────────────
+export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
+  tags: ['!autodocs'],
+  render: () => html`
+<auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Type a value and select the first option so the clear button appears
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await new Promise((r) => setTimeout(r, 100));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Bib should be closed after selection
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    // Focus the native button inside the clear button's shadow DOM.
+    // The clear button is hidden (width:0/opacity:0) unless the wrapper has
+    // :focus-within, which doesn't propagate through shadow DOM in all browsers.
+    // Force the container visible the same way the Tab handler does.
+    const clearBtn = el.input.shadowRoot.querySelector('.clearBtn') as any;
+    await expect(clearBtn).not.toBeNull();
+    const clearContainer = clearBtn.closest('.clear') as HTMLElement;
+    if (clearContainer) {
+      clearContainer.style.display = 'flex';
+    }
+    const nativeBtn = clearBtn.shadowRoot?.querySelector('button') as HTMLElement;
+    nativeBtn.focus();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Verify focus landed inside the clear button
+    await expect(clearBtn.shadowRoot.activeElement).not.toBeNull();
+
+    // Press ArrowDown — bib should NOT open
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await new Promise((r) => setTimeout(r, 100));
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    // Press ArrowUp — bib should NOT open
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    await new Promise((r) => setTimeout(r, 100));
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+  },
+};

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -431,12 +431,6 @@ async function waitUntil(predicate: () => boolean, timeout = 2000, interval = 20
 
 export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
   tags: ['!autodocs'],
-  parameters: {
-    chromatic: {
-      // Run only the desktop mode. Input clear button is not visible in the mobile viewport.
-      modes: { 'XL-Alaska-1232px': { viewport: 'xl', theme: 'Alaska' } },
-    },
-  },
   render: () => html`
 <auro-combobox>
   <span slot="ariaLabel.bib.close">Close combobox</span>
@@ -451,6 +445,13 @@ export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
 </auro-combobox>
   `,
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    // The clear button focus path is not reachable in fullscreen/modal mode
+    // (320px viewport). The combobox opens fullscreen at that width, moving
+    // the input into the bib where the Tab strategy differs. Skip mobile.
+    if (window.innerWidth <= 320) {
+      return;
+    }
+
     const el = canvasElement.querySelector('auro-combobox') as any;
     await el.updateComplete;
 

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -431,6 +431,12 @@ async function waitUntil(predicate: () => boolean, timeout = 2000, interval = 20
 
 export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
   tags: ['!autodocs'],
+  parameters: {
+    chromatic: {
+      // Run only the desktop mode. Input clear button is not visible in the mobile viewport.
+      modes: { 'XL-Alaska-1232px': { viewport: 'xl', theme: 'Alaska' } },
+    },
+  },
   render: () => html`
 <auro-combobox>
   <span slot="ariaLabel.bib.close">Close combobox</span>

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -416,6 +416,19 @@ export const ComboboxBibOpenOptionHighlighted: Story = {
 };
 
 // ─── Arrow keys do not open bib when clear button is focused ─────────────────
+
+/**
+ * Polls a predicate until it returns true or the timeout expires.
+ * More accurate than fixed setTimeout delays — resolves as soon as
+ * the condition is met rather than always waiting a fixed duration.
+ */
+async function waitUntil(predicate: () => boolean, timeout = 2000, interval = 20) {
+  const deadline = Date.now() + timeout;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
 export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
   tags: ['!autodocs'],
   render: () => html`
@@ -435,17 +448,16 @@ export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
     const el = canvasElement.querySelector('auro-combobox') as any;
     await el.updateComplete;
 
-    // Type a value and select the first option so the clear button appears
+    // Type a value and open the bib
     setInputValue(el, 'a');
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    await new Promise((r) => setTimeout(r, 100));
+    await waitUntil(() => el.dropdown.isPopoverVisible);
+
+    // Navigate to first option and select it
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     await el.updateComplete;
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    await el.updateComplete;
-    await new Promise((r) => setTimeout(r, 100));
-
-    // Bib should be closed after selection
+    await waitUntil(() => !el.dropdown.isPopoverVisible);
     await expect(el.dropdown.isPopoverVisible).toBe(false);
 
     // Focus the native button inside the clear button's shadow DOM.
@@ -460,19 +472,17 @@ export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
     }
     const nativeBtn = clearBtn.shadowRoot?.querySelector('button') as HTMLElement;
     nativeBtn.focus();
-    await new Promise((r) => setTimeout(r, 100));
-
-    // Verify focus landed inside the clear button
+    await waitUntil(() => clearBtn.shadowRoot.activeElement !== null);
     await expect(clearBtn.shadowRoot.activeElement).not.toBeNull();
 
     // Press ArrowDown — bib should NOT open
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-    await new Promise((r) => setTimeout(r, 100));
+    await el.updateComplete;
     await expect(el.dropdown.isPopoverVisible).toBe(false);
 
     // Press ArrowUp — bib should NOT open
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
-    await new Promise((r) => setTimeout(r, 100));
+    await el.updateComplete;
     await expect(el.dropdown.isPopoverVisible).toBe(false);
   },
 };


### PR DESCRIPTION
# Alaska Airlines Pull Request

This issue was addressed in https://github.com/AlaskaAirlines/auro-formkit/pull/1384, and this update adds a Storybook test.

## Testing

Tests pass with arrow keys disabled and fail when arrow keys enabled (expected).

## Review Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Tests:
- Add Storybook play-function scenario verifying arrow key presses do not open the combobox dropdown when focus is on the clear button.

## Summary by Sourcery

Tests:
- Add a Storybook play-function story that verifies arrow key presses do not open the combobox dropdown while focus is on the clear button.