### PR TITLE
fix(combobox): prevent noMatch option from being marked active

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -550,7 +550,7 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   activateFirstEnabledAvailableOption() {
-    const firstEnabledOptionIndex = this.availableOptions.findIndex((opt) => !opt.disabled && !opt.noMatch);
+    const firstEnabledOptionIndex = this.availableOptions.findIndex((opt) => !opt.disabled && !opt.hasAttribute('nomatch'));
     this.updateActiveOption(firstEnabledOptionIndex);
   }
 
@@ -564,7 +564,7 @@ export class AuroCombobox extends AuroElement {
 
     // Work backwards through the available options array to find the last enabled option
     for (let index = this.availableOptions.length - 1; index >= 0; index -= 1) {
-      if (!this.availableOptions[index].disabled && !this.availableOptions[index].noMatch) {
+      if (!this.availableOptions[index].disabled && !this.availableOptions[index].hasAttribute('nomatch')) {
         lastEnabledOptionIndex = index;
         break;
       }

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -550,7 +550,7 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   activateFirstEnabledAvailableOption() {
-    const firstEnabledOptionIndex = this.availableOptions.findIndex((opt) => !opt.disabled);
+    const firstEnabledOptionIndex = this.availableOptions.findIndex((opt) => !opt.disabled && !opt.noMatch);
     this.updateActiveOption(firstEnabledOptionIndex);
   }
 
@@ -564,7 +564,7 @@ export class AuroCombobox extends AuroElement {
 
     // Work backwards through the available options array to find the last enabled option
     for (let index = this.availableOptions.length - 1; index >= 0; index -= 1) {
-      if (!this.availableOptions[index].disabled) {
+      if (!this.availableOptions[index].disabled && !this.availableOptions[index].noMatch) {
         lastEnabledOptionIndex = index;
         break;
       }

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -126,7 +126,7 @@ function runFullTest(mobileView) {
       await sendKeys({ press: 'a' });
       await elementUpdated(el);
 
-      const firstEnabledOption = el.availableOptions.find((opt) => !opt.disabled && !opt.noMatch);
+      const firstEnabledOption = el.availableOptions.find((opt) => !opt.disabled && !opt.hasAttribute('nomatch'));
       await expect(el.optionActive).to.not.equal(noMatchOption);
       await expect(firstEnabledOption.classList.contains('active')).to.be.true;
     });

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -104,6 +104,33 @@ function runFullTest(mobileView) {
     //   await expect(el.value).to.equal(undefined);
     // });
 
+    it('should not mark the noMatch option as active when all regular options are filtered out', async () => {
+      const el = await noMatchFixture(mobileView);
+
+
+      // Focus the input and type a value that doesn't match any real option
+      el.input.inputElement.focus();
+      await sendKeys({ press: 'z' });
+      await sendKeys({ press: 'z' });
+      await sendKeys({ press: 'z' });
+      await elementUpdated(el);
+
+      const noMatchOption = el.querySelector('auro-menuoption[nomatch]');
+      await expect(noMatchOption.hasAttribute('hidden')).to.be.false;
+      await expect(el.optionActive).to.not.equal(noMatchOption);
+
+      // Clear the input and type a value that matches real options, hiding the noMatch option
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'a' });
+
+
+      const firstEnabledOption = el.availableOptions.find((opt) => !opt.disabled && !opt.noMatch);
+      await expect(el.optionActive).to.not.equal(noMatchOption);
+      await expect(firstEnabledOption.classList.contains('active')).to.be.true;
+    });
+
     it('should hide the bib when there are no available options', async () => {
       const el = await defaultFixture(mobileView);
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -124,7 +124,7 @@ function runFullTest(mobileView) {
       await sendKeys({ press: 'Backspace' });
       await sendKeys({ press: 'Backspace' });
       await sendKeys({ press: 'a' });
-
+      await elementUpdated(el);
 
       const firstEnabledOption = el.availableOptions.find((opt) => !opt.disabled && !opt.noMatch);
       await expect(el.optionActive).to.not.equal(noMatchOption);

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -65,6 +65,7 @@ The `auro-menuoption` element provides users a way to define a menu option.
 | `iconTag`     |            |           | `string`  |         |                                                  |
 | `isActive`    |            | readonly  | `boolean` |         | Returns whether the menu option is currently active and selectable.<br />An option is considered active if it is not hidden, not disabled, and not static. |
 | `key`         | `key`      |           | `string`  |         | Allows users to set a unique key for the menu option for specified option selection. If no key is provided, the value property will be used. |
+| `noMatch`     | `noMatch`  |           | `boolean` |         | When true, marks this option as the "no matching results" placeholder shown by combobox when the user's input does not match any available options. Enables distinct styling and prevents the option from being treated as a selectable match. |
 | `selected`    | `selected` |           | `boolean` | false   | Specifies that an option is selected.            |
 | `tabIndex`    | `tabIndex` |           | `number`  |         | Specifies the tab index of the menu option.      |
 | `unsubscribe` |            |           |           | null    |                                                  |

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -65,7 +65,7 @@ The `auro-menuoption` element provides users a way to define a menu option.
 | `iconTag`     |            |           | `string`  |         |                                                  |
 | `isActive`    |            | readonly  | `boolean` |         | Returns whether the menu option is currently active and selectable.<br />An option is considered active if it is not hidden, not disabled, and not static. |
 | `key`         | `key`      |           | `string`  |         | Allows users to set a unique key for the menu option for specified option selection. If no key is provided, the value property will be used. |
-| `noMatch`     | `noMatch`  |           | `boolean` |         | When true, marks this option as the "no matching results" placeholder shown by combobox when the user's input does not match any available options. Enables distinct styling and prevents the option from being treated as a selectable match. |
+| `noMatch`     | `nomatch`  |           | `boolean` | false   | When true, marks this option as the "no matching results" placeholder shown by combobox when the user's input does not match any available options. Enables distinct styling and prevents the option from being treated as a selectable match. |
 | `selected`    | `selected` |           | `boolean` | false   | Specifies that an option is selected.            |
 | `tabIndex`    | `tabIndex` |           | `number`  |         | Specifies the tab index of the menu option.      |
 | `unsubscribe` |            |           |           | null    |                                                  |

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -159,6 +159,14 @@ export class AuroMenuOption extends AuroElement {
       },
 
       /**
+       * When true, marks this option as the "no matching results" placeholder shown by combobox when the user's input does not match any available options. Enables distinct styling and prevents the option from being treated as a selectable match.
+       */
+      noMatch: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
        * Specifies that an option is selected.
        */
       selected: {

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -83,6 +83,7 @@ export class AuroMenuOption extends AuroElement {
     this.selected = false;
     this.noCheckmark = false;
     this.disabled = false;
+    this.noMatch = false;
 
     /**
      * @private
@@ -163,7 +164,8 @@ export class AuroMenuOption extends AuroElement {
        */
       noMatch: {
         type: Boolean,
-        reflect: true
+        reflect: true,
+        attribute: 'nomatch'
       },
 
       /**


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure combobox never treats the no-match placeholder option as an active selection when navigating available options.

Bug Fixes:
- Exclude the no-match placeholder option from being activated as the first or last enabled option when filtering combobox results.

Tests:
- Add regression test verifying that the no-match option is not marked active when all regular options are filtered out and that a real option becomes active when available again.