### PR TITLE
fix(dropdown): read breakpoint token lazily to fix fullscreen bib in WebKit

### DIFF
--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -40,7 +40,7 @@ export class AuroDropdownBib extends LitElement {
     /**
      * @private
      */
-    this._mobileBreakpointValue = undefined;
+    this._mobileBreakpointName = undefined;
 
     AuroLibraryRuntimeUtils.prototype.handleComponentTagRename(this, 'auro-dropdownbib');
 
@@ -149,17 +149,22 @@ export class AuroDropdownBib extends LitElement {
     // verify the defined breakpoint is valid and exit out if not
     // 'disabled' is a design token breakpoint so it acts as our "undefined" value
     const validatedValue = DESIGN_TOKEN_BREAKPOINT_OPTIONS.includes(value) ? value : undefined;
-    if (!validatedValue) {
-      this._mobileBreakpointValue = undefined;
-    } else {
-      // get the pixel value for the defined breakpoint
-      const docStyle = getComputedStyle(document.documentElement);
-      this._mobileBreakpointValue = docStyle.getPropertyValue(DESIGN_TOKEN_BREAKPOINT_PREFIX + value);
-    }
+    // Store the breakpoint NAME only. The CSS token pixel value is read lazily
+    // in the getter so it is always resolved against the current document styles.
+    // Caching the pixel value here races against stylesheet load in WebKit —
+    // external CDN stylesheets may not yet be applied when the component upgrades,
+    // causing getPropertyValue() to return "" and fullscreen mode to never activate.
+    this._mobileBreakpointName = validatedValue;
   }
 
   get mobileFullscreenBreakpoint() {
-    return this._mobileBreakpointValue;
+    if (!this._mobileBreakpointName) {
+      return undefined;
+    }
+    const value = getComputedStyle(document.documentElement).
+      getPropertyValue(DESIGN_TOKEN_BREAKPOINT_PREFIX + this._mobileBreakpointName).
+      trim();
+    return value || undefined;
   }
 
   updated(changedProperties) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Full write up here: https://github.com/orgs/AlaskaAirlines/discussions/628

This pull request refactors how the mobile breakpoint value is handled in the `AuroDropdownBib` component to address issues with stylesheet loading timing. Instead of caching the pixel value of the breakpoint at property set time, the code now stores only the breakpoint name and resolves the pixel value dynamically when accessed. This ensures the correct value is always retrieved, even if stylesheets load after the component is initialized.

**Refactor: Mobile breakpoint handling**

* Changed the private property from `_mobileBreakpointValue` to `_mobileBreakpointName` to store the breakpoint name instead of the pixel value.
* Updated the setter for the `mobileFullscreenBreakpoint` property to store only the breakpoint name and defer pixel value resolution to the getter, preventing issues with stylesheet loading order.
* Modified the getter for `mobileFullscreenBreakpoint` to dynamically resolve the CSS custom property value using the stored breakpoint name, ensuring up-to-date values from the current document styles.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Refine mobile fullscreen breakpoint handling in AuroDropdownBib to resolve breakpoint tokens lazily from CSS, avoiding races with stylesheet loading in WebKit.

Bug Fixes:
- Fix fullscreen dropdown behavior in WebKit by preventing early caching of an unresolved mobile breakpoint token value.

Enhancements:
- Change mobile breakpoint storage from a cached pixel value to a breakpoint name and compute the CSS token value on access for always-current styles.