### PR TITLE
fix(select|combobox): shift+tab moves active option to first non-disabled option AB#1516650

### DIFF
--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -57,8 +57,19 @@ export const comboboxKeyboardStrategy = {
     }
   },
 
-  Tab(component, _evt, ctx) {
+  Tab(component, evt, ctx) {
     if (!ctx.isExpanded) {
+      return;
+    }
+
+    // Shift+Tab moves the highlight to the first non-disabled option
+    // without making a selection or closing the bib.
+    if (evt.shiftKey) {
+      evt.preventDefault();
+      const firstActive = component.menu.menuService.menuOptions.find((option) => option.isActive);
+      if (firstActive) {
+        component.menu.updateActiveOption(firstActive);
+      }
       return;
     }
 

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -259,6 +259,55 @@ export const ComboboxHover: Story = {
 </auro-combobox>
   `,
 };
+
+// ─── Shift+Tab moves active option to first option, keeps bib open ───────────
+export const ComboboxShiftTabMovesToFirstOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+    const firstOption = el.querySelector('auro-menuoption[value="Apples"]');
+
+    // Type to filter options. Wait 100ms before clicking the trigger so the
+    // full Lit update chain settles (auro-input value → combobox processes
+    // input event → availableOptions updates). Using el.input.updateComplete
+    // is too fast — it resolves before auro-combobox finishes its own update.
+    // This matches the ComboboxBibOpensOnType pattern.
+    setInputValue(el, 'a');
+    await new Promise((r) => setTimeout(r, 100));
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+
+    // Navigate away from first option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    // Shift+Tab: should move to first option without selecting or closing
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    await el.updateComplete;
+
+    await expect(firstOption.classList.contains('active')).toBe(true);
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+    await expect(el.value).toBeUndefined();
+  },
+};
 ComboboxHover.parameters = {
   pseudo: {
     hover: true,

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -237,6 +237,86 @@ function runFulltest(mobileview) {
     await expect(el.value === options[0].textContent);
   });
 
+  // ─── Shift+Tab moves active option to first non-disabled option ────────────────
+  it('Shift+Tab moves active option to first option and keeps bib open', async () => {
+    const el = await shiftTabFixture(mobileview);
+    const options = el.querySelectorAll('auro-menuoption');
+
+    // Open the bib by typing and pressing Enter
+    el.focus();
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+    if (mobileview) {
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+    }
+
+    // Navigate down past the first option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    // Active should now be options[1] (Oranges or index 1)
+    await expect(el.optionActive).to.not.equal(options[0]);
+
+    // Shift+Tab should move to first option without selecting or closing
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive).to.equal(options[0]);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+    await expect(el.value).to.be.undefined;
+  });
+
+  it('Shift+Tab skips disabled first option when moving to first active option', async () => {
+    const el = await shiftTabDisabledFirstFixture(mobileview);
+    const options = el.querySelectorAll('auro-menuoption');
+
+    el.focus();
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+    if (mobileview) {
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+    }
+
+    // Navigate down to last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+
+    // Shift+Tab should land on options[1] — first non-disabled option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive).to.equal(options[1]);
+    await expect(el.dropdown.isPopoverVisible).to.be.true;
+    await expect(el.value).to.be.undefined;
+
+    // Close bib so the disabled option is not visible during the post-test
+    // a11y check — disabled text color does not meet contrast ratios.
+    el.hideBib();
+    await elementUpdated(el);
+  });
+
+  it('Shift+Tab with bib closed does nothing', async () => {
+    const el = await shiftTabFixture(mobileview);
+
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.dropdown.isPopoverVisible).to.be.false;
+    await expect(el.optionActive).to.be.null;
+  });
 
   // it('hides the bib when tabbing away from combobox', async () => {
   //   const el = await defaultFixture(mobileview);
@@ -1140,6 +1220,42 @@ async function persistInputFixture(mobileview) {
 /**
  *
  */
+async function shiftTabFixture(mobileview) {
+  if (mobileview) {
+    await setViewport({ width: 500, height: 800 });
+  } else {
+    await setViewport({ width: 800, height: 800 });
+  }
+  return fixture(html`
+  <auro-combobox>
+    <span slot="label">Name</span>
+    <auro-menu>
+      <auro-menuoption value="Apples" id="sh-option-0">Apples</auro-menuoption>
+      <auro-menuoption value="Oranges" id="sh-option-1">Oranges</auro-menuoption>
+      <auro-menuoption value="Grapes" id="sh-option-2">Grapes</auro-menuoption>
+    </auro-menu>
+  </auro-combobox>
+  `);
+}
+
+async function shiftTabDisabledFirstFixture(mobileview) {
+  if (mobileview) {
+    await setViewport({ width: 500, height: 800 });
+  } else {
+    await setViewport({ width: 800, height: 800 });
+  }
+  return fixture(html`
+  <auro-combobox>
+    <span slot="label">Name</span>
+    <auro-menu>
+      <auro-menuoption value="Apples" id="sh-dis-option-0" disabled>Apples</auro-menuoption>
+      <auro-menuoption value="Oranges" id="sh-dis-option-1">Oranges</auro-menuoption>
+      <auro-menuoption value="Grapes" id="sh-dis-option-2">Grapes</auro-menuoption>
+    </auro-menu>
+  </auro-combobox>
+  `);
+}
+
 async function defaultFixture(mobileview) {
   if (mobileview) {
     await setViewport({

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -22,8 +22,19 @@ export const selectKeyboardStrategy = {
     component.menu.makeSelection();
   },
 
-  Tab(component, _evt, ctx) {
+  Tab(component, evt, ctx) {
     if (!ctx.isExpanded) {
+      return;
+    }
+
+    // Shift+Tab moves the highlight to the first non-disabled option
+    // without making a selection or closing the bib.
+    if (evt.shiftKey) {
+      evt.preventDefault();
+      const firstActive = component.menu.menuService.menuOptions.find((option) => option.isActive);
+      if (firstActive) {
+        component.menu.updateActiveOption(firstActive);
+      }
       return;
     }
 

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -222,6 +222,45 @@ export const SelectAriaComboboxAttributes: Story = {
   },
 };
 
+// ─── §2.1.X  Shift+Tab moves active option to first option, keeps bib open ──
+export const SelectShiftTabMovesToFirstOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menuoption value="duration">Duration</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+    const firstOption = el.querySelector('auro-menuoption[value="stops"]');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    // Navigate to the last option so first is not currently active
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Shift+Tab: should move active to first option without selecting or closing
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(firstOption.classList.contains('active')).toBe(true);
+    await expect(el.isPopoverVisible).toBe(true);
+    await expect(el.value).toBeUndefined();
+  },
+};
+
 // ─── §2.4.1  Emphasized layout: dropdown opens correctly (P2) ───────────────
 export const SelectEmphasizedOpen: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -186,6 +186,34 @@ async function requiredFixture() {
   `);
 }
 
+async function shiftTabFixture() {
+  return await fixture(html`
+  <auro-select>
+    <span slot="bib.fullscreen.headline">Bib Headline</span>
+    <span slot="label">Name</span>
+    <auro-menu>
+      <auro-menuoption value="Stops" id="sh-option-0">Stops</auro-menuoption>
+      <auro-menuoption value="Price" id="sh-option-1">Price</auro-menuoption>
+      <auro-menuoption value="Duration" id="sh-option-2">Duration</auro-menuoption>
+    </auro-menu>
+  </auro-select>
+  `);
+}
+
+async function shiftTabDisabledFirstFixture() {
+  return await fixture(html`
+  <auro-select>
+    <span slot="bib.fullscreen.headline">Bib Headline</span>
+    <span slot="label">Name</span>
+    <auro-menu>
+      <auro-menuoption value="Stops" id="sh-dis-option-0" disabled>Stops</auro-menuoption>
+      <auro-menuoption value="Price" id="sh-dis-option-1">Price</auro-menuoption>
+      <auro-menuoption value="Duration" id="sh-dis-option-2">Duration</auro-menuoption>
+    </auro-menu>
+  </auro-select>
+  `);
+}
+
 function runTest(mobileView) {
   describe(`auro-select${mobileView ? ' in mobile' : ''}`, () => {
     before(async () => {
@@ -445,6 +473,79 @@ function runTest(mobileView) {
 
       await expect(dropdown.isPopoverVisible).to.be.false;
       await expect(el.value).to.be.undefined;
+    });
+
+    // ─── §2.1.X  Shift+Tab moves active option to first non-disabled option (P0) ─
+    it('Shift+Tab moves active option to first option and keeps bib open', async () => {
+      const el = await shiftTabFixture();
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+      const trigger = dropdown.querySelector('[slot="trigger"]');
+      const options = el.querySelectorAll('auro-menuoption');
+
+      trigger.click();
+      await elementUpdated(el);
+      await expect(dropdown.isPopoverVisible).to.be.true;
+
+      // Navigate to the last option so active is NOT the first
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      await expect(el.optionActive).to.equal(options[2]);
+
+      // Shift+Tab should move to the first option without selecting or closing
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+      await elementUpdated(el);
+
+      await expect(el.optionActive).to.equal(options[0]);
+      await expect(dropdown.isPopoverVisible).to.be.true;
+      await expect(el.value).to.be.undefined;
+    });
+
+    it('Shift+Tab skips disabled first option when moving to first active option', async () => {
+      const el = await shiftTabDisabledFirstFixture();
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+      const trigger = dropdown.querySelector('[slot="trigger"]');
+      const options = el.querySelectorAll('auro-menuoption');
+
+      trigger.click();
+      await elementUpdated(el);
+      await expect(dropdown.isPopoverVisible).to.be.true;
+
+      // Navigate to last option
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+
+      // Shift+Tab should land on options[1] (first non-disabled)
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+      await elementUpdated(el);
+
+      // options[0] is disabled so the first enabled option is options[1]
+      await expect(el.optionActive).to.equal(options[1]);
+      await expect(dropdown.isPopoverVisible).to.be.true;
+      await expect(el.value).to.be.undefined;
+
+      // Close bib so the disabled option is not visible during the post-test
+      // a11y check — disabled text color does not meet contrast ratios.
+      dropdown.hide();
+      await elementUpdated(el);
+    });
+
+    it('Shift+Tab with bib closed does nothing', async () => {
+      const el = await shiftTabFixture();
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+
+      await expect(dropdown.isPopoverVisible).to.be.false;
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+      await elementUpdated(el);
+
+      await expect(dropdown.isPopoverVisible).to.be.false;
+      await expect(el.optionActive).to.be.undefined;
     });
 
     // ─── §2.1.5  Escape closes bib without making a selection (P0) ──────────

--- a/context/keyboard-spec.md
+++ b/context/keyboard-spec.md
@@ -204,6 +204,7 @@ The trade-off: intercepted keys must have their native behaviors manually re-imp
 | **Escape** | Closes the popup without selecting, returns focus to trigger | APG select-only combobox |
 | **Tab** (no option highlighted) | Closes the popup, moves focus to next focusable element on the page | APG select-only combobox |
 | **Tab** (option highlighted) | Selects the highlighted option, closes the popup, moves focus to next focusable element | APG select-only combobox |
+| **Shift+Tab** | Moves visual focus to first non-disabled option, keeps popup open, no selection | Design decision |
 | **Home** | Moves visual focus to first option | APG select-only combobox |
 | **End** | Moves visual focus to last option | APG select-only combobox |
 | **Type-ahead** | Moves visual focus to next option starting with typed character | APG select-only combobox |
@@ -220,6 +221,7 @@ Menu options are **not in the Tab order**. They use `aria-activedescendant` for 
 | **Escape** | Closes the dialog without selecting, returns focus to trigger | Native `<dialog>` `cancel` event | Browsers handle this natively for `<dialog>` |
 | **Tab** (no option highlighted) | Closes the dialog, returns focus to trigger | Design decision (see below) | |
 | **Tab** (option highlighted) | Selects the highlighted option, closes the dialog, returns focus to trigger | Design decision (see below) | |
+| **Shift+Tab** | Moves visual focus to first non-disabled option, keeps dialog open, no selection | Design decision | Bridge re-dispatches Shift+Tab so behavior is identical in fullscreen and desktop |
 
 ### Fullscreen (Mobile) — Combobox Dialog Open
 
@@ -235,6 +237,7 @@ Same arrow key, Enter, and Escape behavior as select. Tab behavior differs becau
 | **Tab** (focus on clear button, option highlighted) | Selects the highlighted option, closes the dialog, returns focus to trigger | Design decision | Consistent with select's Tab behavior |
 | **Tab** (focus on clear button, no option highlighted) | Closes the dialog, returns focus to trigger | Design decision | Tabbing past the last focusable element closes the dialog |
 | **Tab** (no clear button / no value) | Closes the dialog, returns focus to trigger | Design decision | Same as select behavior |
+| **Shift+Tab** | Moves visual focus to first non-disabled option, keeps dialog open, no selection | Design decision | Available regardless of clear button state; bridge re-dispatches Shift+Tab with `shiftKey` preserved |
 
 ---
 
@@ -248,8 +251,17 @@ The dialog event bridge preserves all four modifier flags when re-dispatching ev
 
 ```js
 Tab(component, evt, ctx) {
+  if (!ctx.isExpanded) {
+    return;
+  }
+
+  // Shift+Tab moves the highlight to the first non-disabled option
+  // without making a selection or closing the bib.
   if (evt.shiftKey) {
-    component.dropdown.hide();
+    const firstActive = component.menu.menuService.menuOptions.find(o => o.isActive);
+    if (firstActive) {
+      component.menu.updateActiveOption(firstActive);
+    }
     return;
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request introduces improved keyboard accessibility for both the Combobox and Select components by adding support for Shift+Tab navigation when the popup/bib is open. Pressing Shift+Tab now moves the visual focus to the first non-disabled option without making a selection or closing the popup, aligning with updated accessibility guidelines and design decisions. The implementation is accompanied by comprehensive unit and Storybook tests, as well as updated documentation.

## Manual testing

### `auro-select`

- [ ] Open the popup, press `↓` 2–3 times, then press `Shift+Tab` → highlight jumps to the first option; popup stays open; no value selected
- [ ] With the popup closed, press `Shift+Tab` → moves to previous selection on page
- [ ] **Regression:** open popup, highlight an option, press `Tab` (no shift) → option is selected and popup closes

### `auro-combobox`

- [ ] Type to open the bib, press `↓` to move off the first match, then press `Shift+Tab` → highlight returns to the first match; bib stays open; nothing committed to the input
- [ ] With the bib closed, press `Shift+Tab` → moves to previous selection on page
- [ ] **Regression:** open bib, highlight an option, press `Tab` (no shift) → option is written to the input and bib closes

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add Shift+Tab keyboard navigation behavior to combobox and select components and document the updated interaction pattern.

New Features:
- Support Shift+Tab to move the active option to the first non-disabled option while keeping the popup/bib open for auro-select and auro-combobox.

Enhancements:
- Document the Shift+Tab behavior in the shared keyboard interaction spec and align dialog bridge handling to preserve the interaction.
- Add Storybook stories demonstrating Shift+Tab behavior for select and combobox components.

Tests:
- Add unit tests covering Shift+Tab navigation behavior and disabled-first-option handling for select and combobox components, including the no-op behavior when the popup/bib is closed.