### PR TITLE
fix(datepicker): not to skip a month with next/prev button AB#1530050

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -957,7 +957,7 @@ export class AuroDatePicker extends AuroElement {
       }
     });
   }
-  
+
   /**
    * Binds all behavior needed to the input after rendering.
    * @private

--- a/components/datepicker/src/utilitiesCalendar.js
+++ b/components/datepicker/src/utilitiesCalendar.js
@@ -53,7 +53,7 @@ export class CalendarUtilities {
     // 1. Compare the first rendered month to the earliest renderable month to determine if the previous month button should be hidden or shown
     if (!elem.hasAttribute('calendarStartDate') && !elem.hasAttribute('minDate')) {
       elem.showPrevMonthBtn = true;
-    } else if (this.util.convertDateToFirstOfMonth(new Date(elem.centralDate)) <= elem.firstMonthRenderable) {
+    } else if (new Date(elem.centralDate) <= elem.firstMonthRenderable) {
       elem.showPrevMonthBtn = false;
     } else {
       elem.showPrevMonthBtn = true;
@@ -138,15 +138,12 @@ export class CalendarUtilities {
 
     if (this.util.validDateStr(formattedDateStr, datepicker.format)) {
       // Use current date as base and adjust month by increment
-      newCentralDate = new Date(formattedDateStr).setMonth(new Date(formattedDateStr).getMonth() + increment);
+      newCentralDate = new Date(formattedDateStr).setMonth(new Date(formattedDateStr).getMonth() + increment, 1);
     } else {
       // Fallback to first rendered month if central date invalid
-      newCentralDate = new Date(firstRenderedMonth).setMonth(new Date(firstRenderedMonth).getMonth() + increment);
+      newCentralDate = new Date(firstRenderedMonth).setMonth(new Date(firstRenderedMonth).getMonth() + increment, 1);
     }
 
-    // Update calendar central date
-    if (newCentralDate) {
-      elem.centralDate = this.util.convertDateToFirstOfMonth(newCentralDate);
-    }
+    elem.centralDate = newCentralDate;
   }
 }

--- a/components/datepicker/src/utilitiesCalendarRender.js
+++ b/components/datepicker/src/utilitiesCalendarRender.js
@@ -14,6 +14,8 @@ export class UtilitiesCalendarRender {
    */
   updateCentralDate(elem, date) {
     const dateObj = new Date(date);
+    dateObj.setDate(1);
+    dateObj.setHours(0, 0, 0, 0);
 
     if (!isNaN(dateObj)) {
       elem.centralDate = dateObj;

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -283,6 +283,52 @@ describe('auro-datepicker', () => {
       await expect(centralAfterAgain).to.contain('01/01/2024');
     });
 
+    it('should show April 2026 when next month is clicked from value 03/31/2026', async () => {
+      const el = await fixture(html`
+        <auro-datepicker value="03/31/2026"></auro-datepicker>
+      `);
+
+      await elementUpdated(el);
+
+      const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
+      const nextMonthBth = calendar.shadowRoot.querySelector('.nextMonth');
+
+      const central = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+      await expect(central).to.equal('03/01/2026');
+
+      nextMonthBth.click();
+
+      await elementUpdated(el);
+
+      const centralAfter = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+      await expect(centralAfter).to.equal('04/01/2026');
+    });
+
+    it('should show February 2026 when previous month is clicked from value 03/31/2026', async () => {
+      const el = await fixture(html`
+        <auro-datepicker value="03/31/2026"></auro-datepicker>
+      `);
+
+      await elementUpdated(el);
+
+      const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
+      const prevMonthBth = calendar.shadowRoot.querySelector('.prevMonth');
+
+      const central = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+      await expect(central).to.equal('03/01/2026');
+
+      prevMonthBth.click();
+
+      await elementUpdated(el);
+
+      const centralAfter = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
+
+      await expect(centralAfter).to.equal('02/01/2026');
+    });
+
     it('should hide the dropdown on blur', async () => {
       const el = await fixture(html`
           <auro-datepicker></auro-datepicker>
@@ -337,7 +383,7 @@ describe('auro-datepicker', () => {
 
         const central = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
 
-        await expect(central).to.be.equal('03/23/2023');
+        await expect(central).to.be.equal('03/01/2023');
 
         el.calendarFocusDate = '04/25/2024';
 
@@ -345,7 +391,7 @@ describe('auro-datepicker', () => {
 
         const centralAfter = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
 
-        await expect(centralAfter).to.be.equal('04/25/2024');
+        await expect(centralAfter).to.be.equal('04/01/2024');
       });
 
     });
@@ -750,8 +796,8 @@ describe('auro-datepicker', () => {
 
         await elementUpdated(el);
 
-        const central = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getDate()}`.slice(-2)}/${new Date(el.centralDate).getFullYear()}`;
-        const min = el.minDate;
+        const central = `${`0${new Date(el.centralDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.centralDate).getFullYear()}`.slice(-2)}`;
+        const min = `${`0${new Date(el.minDate).getMonth() + 1}`.slice(-2)}/${`0${new Date(el.minDate).getFullYear()}`.slice(-2)}`;
 
         await expect(min).to.be.equal(central);
       });


### PR DESCRIPTION
# Alaska Airlines Pull Request

### Bug:
With the value or centralDate is set to the last day of a month, pressing next/prev month button skip a month.

### Cause:
When a Date is set to the last day of a month, changing the month with setMonth can cause it to skip into the following month. This happens because JavaScript preserves the day-of-month, and if the new month doesn’t have that day, the date overflows.

For example, starting with 3/31/2022, setting the month to April results in 5/1/2022, since April has only 30 days and the extra day rolls over.

### Solution
Always set the date of `centralDate` to be `1` (FYI, the date value is not being use for any internal logic)


## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Normalize the datepicker’s central month date to the first of the month to prevent skipping months when navigating with next/previous controls.

Bug Fixes:
- Ensure navigating to next or previous month from dates at the end of a month no longer skips an extra month in the calendar view.
- Align minDate comparison with month-based centralDate normalization to avoid incorrect equality checks.

Documentation:
- Document that centralDate is normalized internally to the first day of its month so month navigation behaves consistently.

Tests:
- Add regression tests verifying correct month transitions when navigating from March 31, 2026 using next and previous month buttons.
- Update existing calendar focus and minDate tests to reflect centralDate being fixed to the first day of the month.