### PR TITLE
fix(select): ensure dropdown trigger is focused after click selection…

### DIFF
--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -824,6 +824,7 @@ export class AuroSelect extends AuroElement {
         this.scrollActiveOptionIntoView();
       }
     });
+
     this.menu.addEventListener('auroMenu-selectedOption', (event) => {
 
       // Update the displayed value
@@ -837,6 +838,7 @@ export class AuroSelect extends AuroElement {
 
       if (this.dropdown.isPopoverVisible && !this.multiSelect) {
         this.dropdown.hide();
+        this.dropdown.trigger.focus();
       }
 
       // Announce the selection after the dropdown closes so it isn't
@@ -1097,9 +1099,6 @@ export class AuroSelect extends AuroElement {
       this.validate();
       if (!this.multiSelect) {
         this.hideBib();
-      }
-      if (this.dropdown && this.dropdown.trigger) {
-        this.dropdown.trigger.focus();
       }
 
       // LEGACY EVENT

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -835,6 +835,31 @@ function runTest(mobileView) {
               await expect(dropdown.isPopoverVisible).to.be.false;
             });
 
+            if (!mobileView) {
+              it('should move focus to the trigger after selecting an option via click', async () => {
+                const el = await defaultFixture();
+                const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+                const trigger = dropdown.querySelector('[slot="trigger"]');
+
+                trigger.click();
+                await elementUpdated(el);
+                await expect(dropdown.isPopoverVisible).to.be.true;
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                const menu = el.querySelector('auro-menu');
+                const option = menu.querySelector('auro-menuoption[value="Oranges"]');
+                option.click();
+                await elementUpdated(option);
+                await elementUpdated(menu);
+                await new Promise((resolve) => setTimeout(resolve, 0));
+                await elementUpdated(el);
+
+                await expect(dropdown.isPopoverVisible).to.be.false;
+                await expect(dropdown.trigger.matches(':focus')).to.be.true;
+              });
+            }
+
             it('should not deselect and should close the bib when an already-selected menuoption is clicked', async () => {
               const el = await presetValueFixture();
 
@@ -1279,6 +1304,26 @@ function runTest(mobileView) {
           await expect(el.value).to.equal('Oranges');
           await expect(dropdown.isPopoverVisible).to.be.false;
         });
+
+        if (!mobileView) {
+          it('should move focus to the trigger after selecting an option', async () => {
+            const el = await defaultFixture();
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            const trigger = dropdown.querySelector('[slot="trigger"]');
+
+            trigger.click();
+            await elementUpdated(el);
+            await expect(dropdown.isPopoverVisible).to.be.true;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.false;
+            await expect(dropdown.trigger.matches(':focus')).to.be.true;
+          });
+        }
 
         it('should not deselect and should close the bib when Enter is pressed on an already-selected menuoption', async () => {
           const el = await presetValueFixture();


### PR DESCRIPTION
… [AB#1528057](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1528057)

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Restore focus to the select trigger after closing the dropdown on single-select option click to maintain expected keyboard and accessibility behavior.