### PR TITLE
fix(menu): fix arrow key navigation on nested menu AB#1523822

### DIFF
--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -50,7 +50,7 @@ function runFulltest(mobileview) {
   it('enforces menu selection when behavior is set to filter', async () => {
     const el = await filterFixture(mobileview);
     const {menu} = el;
-    
+
     // initial state
     await expect(el.value).to.be.undefined;
     await expect(el.hasAttribute('error')).to.be.false;
@@ -483,6 +483,43 @@ function runFulltest(mobileview) {
     await expect(menuOptions[1].classList.contains('active')).to.be.false;
   });
 
+  it('navigates nested menu with up and down arrow keys', async () => {
+    const el = await nestedMenuFixture(mobileview);
+
+    setInputValue(el, 'option');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    if (mobileview) {
+      el.inputInBib.focus();
+      await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+    }
+
+    const rootOptions = [...el.querySelectorAll(':scope > auro-menu > auro-menuoption')];
+    const nestedMenu = el.querySelector('auro-menu auro-menu');
+    const nestedOptions = [...nestedMenu.querySelectorAll('auro-menuoption')];
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    await expect(el.optionActive).to.equal(rootOptions[0]);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    await expect(el.optionActive).to.equal(nestedOptions[0]);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    await expect(el.optionActive).to.equal(nestedOptions[1]);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    await expect(el.optionActive).to.equal(rootOptions[1]);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    await elementUpdated(el);
+    await expect(el.optionActive).to.equal(nestedOptions[1]);
+  });
+
   it('typing filters list of options', async () => {
     const el = await defaultFixture(mobileview);
 
@@ -635,10 +672,10 @@ function runFulltest(mobileview) {
 
     // Set up the event listener before triggering the input change
     const inputEventPromise = oneEvent(el, 'input');
-    
+
     // Trigger input change
     setInputValue(el, 'a');
-    
+
     // Wait for the input event to be fired
     await inputEventPromise;
   });
@@ -1279,6 +1316,34 @@ async function defaultFixture(mobileview) {
   `);
 }
 
+async function nestedMenuFixture(mobileview) {
+  if (mobileview) {
+    await setViewport({
+      width: 500,
+      height: 800
+    });
+  } else {
+    await setViewport({
+      width: 800,
+      height: 800
+    });
+  }
+
+  return fixture(html`
+  <auro-combobox>
+    <span slot="label">Name</span>
+    <auro-menu>
+      <auro-menuoption value="option 1" id="nested-option-0">option 1</auro-menuoption>
+      <auro-menu>
+        <auro-menuoption value="option a" id="nested-option-1">option a</auro-menuoption>
+        <auro-menuoption value="option b" id="nested-option-2">option b</auro-menuoption>
+      </auro-menu>
+      <auro-menuoption value="option 2" id="nested-option-3">option 2</auro-menuoption>
+    </auro-menu>
+  </auro-combobox>
+  `);
+}
+
 /**
  *
  */
@@ -1439,7 +1504,7 @@ async function persistentFixture(mobileview) {
 }
 
 /**
- * 
+ *
  */
 async function filterFixture(mobileview) {
   if (mobileview) {

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -328,6 +328,13 @@ export class AuroMenu extends AuroElement {
    * @protected
    */
   provideContext() {
+    if (this.parentElement && this.parentElement.closest('auro-menu, [auro-menu]')) {
+      this.rootMenu = false;
+      this.menuService = this.parentElement.menuService;
+      this._contextProvider = this.parentElement._contextProvider;
+      return;
+    }
+
     this.menuService = new MenuService({host: this});
     this.menuService.setProperties(this.propertyValues);
     this.menuService.subscribe(this.handleMenuChange.bind(this));
@@ -510,9 +517,9 @@ export class AuroMenu extends AuroElement {
       if (this.multiSelect) {
         this.setAttribute('aria-multiselectable', 'true');
       }
-
-      this.handleNestedMenus(this);
     }
+
+    this.handleNestedMenus(this);
   }
 
   /**
@@ -611,10 +618,6 @@ export class AuroMenu extends AuroElement {
    * @private
    */
   handleSlotChange() {
-    if (this.parentElement && this.parentElement.closest('auro-menu, [auro-menu]')) {
-      this.rootMenu = false;
-    }
-
     if (this.rootMenu) {
       this.initializeMenu();
     }

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -1031,6 +1031,96 @@ describe('arrayConverter', () => {
   });
 });
 
+describe('nested menu: arrow key navigation', () => {
+  // The nestedMenuFixture layout (flat navigation order):
+  //   [0] option 1  (root)
+  //   [1] option a  (nested)
+  //   [2] option b  (nested)
+  //   [3] option 2  (root)
+
+  it('ArrowDown moves from root option into nested options', async () => {
+    const el = await nestedMenuFixture();
+    const rootMenu = el.querySelector('auro-menu');
+    const nestedMenu = el.querySelector('auro-menu auro-menu');
+    const nestedOptions = [...nestedMenu.querySelectorAll('auro-menuoption')];
+
+    // First ArrowDown → highlights option 1 (root)
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    await elementUpdated(rootMenu);
+
+    // Second ArrowDown → highlights option a (first nested option)
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    await elementUpdated(rootMenu);
+
+    expect(rootMenu.optionActive).to.equal(nestedOptions[0]);
+  });
+
+  it('ArrowDown moves from last nested option to next root option', async () => {
+    const el = await nestedMenuFixture();
+    const rootMenu = el.querySelector('auro-menu');
+    const rootOptions = [...el.querySelectorAll(':scope > auro-menu > auro-menuoption')];
+
+    // Navigate to option 1 → option a → option b → option 2
+    for (let i = 0; i < 4; i++) {
+      rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+      await elementUpdated(rootMenu);
+    }
+
+    expect(rootMenu.optionActive).to.equal(rootOptions[1]);
+  });
+
+  it('ArrowUp moves from first nested option back to the preceding root option', async () => {
+    const el = await nestedMenuFixture();
+    const rootMenu = el.querySelector('auro-menu');
+    const rootOptions = [...el.querySelectorAll(':scope > auro-menu > auro-menuoption')];
+
+    // Navigate down to the first nested option (option a)
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    await elementUpdated(rootMenu);
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    await elementUpdated(rootMenu);
+
+    // ArrowUp should go back to option 1 (root)
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowUp' }));
+    await elementUpdated(rootMenu);
+
+    expect(rootMenu.optionActive).to.equal(rootOptions[0]);
+  });
+
+  it('ArrowUp from top of nested menu wraps to last option', async () => {
+    const el = await nestedMenuFixture();
+    const rootMenu = el.querySelector('auro-menu');
+    const allOptions = [...el.querySelectorAll('auro-menuoption')];
+
+    // ArrowUp with no active option wraps to the last option
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowUp' }));
+    await elementUpdated(rootMenu);
+
+    expect(rootMenu.optionActive).to.equal(allOptions[allOptions.length - 1]);
+  });
+
+  it('Enter selects a nested option', async () => {
+    const el = await nestedMenuFixture();
+    const rootMenu = el.querySelector('auro-menu');
+    const nestedMenu = el.querySelector('auro-menu auro-menu');
+    const nestedOptions = [...nestedMenu.querySelectorAll('auro-menuoption')];
+
+    // Navigate to first nested option (option a)
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    await elementUpdated(rootMenu);
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    await elementUpdated(rootMenu);
+
+    // Select it
+    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'Enter' }));
+    await elementUpdated(rootMenu);
+
+    expect(rootMenu.optionSelected).to.equal(nestedOptions[0]);
+    expect(nestedOptions[0].hasAttribute('selected')).to.be.true;
+    expect(rootMenu.value).to.equal('option a');
+  });
+});
+
 function getOptions(menu) {
   let options = menu.shadowRoot.querySelector('slot').assignedNodes();
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -214,6 +214,23 @@ async function shiftTabDisabledFirstFixture() {
   `);
 }
 
+async function nestedMenuFixture() {
+  return await fixture(html`
+  <auro-select>
+    <span slot="bib.fullscreen.headline">Bib Headline</span>
+    <span slot="label">Name</span>
+    <auro-menu>
+      <auro-menuoption value="option 1" id="nested-option-0">option 1</auro-menuoption>
+      <auro-menu>
+        <auro-menuoption value="option a" id="nested-option-1">option a</auro-menuoption>
+        <auro-menuoption value="option b" id="nested-option-2">option b</auro-menuoption>
+      </auro-menu>
+      <auro-menuoption value="option 2" id="nested-option-3">option 2</auro-menuoption>
+    </auro-menu>
+  </auro-select>
+  `);
+}
+
 function runTest(mobileView) {
   describe(`auro-select${mobileView ? ' in mobile' : ''}`, () => {
     before(async () => {
@@ -712,6 +729,39 @@ function runTest(mobileView) {
 
       await expect(menuOptions[0].classList.contains('active')).to.be.true;
       await expect(menuOptions[1].classList.contains('active')).to.be.false;
+    });
+
+    it('navigates nested menu with up and down arrow keys', async () => {
+      const el = await nestedMenuFixture();
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+      const trigger = dropdown.querySelector('[slot="trigger"]');
+      const rootOptions = [...el.querySelectorAll(':scope > auro-menu > auro-menuoption')];
+      const nestedMenu = el.querySelector('auro-menu auro-menu');
+      const nestedOptions = [...nestedMenu.querySelectorAll('auro-menuoption')];
+
+      trigger.click();
+      await elementUpdated(el);
+      await expect(dropdown.isPopoverVisible).to.be.true;
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      await expect(el.optionActive).to.equal(rootOptions[0]);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      await expect(el.optionActive).to.equal(nestedOptions[0]);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      await expect(el.optionActive).to.equal(nestedOptions[1]);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      await expect(el.optionActive).to.equal(rootOptions[1]);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      await elementUpdated(el);
+      await expect(el.optionActive).to.equal(nestedOptions[1]);
     });
 
     it('makes a selection programmatically', async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

link nested menu's menuService and contextProvider to the root's so that the menuService has all menuoptions to properly calculate the next/prev menuoption to focus

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve nested menu keyboard navigation and selection behavior

Bug Fixes:
- Fix ArrowUp and ArrowDown navigation across root and nested menu options so focus follows the visual order, including wrapping from the top to the last option
- Ensure Enter key correctly selects nested menu options and updates the root menu’s selected value
- Correct context and menu service wiring for nested menus so they share the root menu’s service for consistent navigation state

Enhancements:
- Refine root menu detection and nested menu initialization so nested menus reuse the parent menu’s context provider and service

Tests:
- Add integration-style tests covering ArrowUp/ArrowDown navigation, wrapping, and Enter selection behavior within nested menus