### PR TITLE
fix(combobox): emphasized layout color should not appear in full-screen dialog input

### DIFF
--- a/components/combobox/src/styles/emphasized/style.scss
+++ b/components/combobox/src/styles/emphasized/style.scss
@@ -6,7 +6,7 @@
 
 
 :host([layout*='emphasized'][shape*='pill']) {
-  [auro-input] { // CAN I MOVE THESE INTO DROPDOWN? DROPDOWN SHOULD BE SMART ENOUGH TO HIDE THE HELP TEXT OF ANY INPUT INSIDE IT
+  [auro-input][slot='trigger'] { // CAN I MOVE THESE INTO DROPDOWN? DROPDOWN SHOULD BE SMART ENOUGH TO HIDE THE HELP TEXT OF ANY INPUT INSIDE IT
     --ds-auro-input-background-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
     --ds-auro-input-container-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
     

--- a/components/combobox/src/styles/emphasized/style.scss
+++ b/components/combobox/src/styles/emphasized/style.scss
@@ -6,7 +6,7 @@
 
 
 :host([layout*='emphasized'][shape*='pill']) {
-  [auro-input][slot='trigger'] { // CAN I MOVE THESE INTO DROPDOWN? DROPDOWN SHOULD BE SMART ENOUGH TO HIDE THE HELP TEXT OF ANY INPUT INSIDE IT
+  [auro-input][slot='trigger'] {
     --ds-auro-input-background-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
     --ds-auro-input-container-color: var(--ds-advanced-color-dropdown-emphasized-background, #{v.$ds-advanced-color-dropdown-emphasized-background});
     


### PR DESCRIPTION
When opening a full-screen dialog using the Emphasized Layout, the gray color appears in the dialog input.

**Before:**

https://github.com/user-attachments/assets/4325240a-5a08-4165-9e37-677625f25fed

**After:**

https://github.com/user-attachments/assets/ba25ff02-965f-4f3b-bfc8-70274f790ef0

## Summary by Sourcery

Bug Fixes:
- Prevent emphasized layout background color from being applied to the full-screen dialog input in combobox usage.