### PR TITLE
fix(voiceover): fullscreen mode in combobox and select components using arrows AB#1525392

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -901,7 +901,10 @@ export class AuroCombobox extends AuroElement {
       // the CSS rule `.wrapper:not(:focus-within) .notification.clear`
       // hides the container with display:none, preventing focus.
       const clearContainer = clearBtn.closest('.clear');
+<<<<<<< HEAD
 
+=======
+>>>>>>> 53d8fdee (fix(combobox): fix tab behavior to select option and focus clear button)
       if (clearContainer) {
         clearContainer.style.display = 'flex';
         clearBtn.addEventListener('focusout', () => {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -14,7 +14,7 @@ import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts
 import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
 import AuroFormValidation from '@aurodesignsystem/form-validation';
 
-import { announceToScreenReader, closeFullscreenDialog, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
+import { announceToScreenReader, getAnnouncementRoot, closeFullscreenDialog, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
 import { comboboxKeyboardStrategy } from './comboboxKeyboardStrategy.js';
 
 import { AuroDropdown } from '@aurodesignsystem/auro-dropdown';
@@ -1091,14 +1091,7 @@ export class AuroCombobox extends AuroElement {
         const optionIndex = this.availableOptions.indexOf(this.optionActive) + 1;
         const optionCount = this.availableOptions.length;
 
-        // In fullscreen mode the combobox's live region is outside the modal
-        // dialog and inert, so route announcements to the bib's live region
-        // which is inside the dialog.
-        const bibEl = this.dropdown.bibElement && this.dropdown.bibElement.value;
-        const bibShadowRoot = bibEl && bibEl.shadowRoot;
-        const announcementRoot = this.dropdown.isBibFullscreen && bibShadowRoot
-          ? bibShadowRoot
-          : this.shadowRoot;
+        const announcementRoot = getAnnouncementRoot(this.dropdown, this.shadowRoot);
 
         announceToScreenReader(announcementRoot, `${optionText}${selectedState}, ${optionIndex} of ${optionCount}`);
       }

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -906,10 +906,7 @@ export class AuroCombobox extends AuroElement {
       // the CSS rule `.wrapper:not(:focus-within) .notification.clear`
       // hides the container with display:none, preventing focus.
       const clearContainer = clearBtn.closest('.clear');
-<<<<<<< HEAD
 
-=======
->>>>>>> 53d8fdee (fix(combobox): fix tab behavior to select option and focus clear button)
       if (clearContainer) {
         clearContainer.style.display = 'flex';
         clearBtn.addEventListener('focusout', () => {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -758,6 +758,11 @@ export class AuroCombobox extends AuroElement {
       // Clear aria-activedescendant when dropdown closes
       if (!this.dropdownOpen && this.input) {
         this.input.setActiveDescendant(null);
+        // Also clear on inputInBib since fullscreen mode sets
+        // aria-activedescendant on both inputs.
+        if (this.inputInBib) {
+          this.inputInBib.setActiveDescendant(null);
+        }
         this.optionActive = null;
 
         // Remove the highlighted state from all menu options so re-opening
@@ -1073,6 +1078,13 @@ export class AuroCombobox extends AuroElement {
         this.input.setActiveDescendant(this.optionActive);
       }
 
+      // In fullscreen mode, focus is on inputInBib inside the dialog, so
+      // aria-activedescendant must also be set there for screen readers to
+      // follow the active option from the focused element.
+      if (this.inputInBib && this.dropdown.isBibFullscreen) {
+        this.inputInBib.setActiveDescendant(this.optionActive);
+      }
+
       // Announce the active option for screen readers including position,
       // since shadow DOM boundaries prevent native reading of
       // aria-setsize/aria-posinset via aria-activedescendant.
@@ -1081,7 +1093,17 @@ export class AuroCombobox extends AuroElement {
         const selectedState = this.optionActive.hasAttribute('selected') ? ', selected' : ', not selected';
         const optionIndex = this.availableOptions.indexOf(this.optionActive) + 1;
         const optionCount = this.availableOptions.length;
-        announceToScreenReader(this.shadowRoot, `${optionText}${selectedState}, ${optionIndex} of ${optionCount}`);
+
+        // In fullscreen mode the combobox's live region is outside the modal
+        // dialog and inert, so route announcements to the bib's live region
+        // which is inside the dialog.
+        const bibEl = this.dropdown.bibElement && this.dropdown.bibElement.value;
+        const bibShadowRoot = bibEl && bibEl.shadowRoot;
+        const announcementRoot = this.dropdown.isBibFullscreen && bibShadowRoot
+          ? bibShadowRoot
+          : this.shadowRoot;
+
+        announceToScreenReader(announcementRoot, `${optionText}${selectedState}, ${optionIndex} of ${optionCount}`);
       }
 
       // Check if user prefers reduced motion for accessibility

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -486,6 +486,140 @@ export const ComboboxBibOpenOptionHighlighted: Story = {
 // ─── Arrow keys do not open bib when clear button is focused ─────────────────
 
 
+// ─── Fullscreen: live region announcements route to bib ─────────────────────
+export const ComboboxFullscreenLiveRegionInBib: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes" id="option-2">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Open the dropdown
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    await waitUntil(() => el.dropdown.isPopoverVisible);
+
+    // Simulate fullscreen
+    el.dropdown.isBibFullscreen = true;
+    await el.updateComplete;
+
+    // Navigate to an option via the menu directly (dialog bridge
+    // doesn't fire in Storybook's play function environment)
+    el.menu.navigateOptions('down');
+    await el.updateComplete;
+
+    // Wait a frame for the rAF inside announceToScreenReader
+    await new Promise((r) => requestAnimationFrame(r));
+
+    const bibEl = el.dropdown.bibElement.value;
+    const bibLiveRegion = bibEl.shadowRoot.querySelector('#srAnnouncement');
+    await expect(bibLiveRegion).not.toBeNull();
+    await expect(bibLiveRegion.textContent).not.toBe('');
+  },
+};
+
+// ─── Fullscreen: aria-activedescendant set on inputInBib ────────────────────
+export const ComboboxFullscreenActiveDescendantOnInputInBib: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes" id="option-2">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Open the dropdown
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    await waitUntil(() => el.dropdown.isPopoverVisible);
+
+    // Simulate fullscreen
+    el.dropdown.isBibFullscreen = true;
+    await el.updateComplete;
+    await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
+
+    // Navigate to an option
+    el.menu.navigateOptions('down');
+    await el.updateComplete;
+    await el.inputInBib.updateComplete;
+
+    await expect(el.optionActive).not.toBeNull();
+
+    const nativeInput = el.inputInBib.inputElement;
+    await expect(nativeInput.getAttribute('aria-activedescendant')).not.toBeNull();
+  },
+};
+
+// ─── Fullscreen: aria-activedescendant cleared on close ─────────────────────
+export const ComboboxFullscreenActiveDescendantClearedOnClose: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Bib Header</span>
+  <span slot="label">Fruit</span>
+  <auro-menu>
+    <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+    <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+    <auro-menuoption value="Grapes" id="option-2">Grapes</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Open the dropdown
+    setInputValue(el, 'a');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await el.updateComplete;
+    await waitUntil(() => el.dropdown.isPopoverVisible);
+
+    // Simulate fullscreen
+    el.dropdown.isBibFullscreen = true;
+    await el.updateComplete;
+    await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
+
+    // Navigate to set activedescendant
+    el.menu.navigateOptions('down');
+    await el.updateComplete;
+
+    // Close the dropdown
+    el.hideBib();
+    await el.updateComplete;
+    await waitUntil(() => !el.dropdown.isPopoverVisible);
+    await el.inputInBib.updateComplete;
+
+    const nativeInput = el.inputInBib.inputElement;
+    await expect(nativeInput.hasAttribute('aria-activedescendant')).toBe(false);
+  },
+};
+
 export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
   tags: ['!autodocs'],
   render: () => html`

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -514,7 +514,7 @@ export const ComboboxFullscreenLiveRegionInBib: Story = {
 
     // Simulate fullscreen
     el.dropdown.isBibFullscreen = true;
-    await el.updateComplete;
+    await el.dropdown.updateComplete;
 
     // Navigate to an option via the menu directly (dialog bridge
     // doesn't fire in Storybook's play function environment)
@@ -559,7 +559,7 @@ export const ComboboxFullscreenActiveDescendantOnInputInBib: Story = {
 
     // Simulate fullscreen
     el.dropdown.isBibFullscreen = true;
-    await el.updateComplete;
+    await el.dropdown.updateComplete;
     await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
 
     // Navigate to an option
@@ -602,7 +602,7 @@ export const ComboboxFullscreenActiveDescendantClearedOnClose: Story = {
 
     // Simulate fullscreen
     el.dropdown.isBibFullscreen = true;
-    await el.updateComplete;
+    await el.dropdown.updateComplete;
     await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
 
     // Navigate to set activedescendant

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -1065,7 +1065,7 @@ function runFulltest(mobileview) {
 
         // Simulate fullscreen (resize observers don't fire in test env)
         el.dropdown.isBibFullscreen = true;
-        await elementUpdated(el);
+        await elementUpdated(el.dropdown);
 
         // Navigate to an option
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
@@ -1093,7 +1093,7 @@ function runFulltest(mobileview) {
 
         // Simulate fullscreen (resize observers don't fire in test env)
         el.dropdown.isBibFullscreen = true;
-        await elementUpdated(el);
+        await elementUpdated(el.dropdown);
 
         // Wait for inputInBib's inner input to render
         await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
@@ -1127,7 +1127,7 @@ function runFulltest(mobileview) {
 
         // Simulate fullscreen (resize observers don't fire in test env)
         el.dropdown.isBibFullscreen = true;
-        await elementUpdated(el);
+        await elementUpdated(el.dropdown);
 
         // Wait for inputInBib's inner input to render
         await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -1021,7 +1021,12 @@ function runFulltest(mobileview) {
       // Wait a frame for the rAF inside announceToScreenReader
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      const liveRegion = el.shadowRoot.querySelector('#srAnnouncement');
+      // In fullscreen mode, announcements route to the bib's live region
+      // inside the dialog; in desktop mode, to the component's own shadow root.
+      const announcementRoot = el.dropdown.isBibFullscreen
+        ? el.dropdown.bibElement.value.shadowRoot
+        : el.shadowRoot;
+      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
       expect(liveRegion).to.exist;
       expect(liveRegion.textContent).to.not.equal('');
     });
@@ -1039,7 +1044,13 @@ function runFulltest(mobileview) {
       await elementUpdated(el);
 
       await new Promise((resolve) => requestAnimationFrame(resolve));
-      const liveRegion = el.shadowRoot.querySelector('#srAnnouncement');
+
+      // In fullscreen mode, announcements route to the bib's live region
+      // inside the dialog; in desktop mode, to the component's own shadow root.
+      const announcementRoot = el.dropdown.isBibFullscreen
+        ? el.dropdown.bibElement.value.shadowRoot
+        : el.shadowRoot;
+      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
       expect(liveRegion.textContent).to.not.equal('');
 
       // Multiple announcements can chain (e.g., active-option followed by selection),
@@ -1048,6 +1059,102 @@ function runFulltest(mobileview) {
       await new Promise((resolve) => setTimeout(resolve, 2200));
       expect(liveRegion.textContent).to.equal('');
     });
+
+    if (mobileview) {
+      it('routes announcements to the bib live region in fullscreen mode', async () => {
+        const el = await noFilterFixture(mobileview);
+        await elementUpdated(el);
+
+        // Open the dropdown
+        el.focus();
+        setInputValue(el, 'a');
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        await elementUpdated(el);
+        await waitUntil(() => el.dropdown.isPopoverVisible);
+
+        // Simulate fullscreen (resize observers don't fire in test env)
+        el.dropdown.isBibFullscreen = true;
+        await elementUpdated(el);
+
+        // Navigate to an option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        // Wait a frame for the rAF inside announceToScreenReader
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+
+        const bibEl = el.dropdown.bibElement.value;
+        const bibLiveRegion = bibEl.shadowRoot.querySelector('#srAnnouncement');
+        expect(bibLiveRegion).to.exist;
+        expect(bibLiveRegion.textContent).to.not.equal('');
+      });
+
+      it('sets aria-activedescendant on inputInBib in fullscreen mode', async () => {
+        const el = await noFilterFixture(mobileview);
+        await elementUpdated(el);
+
+        // Open the dropdown
+        el.focus();
+        setInputValue(el, 'a');
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        await elementUpdated(el);
+        await waitUntil(() => el.dropdown.isPopoverVisible);
+
+        // Simulate fullscreen (resize observers don't fire in test env)
+        el.dropdown.isBibFullscreen = true;
+        await elementUpdated(el);
+
+        // Wait for inputInBib's inner input to render
+        await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
+
+        // Navigate directly via the menu to trigger auroMenu-activatedOption,
+        // bypassing the dialog keyboard bridge which doesn't fire in test env.
+        el.menu.navigateOptions('down');
+        await elementUpdated(el);
+        // Wait for Lit to propagate optionActive to inputInBib's template
+        await elementUpdated(el.inputInBib);
+
+        expect(el.optionActive).to.exist;
+
+        // The Lit template binding sets a11yActivedescendant on inputInBib
+        // when optionActive is set, which renders as aria-activedescendant
+        // on the native input.
+        const nativeInput = el.inputInBib.inputElement;
+        expect(nativeInput.getAttribute('aria-activedescendant')).to.exist;
+      });
+
+      it('clears aria-activedescendant on inputInBib when dropdown closes', async () => {
+        const el = await noFilterFixture(mobileview);
+        await elementUpdated(el);
+
+        // Open the dropdown
+        el.focus();
+        setInputValue(el, 'a');
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        await elementUpdated(el);
+        await waitUntil(() => el.dropdown.isPopoverVisible);
+
+        // Simulate fullscreen (resize observers don't fire in test env)
+        el.dropdown.isBibFullscreen = true;
+        await elementUpdated(el);
+
+        // Wait for inputInBib's inner input to render
+        await waitUntil(() => el.inputInBib && el.inputInBib.inputElement);
+
+        // Navigate directly via the menu to set activedescendant
+        el.menu.navigateOptions('down');
+        await elementUpdated(el);
+
+        // Close the dropdown
+        el.hideBib();
+        await elementUpdated(el);
+        await waitUntil(() => !el.dropdown.isPopoverVisible);
+        await elementUpdated(el.inputInBib);
+
+        const nativeInput = el.inputInBib.inputElement;
+        expect(nativeInput.hasAttribute('aria-activedescendant')).to.be.false;
+      });
+    }
   });
 
   describe('updateBibDialogRole', () => {

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -2,6 +2,7 @@
 import { fixture, html, expect, waitUntil, elementUpdated, oneEvent } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import { comboboxKeyboardStrategy } from '../src/comboboxKeyboardStrategy.js';
+import { getAnnouncementRoot } from '@aurodesignsystem/utils';
 import '../src/registered.js';
 import '../../menu/src/registered.js';
 
@@ -1021,12 +1022,7 @@ function runFulltest(mobileview) {
       // Wait a frame for the rAF inside announceToScreenReader
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      // In fullscreen mode, announcements route to the bib's live region
-      // inside the dialog; in desktop mode, to the component's own shadow root.
-      const announcementRoot = el.dropdown.isBibFullscreen
-        ? el.dropdown.bibElement.value.shadowRoot
-        : el.shadowRoot;
-      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
+      const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
       expect(liveRegion).to.exist;
       expect(liveRegion.textContent).to.not.equal('');
     });
@@ -1045,12 +1041,7 @@ function runFulltest(mobileview) {
 
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      // In fullscreen mode, announcements route to the bib's live region
-      // inside the dialog; in desktop mode, to the component's own shadow root.
-      const announcementRoot = el.dropdown.isBibFullscreen
-        ? el.dropdown.bibElement.value.shadowRoot
-        : el.shadowRoot;
-      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
+      const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
       expect(liveRegion.textContent).to.not.equal('');
 
       // Multiple announcements can chain (e.g., active-option followed by selection),

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -451,6 +451,7 @@ export class AuroDropdownBib extends LitElement {
     return html`
       <dialog class="${classMap(classes)}" part="bibContainer" role="${ifDefined(this.dialogRole)}" aria-labelledby="${ifDefined(this.dialogLabel ? 'dialogLabel' : undefined)}">
         ${this.dialogLabel ? html`<span id="dialogLabel" class="util_displayHiddenVisually">${this.dialogLabel}</span>` : ''}
+        <span id="srAnnouncement" class="util_displayHiddenVisually" aria-live="polite" role="status"></span>
         <slot></slot>
       </dialog>
     `;

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -18,7 +18,7 @@ import tokensCss from "./styles/tokens-css.js";
 import AuroFormValidation from '@aurodesignsystem/form-validation';
 import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
 
-import { announceToScreenReader, closeFullscreenDialog, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
+import { announceToScreenReader, getAnnouncementRoot, closeFullscreenDialog, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
 import { selectKeyboardStrategy } from './selectKeyboardStrategy.js';
 
 import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
@@ -791,17 +791,10 @@ export class AuroSelect extends AuroElement {
       }
 
       // Announce the active option for screen readers.
-      // In fullscreen mode the select's live region is outside the modal
-      // dialog and inert, so route announcements to the bib's live region
-      // which is inside the dialog.
       if (this.optionActive) {
         const optionText = this.optionActive.textContent.trim();
         const selectedState = this.optionActive.hasAttribute('selected') ? ', selected' : ', not selected';
-        const bibEl = this.dropdown.bibElement && this.dropdown.bibElement.value;
-        const bibShadowRoot = bibEl && bibEl.shadowRoot;
-        const announcementRoot = this.dropdown.isBibFullscreen && bibShadowRoot
-          ? bibShadowRoot
-          : this.shadowRoot;
+        const announcementRoot = getAnnouncementRoot(this.dropdown, this.shadowRoot);
 
         announceToScreenReader(announcementRoot, `${optionText}${selectedState}`);
       }

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -790,11 +790,20 @@ export class AuroSelect extends AuroElement {
         this.dropdown.setActiveDescendant(this.optionActive);
       }
 
-      // Announce the active option for screen readers
+      // Announce the active option for screen readers.
+      // In fullscreen mode the select's live region is outside the modal
+      // dialog and inert, so route announcements to the bib's live region
+      // which is inside the dialog.
       if (this.optionActive) {
         const optionText = this.optionActive.textContent.trim();
         const selectedState = this.optionActive.hasAttribute('selected') ? ', selected' : ', not selected';
-        announceToScreenReader(this.shadowRoot, `${optionText}${selectedState}`);
+        const bibEl = this.dropdown.bibElement && this.dropdown.bibElement.value;
+        const bibShadowRoot = bibEl && bibEl.shadowRoot;
+        const announcementRoot = this.dropdown.isBibFullscreen && bibShadowRoot
+          ? bibShadowRoot
+          : this.shadowRoot;
+
+        announceToScreenReader(announcementRoot, `${optionText}${selectedState}`);
       }
 
       if (this.dropdown.isPopoverVisible) {

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -454,3 +454,44 @@ export const SelectFullscreenEnterOnCloseSelectsActiveOption: Story = {
   },
 };
 
+// ─── Fullscreen: live region announcements route to bib ─────────────────────
+export const SelectFullscreenLiveRegionInBib: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops" id="option-0">Stops</auro-menuoption>
+    <auro-menuoption value="price" id="option-1">Price</auro-menuoption>
+    <auro-menuoption value="duration" id="option-2">Duration</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    // Simulate fullscreen
+    el.dropdown.isBibFullscreen = true;
+    await el.updateComplete;
+
+    // Navigate to an option via the menu directly (dialog bridge
+    // doesn't fire in Storybook's play function environment)
+    el.menu.navigateOptions('down');
+    await el.updateComplete;
+
+    // Wait a frame for the rAF inside announceToScreenReader
+    await new Promise((r) => requestAnimationFrame(r));
+
+    const bibEl = el.dropdown.bibElement.value;
+    const bibLiveRegion = bibEl.shadowRoot.querySelector('#srAnnouncement');
+    await expect(bibLiveRegion).not.toBeNull();
+    await expect(bibLiveRegion.textContent).not.toBe('');
+  },
+};
+

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -478,7 +478,7 @@ export const SelectFullscreenLiveRegionInBib: Story = {
 
     // Simulate fullscreen
     el.dropdown.isBibFullscreen = true;
-    await el.updateComplete;
+    await el.dropdown.updateComplete;
 
     // Navigate to an option via the menu directly (dialog bridge
     // doesn't fire in Storybook's play function environment)

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -480,15 +480,23 @@ export const SelectFullscreenLiveRegionInBib: Story = {
     el.dropdown.isBibFullscreen = true;
     await el.dropdown.updateComplete;
 
+    const bibEl = el.dropdown.bibElement.value;
+
+    if (bibEl?.updateComplete) {
+      await bibEl.updateComplete;
+    }
+
     // Navigate to an option via the menu directly (dialog bridge
     // doesn't fire in Storybook's play function environment)
     el.menu.navigateOptions('down');
-    await el.updateComplete;
+    await el.dropdown.updateComplete;
+
+    if (bibEl?.updateComplete) {
+      await bibEl.updateComplete;
+    }
 
     // Wait a frame for the rAF inside announceToScreenReader
     await new Promise((r) => requestAnimationFrame(r));
-
-    const bibEl = el.dropdown.bibElement.value;
     const bibLiveRegion = bibEl.shadowRoot.querySelector('#srAnnouncement');
     await expect(bibLiveRegion).not.toBeNull();
     await expect(bibLiveRegion.textContent).not.toBe('');

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines, jsdoc/require-jsdoc, no-return-await, no-undef */
 import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
 
-import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated, waitUntil } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import { selectKeyboardStrategy } from '../src/selectKeyboardStrategy.js';
 import '@aurodesignsystem/auro-dropdown';
@@ -1154,7 +1154,12 @@ function runTest(mobileView) {
       // Wait a frame for the rAF inside announceToScreenReader
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      const liveRegion = el.shadowRoot.querySelector('#srAnnouncement');
+      // In fullscreen mode, announcements route to the bib's live region
+      // inside the dialog; in desktop mode, to the component's own shadow root.
+      const announcementRoot = el.dropdown.isBibFullscreen
+        ? el.dropdown.bibElement.value.shadowRoot
+        : el.shadowRoot;
+      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
       expect(liveRegion).to.exist;
       expect(liveRegion.textContent).to.not.equal('');
     });
@@ -1167,7 +1172,13 @@ function runTest(mobileView) {
       await elementUpdated(el);
 
       await new Promise((resolve) => requestAnimationFrame(resolve));
-      const liveRegion = el.shadowRoot.querySelector('#srAnnouncement');
+
+      // In fullscreen mode, announcements route to the bib's live region
+      // inside the dialog; in desktop mode, to the component's own shadow root.
+      const announcementRoot = el.dropdown.isBibFullscreen
+        ? el.dropdown.bibElement.value.shadowRoot
+        : el.shadowRoot;
+      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
       expect(liveRegion.textContent).to.not.equal('');
 
       // Multiple announcements can chain (e.g., active-option followed by selection),
@@ -1176,6 +1187,35 @@ function runTest(mobileView) {
       await new Promise((resolve) => setTimeout(resolve, 2200));
       expect(liveRegion.textContent).to.equal('');
     });
+
+    if (mobileView) {
+      it('routes announcements to the bib live region in fullscreen mode', async () => {
+        const el = await defaultFixture();
+        await setScreenSize(mobileView);
+        await elementUpdated(el);
+
+        // Open the dropdown
+        el.dropdown.show();
+        await elementUpdated(el);
+        await waitUntil(() => el.dropdown.isPopoverVisible);
+
+        // Simulate fullscreen (resize observers don't fire in test env)
+        el.dropdown.isBibFullscreen = true;
+        await elementUpdated(el);
+
+        // Navigate to an option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        // Wait a frame for the rAF inside announceToScreenReader
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+
+        const bibEl = el.dropdown.bibElement.value;
+        const bibLiveRegion = bibEl.shadowRoot.querySelector('#srAnnouncement');
+        expect(bibLiveRegion).to.exist;
+        expect(bibLiveRegion.textContent).to.not.equal('');
+      });
+    }
   });
 }
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1192,7 +1192,7 @@ function runTest(mobileView) {
 
         // Simulate fullscreen (resize observers don't fire in test env)
         el.dropdown.isBibFullscreen = true;
-        await elementUpdated(el);
+        await elementUpdated(el.dropdown);
 
         // Navigate to an option
         el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -4,6 +4,7 @@ import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plu
 import { fixture, html, expect, elementUpdated, waitUntil } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import { selectKeyboardStrategy } from '../src/selectKeyboardStrategy.js';
+import { getAnnouncementRoot } from '@aurodesignsystem/utils';
 import '@aurodesignsystem/auro-dropdown';
 import '../../menu/src/registered.js';
 import '../src/registered.js';
@@ -1154,12 +1155,7 @@ function runTest(mobileView) {
       // Wait a frame for the rAF inside announceToScreenReader
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      // In fullscreen mode, announcements route to the bib's live region
-      // inside the dialog; in desktop mode, to the component's own shadow root.
-      const announcementRoot = el.dropdown.isBibFullscreen
-        ? el.dropdown.bibElement.value.shadowRoot
-        : el.shadowRoot;
-      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
+      const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
       expect(liveRegion).to.exist;
       expect(liveRegion.textContent).to.not.equal('');
     });
@@ -1173,12 +1169,7 @@ function runTest(mobileView) {
 
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      // In fullscreen mode, announcements route to the bib's live region
-      // inside the dialog; in desktop mode, to the component's own shadow root.
-      const announcementRoot = el.dropdown.isBibFullscreen
-        ? el.dropdown.bibElement.value.shadowRoot
-        : el.shadowRoot;
-      const liveRegion = announcementRoot.querySelector('#srAnnouncement');
+      const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
       expect(liveRegion.textContent).to.not.equal('');
 
       // Multiple announcements can chain (e.g., active-option followed by selection),

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -29,17 +29,20 @@ const pendingClearTimeouts = new WeakMap();
  *
  * @param {HTMLElement} dropdown - The `auro-dropdown` element.
  * @param {ShadowRoot} fallbackRoot - The component's own shadow root (used in desktop mode).
- * @returns {ShadowRoot} The shadow root containing the target `#srAnnouncement` element.
+ * @returns {ShadowRoot|null} The shadow root containing the target `#srAnnouncement` element,
+ *   or `null` when fullscreen mode is active but the bib shadow root is not yet available
+ *   (the announcement is silently skipped rather than sent to the inert host shadow root).
  */
 export function getAnnouncementRoot(dropdown, fallbackRoot) {
-  const bibEl = dropdown.bibElement && dropdown.bibElement.value;
-  const bibShadowRoot = bibEl && bibEl.shadowRoot;
-  return dropdown.isBibFullscreen && bibShadowRoot
-    ? bibShadowRoot
-    : fallbackRoot;
+  if (dropdown.isBibFullscreen) {
+    const bibEl = dropdown.bibElement && dropdown.bibElement.value;
+    return (bibEl && bibEl.shadowRoot) || null;
+  }
+  return fallbackRoot;
 }
 
 export function announceToScreenReader(shadowRoot, text) {
+  if (!shadowRoot) return;
   const liveRegion = shadowRoot.querySelector('#srAnnouncement');
   if (liveRegion) {
     // Cancel any pending clear so a previous announcement's timeout

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -20,6 +20,25 @@ const ANNOUNCEMENT_DURATION_MS = 1000;
 // in the first component's live region.
 const pendingClearTimeouts = new WeakMap();
 
+/**
+ * Returns the shadow root where live-region announcements should be routed.
+ *
+ * In fullscreen mode the component's own live region sits outside the modal
+ * dialog and is inert, so announcements must go to the bib's live region
+ * (inside the dialog) instead.
+ *
+ * @param {HTMLElement} dropdown - The `auro-dropdown` element.
+ * @param {ShadowRoot} fallbackRoot - The component's own shadow root (used in desktop mode).
+ * @returns {ShadowRoot} The shadow root containing the target `#srAnnouncement` element.
+ */
+export function getAnnouncementRoot(dropdown, fallbackRoot) {
+  const bibEl = dropdown.bibElement && dropdown.bibElement.value;
+  const bibShadowRoot = bibEl && bibEl.shadowRoot;
+  return dropdown.isBibFullscreen && bibShadowRoot
+    ? bibShadowRoot
+    : fallbackRoot;
+}
+
 export function announceToScreenReader(shadowRoot, text) {
   const liveRegion = shadowRoot.querySelector('#srAnnouncement');
   if (liveRegion) {

--- a/packages/utils/src/a11y.js
+++ b/packages/utils/src/a11y.js
@@ -6,7 +6,7 @@
  * repeated identical announcements still fire, and is cleared again after
  * {@link ANNOUNCEMENT_DURATION_MS} so VoiceOver cannot swipe to stale text.
  *
- * @param {ShadowRoot} shadowRoot - The shadow root containing the live region.
+ * @param {ShadowRoot|null} shadowRoot - The shadow root containing the live region, or `null` (in which case the call is a no-op).
  * @param {string} text - The text to announce.
  */
 

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,4 +1,4 @@
-export { announceToScreenReader, closeFullscreenDialog, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose } from './a11y.js';
+export { announceToScreenReader, getAnnouncementRoot, closeFullscreenDialog, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose } from './a11y.js';
 export { IconUtil } from './iconUtil.js';
 export { generateStoriesFromGlobData, generateGroupedStory } from './storyHelpers.js';
 export { createDisplayContext, applyKeyboardStrategy, navigateArrow } from './keyboard.js';


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes screen reader announcements being silent when navigating options with arrow keys in fullscreen (mobile breakpoint) mode for combobox and select components.

**Root cause:** When the dropdown opens as a modal `<dialog>` via `.showModal()`, the browser makes everything outside the dialog inert. Two accessibility mechanisms were placed outside the dialog:

1. **Live region (`#srAnnouncement`)** — Located in the combobox/select shadow root, outside the `<dialog>`. Announcements were suppressed because the browser treated the live region as inert.
2. **`aria-activedescendant`** (combobox only) — Set on the trigger input via `ariaActiveDescendantElement`, but in fullscreen mode the trigger is inert and focus is on `inputInBib` inside the dialog.

This did not affect real mobile devices using VoiceOver swipe gestures, because swiping navigates directly to option elements inside the dialog without relying on `aria-activedescendant` or the live region.

## Changes

- **`auro-dropdownBib.js`** — Added `#srAnnouncement` live region inside the `<dialog>` element so it remains accessible when shown modally
- **`auro-combobox.js`** — Set `ariaActiveDescendantElement` on `inputInBib` in fullscreen mode (the element that actually has focus), clear it on close, and route live region announcements to the bib's shadow root in fullscreen
- **`auro-select.js`** — Route live region announcements to the bib's shadow root in fullscreen mode

## Components affected

| Component | Affected | Why |
|-----------|----------|-----|
| `auro-combobox` | Yes | Live region + `aria-activedescendant` both outside dialog |
| `auro-select` | Yes | Live region outside dialog |
| `auro-datepicker` | No | Calendar cells receive direct focus inside dialog |
| `auro-counter` | No | No dropdown/fullscreen dialog pattern |

## Test plan

- [x] Open combobox at mobile breakpoint in desktop browser, navigate options with arrow keys, verify VoiceOver announces each option
- [x] Open select at mobile breakpoint in desktop browser, navigate options with arrow keys, verify VoiceOver announces each option
- [x] Verify desktop (non-fullscreen) combobox/select announcements still work
- [x] Verify real mobile device VoiceOver swipe navigation still works
- [x] Verify selection announcements fire after dropdown closes in both modes


## Review Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve accessibility behavior for combobox and select components when their dropdowns render in fullscreen (bib dialog) mode so screen readers correctly announce active options and focused elements.

Bug Fixes:
- Ensure combobox live region announcements are delivered from within the fullscreen dialog so they are not treated as inert by the browser.
- Ensure select live region announcements are delivered from within the fullscreen dialog so they are not treated as inert by the browser.
- Ensure aria-activedescendant is set on and cleared from the in-dialog input element for combobox when operating in fullscreen mode so screen readers follow focus correctly.

Tests:
- Add regression tests and Storybook stories verifying live region announcements and aria-activedescendant behavior for combobox and select in fullscreen (mobile) mode.