### PR TITLE
fix(combobox,menu): preserve programmatic value across async option loads

### DIFF
--- a/apps/react-framework/src/App.tsx
+++ b/apps/react-framework/src/App.tsx
@@ -17,6 +17,12 @@ import FormInteraction from './pages/FormInteraction';
 import InputInteraction from './pages/InputInteraction';
 import MenuInteraction from './pages/MenuInteraction';
 import RadioInteraction from './pages/RadioInteraction';
+import SelectDynamic from './pages/SelectDynamic';
+import SelectDynamicNavigate from './pages/SelectDynamicNavigate';
+import ComboboxCitySearch from './pages/ComboboxCitySearch';
+import ComboboxCitySearchFull from './pages/ComboboxCitySearchFull';
+import ComboboxCitySearchPreselected from './pages/ComboboxCitySearchPreselected';
+import ComboboxCitySearchPreselectedNavigate from './pages/ComboboxCitySearchPreselectedNavigate';
 
 export default function App() {
   return (
@@ -25,8 +31,14 @@ export default function App() {
       <Route path="/select-remount" component={SelectRemount} />
       <Route path="/select-remount-multiselect" component={SelectRemountMultiselect} />
       <Route path="/select-interaction" component={SelectInteraction} />
+      <Route path="/select-dynamic" component={SelectDynamic} />
+      <Route path="/select-dynamic-navigate" component={SelectDynamicNavigate} />
       <Route path="/combobox-remount" component={ComboboxRemount} />
       <Route path="/combobox-interaction" component={ComboboxInteraction} />
+      <Route path="/combobox-city-search" component={ComboboxCitySearch} />
+      <Route path="/combobox-city-search-full" component={ComboboxCitySearchFull} />
+      <Route path="/combobox-city-search-preselected" component={ComboboxCitySearchPreselected} />
+      <Route path="/combobox-city-search-preselected-navigate" component={ComboboxCitySearchPreselectedNavigate} />
       <Route path="/counter-dropdown" component={CounterDropdown} />
       <Route path="/counter-remount" component={CounterRemount} />
       <Route path="/counter-interaction" component={CounterInteraction} />

--- a/apps/react-framework/src/pages/ComboboxCitySearch.tsx
+++ b/apps/react-framework/src/pages/ComboboxCitySearch.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect, useRef, useCallback, Fragment } from 'react';
+
+interface Station {
+  name: string;
+  shortName?: string;
+  code: string;
+  subStations?: Station[];
+}
+
+const MOCK_CITIES: Station[] = [
+  { name: 'Seattle/Tacoma, WA', code: 'SEA' },
+  {
+    name: 'San Francisco Bay Area (All Airports)',
+    code: 'BA3',
+    shortName: 'SFO+2',
+    subStations: [
+      { name: 'San Francisco, CA', code: 'SFO' },
+      { name: 'Oakland, CA', code: 'OAK' },
+      { name: 'San Jose, CA', code: 'SJC' },
+    ],
+  },
+  { name: 'Portland, OR', code: 'PDX' },
+  {
+    name: 'Los Angeles (All Airports)',
+    code: 'LA4',
+    shortName: 'LAX+3',
+    subStations: [
+      { name: 'Los Angeles, CA', code: 'LAX' },
+      { name: 'Burbank, CA', code: 'BUR' },
+      { name: 'Long Beach, CA', code: 'LGB' },
+      { name: 'Ontario, CA', code: 'ONT' },
+    ],
+  },
+  { name: 'Anchorage, AK', code: 'ANC' },
+  {
+    name: 'New York (All Airports)',
+    code: 'NYC',
+    subStations: [
+      { name: 'John F. Kennedy, NY', code: 'JFK' },
+      { name: 'LaGuardia, NY', code: 'LGA' },
+      { name: 'Newark, NJ', code: 'EWR' },
+    ],
+  },
+  { name: 'Boston, MA', code: 'BOS' },
+  { name: 'Denver, CO', code: 'DEN' },
+  { name: 'Honolulu, HI', code: 'HNL' },
+  { name: 'Juneau, AK', code: 'JNU' },
+  { name: 'Fairbanks, AK', code: 'FAI' },
+];
+
+function searchCities(query: string): Station[] {
+  const q = query.toLowerCase();
+  return MOCK_CITIES.filter(
+    (city) =>
+      city.name.toLowerCase().includes(q) ||
+      city.code.toLowerCase() === q ||
+      city.subStations?.some(
+        (s) => s.name.toLowerCase().includes(q) || s.code.toLowerCase() === q,
+      ),
+  );
+}
+
+interface ComboboxWrapperProps {
+  onSelectedValueChange: (value: string) => void;
+}
+
+function ComboboxWrapper({ onSelectedValueChange }: ComboboxWrapperProps) {
+  const [stations, setStations] = useState<Station[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const comboboxRef = useRef<HTMLElement>(null);
+  const menuRef = useRef<HTMLElement & { loading?: boolean }>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (menuRef.current) {
+      (menuRef.current as any).loading = loading;
+    }
+  }, [loading]);
+
+  const handleTextInput = useCallback((event: Event) => {
+    const query = (event as CustomEvent<{ value: string }>).detail?.value ?? '';
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!query) {
+      setStations([]);
+      setLoading(false);
+      return;
+    }
+
+    setHasSearched(true);
+    setLoading(true);
+
+    debounceRef.current = setTimeout(() => {
+      setStations(searchCities(query));
+      setLoading(false);
+    }, 300);
+  }, []);
+
+  const handleOptionSelected = useCallback((event: Event) => {
+    const el = event.target as any;
+    onSelectedValueChange(el?.value ?? '');
+  }, [onSelectedValueChange]);
+
+  useEffect(() => {
+    const el = comboboxRef.current;
+    if (!el) return;
+
+    el.addEventListener('inputValue', handleTextInput);
+    el.addEventListener('input', handleOptionSelected);
+
+    return () => {
+      el.removeEventListener('inputValue', handleTextInput);
+      el.removeEventListener('input', handleOptionSelected);
+    };
+  }, [handleTextInput, handleOptionSelected]);
+
+  return (
+    <>
+      <auro-combobox ref={comboboxRef} noFilter persistInput required autocomplete="off" dvInputOnly>
+        <span slot="label">From</span>
+        <auro-menu ref={menuRef} hasLoadingPlaceholder>
+          {stations.map((city) => (
+            <Fragment key={city.code}>
+              <auro-menuoption value={city.code}>
+                {city.name}
+                {city.shortName && <span slot="displayValue">{city.shortName}</span>}
+              </auro-menuoption>
+              {city.subStations && (
+                <auro-menu>
+                  {city.subStations.map((sub) => (
+                    <auro-menuoption key={sub.code} value={sub.code}>
+                      {sub.name}
+                      <span slot="displayValue">{sub.code}</span>
+                    </auro-menuoption>
+                  ))}
+                </auro-menu>
+              )}
+            </Fragment>
+          ))}
+
+          {hasSearched && stations.length === 0 && !loading && (
+            <auro-menuoption static nomatch data-testid="no-results">
+              No cities found
+            </auro-menuoption>
+          )}
+
+          <span slot="loadingText">Loading cities...</span>
+        </auro-menu>
+      </auro-combobox>
+    </>
+  );
+}
+
+export default function ComboboxCitySearch() {
+  const [show, setShow] = useState(true);
+  const [selectedValue, setSelectedValue] = useState('');
+
+  return (
+    <div>
+      <button id="toggle" onClick={() => setShow((s) => !s)}>
+        {show ? 'Hide' : 'Show'} Combobox
+      </button>
+      <div id="selected-value" data-testid="selected-value">{selectedValue}</div>
+      {show && <ComboboxWrapper onSelectedValueChange={setSelectedValue} />}
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/ComboboxCitySearchFull.tsx
+++ b/apps/react-framework/src/pages/ComboboxCitySearchFull.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useRef, useCallback, Fragment } from 'react';
+
+interface Station {
+  name: string;
+  shortName?: string;
+  code: string;
+  subStations?: Station[];
+}
+
+const MOCK_CITIES: Station[] = [
+  { name: 'Seattle/Tacoma, WA', code: 'SEA' },
+  {
+    name: 'San Francisco Bay Area (All Airports)',
+    code: 'BA3',
+    shortName: 'SFO+2',
+    subStations: [
+      { name: 'San Francisco, CA', code: 'SFO' },
+      { name: 'Oakland, CA', code: 'OAK' },
+      { name: 'San Jose, CA', code: 'SJC' },
+    ],
+  },
+  { name: 'Portland, OR', code: 'PDX' },
+  {
+    name: 'Los Angeles (All Airports)',
+    code: 'LA4',
+    shortName: 'LAX+3',
+    subStations: [
+      { name: 'Los Angeles, CA', code: 'LAX' },
+      { name: 'Burbank, CA', code: 'BUR' },
+      { name: 'Long Beach, CA', code: 'LGB' },
+      { name: 'Ontario, CA', code: 'ONT' },
+    ],
+  },
+  { name: 'Anchorage, AK', code: 'ANC' },
+  {
+    name: 'New York (All Airports)',
+    code: 'NYC',
+    subStations: [
+      { name: 'John F. Kennedy, NY', code: 'JFK' },
+      { name: 'LaGuardia, NY', code: 'LGA' },
+      { name: 'Newark, NJ', code: 'EWR' },
+    ],
+  },
+  { name: 'Boston, MA', code: 'BOS' },
+  { name: 'Denver, CO', code: 'DEN' },
+  { name: 'Honolulu, HI', code: 'HNL' },
+  { name: 'Juneau, AK', code: 'JNU' },
+  { name: 'Fairbanks, AK', code: 'FAI' },
+];
+
+function searchCities(query: string): Station[] {
+  const q = query.toLowerCase();
+  return MOCK_CITIES.filter(
+    (city) =>
+      city.name.toLowerCase().includes(q) ||
+      city.code.toLowerCase() === q ||
+      city.subStations?.some(
+        (s) => s.name.toLowerCase().includes(q) || s.code.toLowerCase() === q,
+      ),
+  );
+}
+
+const MISSING_FIELD_ERROR = 'Please select a departure city';
+
+interface ComboboxFullProps {
+  initialValue?: string;
+  initialTypedValue?: string;
+}
+
+export function ComboboxFullWrapper({ initialValue = '', initialTypedValue = '' }: ComboboxFullProps) {
+  const [stations, setStations] = useState<Station[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(initialValue);
+  const [appearance, setAppearance] = useState<'default' | 'inverse'>('default');
+  const comboboxRef = useRef<HTMLElement>(null);
+  const menuRef = useRef<HTMLElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const el = comboboxRef.current as any;
+    if (el && initialTypedValue) {
+      el.typedValue = initialTypedValue;
+    }
+  }, [initialTypedValue]);
+
+  useEffect(() => {
+    if (menuRef.current) {
+      (menuRef.current as any).loading = loading;
+    }
+  }, [loading]);
+
+  const handleTextInput = useCallback((event: Event) => {
+    const query = (event as CustomEvent<{ value: string }>).detail?.value ?? '';
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!query) {
+      setStations([]);
+      setLoading(false);
+      return;
+    }
+
+    setHasSearched(true);
+    setLoading(true);
+
+    debounceRef.current = setTimeout(() => {
+      setStations(searchCities(query));
+      setLoading(false);
+    }, 300);
+  }, []);
+
+  const handleOptionSelected = useCallback((event: Event) => {
+    const el = event.target as any;
+    setSelectedValue(el?.value ?? '');
+  }, []);
+
+  useEffect(() => {
+    const el = comboboxRef.current;
+    if (!el) return;
+    el.addEventListener('inputValue', handleTextInput);
+    el.addEventListener('input', handleOptionSelected);
+    return () => {
+      el.removeEventListener('inputValue', handleTextInput);
+      el.removeEventListener('input', handleOptionSelected);
+    };
+  }, [handleTextInput, handleOptionSelected]);
+
+  function triggerValidation() {
+    (comboboxRef.current as any)?.checkValidity?.();
+  }
+
+  function reset() {
+    setSelectedValue('');
+    setStations([]);
+    setHasSearched(false);
+    (comboboxRef.current as any)?.reset?.();
+  }
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
+        <button onClick={() => setAppearance((a) => (a === 'default' ? 'inverse' : 'default'))}>
+          Toggle appearance <em>({appearance})</em>
+        </button>
+        <button onClick={triggerValidation}>Validate</button>
+        <button onClick={reset}>Reset</button>
+      </div>
+
+      <div
+        data-testid="selected-value"
+        style={{ fontFamily: 'monospace', background: '#f5f5f5', padding: '0.5rem 0.75rem', borderRadius: '4px', marginBottom: '1.25rem' }}
+      >
+        Selected value: <strong>{selectedValue || '(none)'}</strong>
+      </div>
+
+      <auro-combobox
+        ref={comboboxRef}
+        appearance={appearance}
+        value={selectedValue}
+        noFilter
+        persistInput
+        required
+        dvInputOnly
+        size="lg"
+        shape="snowflake"
+        layout="snowflake"
+        fullscreenBreakpoint="md"
+        autocomplete="off"
+        noFlip
+        setCustomValidityValueMissing={MISSING_FIELD_ERROR}
+      >
+        <span slot="label">From</span>
+        <auro-menu ref={menuRef} hasLoadingPlaceholder>
+          {stations.map((city) => (
+            <Fragment key={city.code}>
+              <auro-menuoption value={city.code}>
+                {city.name}
+                {city.shortName && <span slot="displayValue">{city.shortName}</span>}
+              </auro-menuoption>
+              {city.subStations && (
+                <auro-menu>
+                  {city.subStations.map((sub) => (
+                    <auro-menuoption key={sub.code} value={sub.code}>
+                      {sub.name}
+                      <span slot="displayValue">{sub.code}</span>
+                    </auro-menuoption>
+                  ))}
+                </auro-menu>
+              )}
+            </Fragment>
+          ))}
+
+          {hasSearched && stations.length === 0 && !loading && (
+            <auro-menuoption static nomatch data-testid="no-results">
+              No cities found
+            </auro-menuoption>
+          )}
+
+          <span slot="loadingText">Loading cities...</span>
+        </auro-menu>
+      </auro-combobox>
+    </>
+  );
+}
+
+export default function ComboboxCitySearchFull() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: '600px' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        <button id="toggle" onClick={() => setShow((s) => !s)}>
+          {show ? 'Hide' : 'Show'} Combobox
+        </button>
+      </div>
+      {show && <ComboboxFullWrapper />}
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/ComboboxCitySearchPreselected.tsx
+++ b/apps/react-framework/src/pages/ComboboxCitySearchPreselected.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { ComboboxFullWrapper } from './ComboboxCitySearchFull';
+
+export default function ComboboxCitySearchPreselected() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: '600px' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        <button id="toggle" onClick={() => setShow((s) => !s)}>
+          {show ? 'Hide' : 'Show'} Combobox
+        </button>
+      </div>
+      {show && <ComboboxFullWrapper initialValue="SFO" initialTypedValue="" />}
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/ComboboxCitySearchPreselectedNavigate.tsx
+++ b/apps/react-framework/src/pages/ComboboxCitySearchPreselectedNavigate.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+export default function ComboboxCitySearchPreselectedNavigate() {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      window.history.pushState({}, '', '/combobox-city-search-preselected');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }, 200);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return <p>Navigating to preselected combobox page...</p>;
+}

--- a/apps/react-framework/src/pages/Home.tsx
+++ b/apps/react-framework/src/pages/Home.tsx
@@ -1,12 +1,29 @@
 import { Link } from '../router';
 
 const SUITES: { label: string; path: string }[] = [
-  { label: 'auro-select: remount', path: '/select-remount' },
-  { label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
+  { label: 'auro-checkbox: interaction', path: '/checkbox-interaction' },
+  { label: 'auro-combobox: interaction', path: '/combobox-interaction' },
   { label: 'auro-combobox: remount', path: '/combobox-remount' },
+  { label: 'auro-combobox: city search', path: '/combobox-city-search' },
+  { label: 'auro-combobox: city search (full planbook config)', path: '/combobox-city-search-full' },
+  { label: 'auro-combobox: city search (preselected)', path: '/combobox-city-search-preselected' },
+  { label: 'auro-combobox: city search (preselected, auto-navigate)', path: '/combobox-city-search-preselected-navigate' },
   { label: 'auro-counter-group: dropdown keyboard', path: '/counter-dropdown' },
+  { label: 'auro-counter-group: interaction', path: '/counter-interaction' },
   { label: 'auro-counter-group: remount', path: '/counter-remount' },
   { label: 'auro-counter: remount (single)', path: '/single-counter-remount' },
+  { label: 'auro-datepicker: fullscreen', path: '/datepicker-fullscreen' },
+  { label: 'auro-datepicker: interaction', path: '/datepicker-interaction' },
+  { label: 'auro-dropdown: interaction', path: '/dropdown-interaction' },
+  { label: 'auro-form: interaction', path: '/form-interaction' },
+  { label: 'auro-input: interaction', path: '/input-interaction' },
+  { label: 'auro-menu: interaction', path: '/menu-interaction' },
+  { label: 'auro-radio: interaction', path: '/radio-interaction' },
+  { label: 'auro-select: interaction', path: '/select-interaction' },
+  { label: 'auro-select: remount', path: '/select-remount' },
+  { label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
+  { label: 'auro-select: dynamic menu (preselected)', path: '/select-dynamic' },
+  { label: 'auro-select: dynamic menu (preselected, auto-navigate)', path: '/select-dynamic-navigate' },
 ];
 
 export default function Home() {

--- a/apps/react-framework/src/pages/SelectDynamic.tsx
+++ b/apps/react-framework/src/pages/SelectDynamic.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+
+const ALL_OPTIONS: [string, string][] = [
+  ['foo', 'Foo'],
+  ['bar', 'Bar'],
+  ['baz', 'Baz'],
+];
+
+const INITIAL_VALUE = 'bar';
+
+function SelectDynamicWrapper() {
+  const [options, setOptions] = useState<[string, string][]>([]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setOptions(ALL_OPTIONS);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <auro-select value={INITIAL_VALUE}>
+      <auro-menu>
+        {options.map(([value, label]) => (
+          <auro-menuoption key={value} value={value}>{label}</auro-menuoption>
+        ))}
+      </auro-menu>
+    </auro-select>
+  );
+}
+
+export default function SelectDynamic() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div>
+      <button id="toggle" onClick={() => setShow((s) => !s)}>
+        {show ? 'Hide' : 'Show'} Select
+      </button>
+      {show && <SelectDynamicWrapper />}
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/SelectDynamicNavigate.tsx
+++ b/apps/react-framework/src/pages/SelectDynamicNavigate.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+export default function SelectDynamicNavigate() {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      window.history.pushState({}, '', '/select-dynamic');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }, 200);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return <p>Navigating to select dynamic page...</p>;
+}

--- a/apps/react-framework/src/web-components.d.ts
+++ b/apps/react-framework/src/web-components.d.ts
@@ -1,0 +1,68 @@
+import type { DetailedHTMLProps, HTMLAttributes } from 'react';
+
+type WC = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'auro-combobox': WC & {
+        value?: string;
+        behavior?: string;
+        typedValue?: string;
+        appearance?: string;
+        noFilter?: boolean | '';
+        persistInput?: boolean | '';
+        required?: boolean | '';
+        autocomplete?: string;
+        setCustomValidityValueMissing?: string;
+        dvInputOnly?: boolean | '';
+        size?: string;
+        shape?: string;
+        layout?: string;
+        fullscreenBreakpoint?: string;
+        noFlip?: boolean | '';
+      };
+
+      'auro-select': WC & {
+        value?: string;
+        multiselect?: boolean;
+      };
+
+      'auro-menu': WC & {
+        loading?: boolean | '';
+        hasLoadingPlaceholder?: boolean | '';
+      };
+
+      'auro-menuoption': WC & {
+        value?: string;
+        static?: boolean | '';
+        nomatch?: boolean | '';
+      };
+
+      'auro-counter': WC & {
+        value?: number | string;
+        min?: number | string;
+        max?: number | string;
+        name?: string;
+      };
+      'auro-counter-group': WC & {
+        isDropdown?: boolean | '';
+        min?: string | number;
+        max?: string | number;
+      };
+
+      'auro-datepicker': WC & {
+        value?: string;
+        valueEnd?: string;
+        range?: boolean | '';
+        mobileFriendly?: boolean | '';
+        centralDate?: string;
+      };
+
+      'auro-icon': WC & {
+        category?: string;
+        name?: string;
+      };
+    }
+  }
+}

--- a/apps/react-framework/tests/combobox-city-search.spec.ts
+++ b/apps/react-framework/tests/combobox-city-search.spec.ts
@@ -1,0 +1,3 @@
+import { comboboxCitySearchSuite } from '../../shared/combobox-city-search.suite';
+
+comboboxCitySearchSuite('React');

--- a/apps/react-framework/tests/combobox-preselected-navigation.spec.ts
+++ b/apps/react-framework/tests/combobox-preselected-navigation.spec.ts
@@ -1,0 +1,3 @@
+import { comboboxPreselectedNavigationSuite } from '../../shared/combobox-preselected-navigation.suite';
+
+comboboxPreselectedNavigationSuite('React');

--- a/apps/react-framework/tests/select-dynamic-navigation.spec.ts
+++ b/apps/react-framework/tests/select-dynamic-navigation.spec.ts
@@ -1,0 +1,3 @@
+import { selectDynamicNavigationSuite } from '../../shared/select-dynamic-navigation.suite';
+
+selectDynamicNavigationSuite('React');

--- a/apps/shared/combobox-city-search.suite.ts
+++ b/apps/shared/combobox-city-search.suite.ts
@@ -1,0 +1,176 @@
+import { test, expect, type Page } from './coverage-fixture';
+
+async function typeIntoCombobox(page: Page, text: string) {
+  await page.waitForFunction(() => {
+    const combobox = document.querySelector('auro-combobox') as any;
+    return !!combobox?.input;
+  }, { timeout: 8000 });
+
+  await page.locator('auro-combobox').evaluate((el: any, value: string) => {
+    const input = el.input;
+    if (!input) {
+      throw new Error('Combobox input is not initialized');
+    }
+
+    if (typeof el.focus === 'function') {
+      el.focus();
+    }
+    if (typeof input.focus === 'function') {
+      input.focus();
+    }
+
+    const nativeInput = input.inputElement;
+    if (nativeInput) {
+      nativeInput.value = value;
+      input.value = value;
+      nativeInput.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+      return;
+    }
+
+    input.value = value;
+    el.handleInputValueChange({ target: input });
+  }, text);
+
+  await page.waitForFunction((value: string) => {
+    const combobox = document.querySelector('auro-combobox') as any;
+    if (!combobox || !combobox.input) {
+      return false;
+    }
+
+    const triggerValue = combobox.input.value || '';
+    const bibValue = combobox.inputInBib?.value || triggerValue;
+    return triggerValue === value && bibValue === value;
+  }, text, { timeout: 8000 });
+
+  await page.locator('auro-combobox').evaluate((el: any) => {
+    if (el.dropdown && !el.dropdownOpen && typeof el.dropdown.show === 'function') {
+      el.dropdown.show();
+    }
+  });
+}
+
+async function waitForOption(page: Page, value: string, timeout = 8000) {
+  try {
+    await page.waitForSelector(`auro-menuoption[value="${value}"]`, { timeout });
+  } catch {
+    await page.locator('auro-combobox').evaluate((el: any) => {
+      if (typeof el.focus === 'function') {
+        el.focus();
+      }
+      if (el.input && typeof el.input.focus === 'function') {
+        el.input.focus();
+      }
+      if (!el.dropdownOpen && typeof el.showBib === 'function') {
+        el.showBib();
+      }
+    });
+
+    await page.waitForSelector(`auro-menuoption[value="${value}"]`, { timeout });
+  }
+}
+
+function getComboboxValue(page: Page) {
+  return page.locator('auro-combobox').evaluate((el: any) => el.value);
+}
+
+export function comboboxCitySearchSuite(framework: string) {
+  const route = '/combobox-city-search';
+
+  test.describe(`auro-combobox city search in ${framework}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(route);
+      await page.waitForFunction(() => customElements.get('auro-combobox') !== undefined, {
+        timeout: 10_000,
+      });
+    });
+
+    test('typing "sea" loads Seattle option', async ({ page }) => {
+      await typeIntoCombobox(page, 'sea');
+      await waitForOption(page, 'SEA');
+
+      const option = page.locator('auro-menuoption[value="SEA"]');
+      await expect(option).toBeAttached();
+    });
+
+    test('selecting an option sets combobox value to the IATA code', async ({ page }) => {
+      await typeIntoCombobox(page, 'portland');
+      await waitForOption(page, 'PDX');
+
+      await page.locator('auro-menuoption[value="PDX"]').click();
+
+      await page.waitForFunction(
+        () => (document.querySelector('auro-combobox') as any)?.value === 'PDX',
+        { timeout: 3000 },
+      );
+
+      const value = await getComboboxValue(page);
+      expect(value).toBe('PDX');
+    });
+
+    test('typing a new query replaces previous options', async ({ page }) => {
+      await typeIntoCombobox(page, 'sea');
+      await waitForOption(page, 'SEA');
+
+      await typeIntoCombobox(page, 'anchorage');
+      await waitForOption(page, 'ANC');
+
+      const seaOption = page.locator('auro-menuoption[value="SEA"]');
+      await expect(seaOption).not.toBeAttached();
+    });
+
+    test('typing gibberish shows no results message', async ({ page }) => {
+      await typeIntoCombobox(page, 'xyzxyzxyz');
+
+      await page.waitForSelector('[data-testid="no-results"]', { timeout: 5000 });
+
+      const noResults = page.locator('[data-testid="no-results"]');
+      await expect(noResults).toBeAttached();
+    });
+
+    test('metro area results include sub-station options', async ({ page }) => {
+      await typeIntoCombobox(page, 'san francisco');
+      await waitForOption(page, 'SFO');
+
+      const metroOption = page.locator('auro-menuoption[value="BA3"]');
+      await expect(metroOption).toBeAttached();
+
+      await expect(page.locator('auro-menuoption[value="SFO"]')).toBeAttached();
+      await expect(page.locator('auro-menuoption[value="OAK"]')).toBeAttached();
+      await expect(page.locator('auro-menuoption[value="SJC"]')).toBeAttached();
+    });
+
+    test('value persists after DOM remount', async ({ page }) => {
+      await typeIntoCombobox(page, 'denver');
+      await waitForOption(page, 'DEN');
+      await page.locator('auro-menuoption[value="DEN"]').click();
+
+      await page.waitForFunction(
+        () => (document.querySelector('auro-combobox') as any)?.value === 'DEN',
+        { timeout: 3000 },
+      );
+
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-combobox', { state: 'detached' });
+
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-combobox', { state: 'attached' });
+
+      const displayValue = await page.locator('[data-testid="selected-value"]').textContent();
+      expect(displayValue).toBe('DEN');
+    });
+
+    test('selected value is reflected in the display element', async ({ page }) => {
+      await typeIntoCombobox(page, 'anchorage');
+      await waitForOption(page, 'ANC');
+      await page.locator('auro-menuoption[value="ANC"]').click();
+
+      await page.waitForFunction(
+        () => (document.querySelector('[data-testid="selected-value"]') as HTMLElement)?.textContent === 'ANC',
+        { timeout: 3000 },
+      );
+
+      const display = page.locator('[data-testid="selected-value"]');
+      await expect(display).toHaveText('ANC');
+    });
+  });
+}

--- a/apps/shared/combobox-preselected-navigation.suite.ts
+++ b/apps/shared/combobox-preselected-navigation.suite.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from './coverage-fixture';
+
+const PRESELECTED_VALUE = 'SFO';
+
+async function waitForCombobox(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('auro-combobox') as any;
+      return (
+        customElements.get('auro-combobox') !== undefined &&
+        el != null &&
+        el.dropdown != null
+      );
+    },
+    { timeout: 10_000 },
+  );
+}
+
+async function getComboboxState(page: Page) {
+  return page.locator('auro-combobox').evaluate((el: any) => {
+    return {
+      value: el.value,
+      dropdownOpen: el.dropdownOpen,
+    };
+  });
+}
+
+async function waitForPreselectedPath(page: Page) {
+  await page.waitForFunction(
+    () => window.location.pathname.endsWith('/combobox-city-search-preselected'),
+    { timeout: 10_000 },
+  );
+}
+
+export function comboboxPreselectedNavigationSuite(framework: string) {
+  test.describe(`auro-combobox preselected value after SPA navigation in ${framework}`, () => {
+    test('value equals preselected value after SPA navigation from homepage', async ({ page }) => {
+      await page.goto('/combobox-city-search-preselected-navigate');
+
+      await waitForPreselectedPath(page);
+      await waitForCombobox(page);
+
+      const result = await getComboboxState(page);
+
+      expect(result.value, 'combobox.value should equal the preselected value').toBe(PRESELECTED_VALUE);
+      expect(result.dropdownOpen, 'menu should not open on its own after navigation').toBe(false);
+    });
+
+    test('selected-value display reflects preselected value after SPA navigation', async ({ page }) => {
+      await page.goto('/combobox-city-search-preselected-navigate');
+
+      await waitForPreselectedPath(page);
+      await waitForCombobox(page);
+
+      const display = page.locator('[data-testid="selected-value"]');
+      await expect(display).toContainText(PRESELECTED_VALUE);
+    });
+
+    test('value equals preselected value on direct navigation (control)', async ({ page }) => {
+      await page.goto('/combobox-city-search-preselected');
+      await waitForCombobox(page);
+
+      const result = await getComboboxState(page);
+
+      expect(result.value, 'combobox.value should equal the preselected value').toBe(PRESELECTED_VALUE);
+      expect(result.dropdownOpen, 'menu should not open on direct navigation').toBe(false);
+    });
+  });
+}

--- a/apps/shared/select-dynamic-navigation.suite.ts
+++ b/apps/shared/select-dynamic-navigation.suite.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from './coverage-fixture';
+
+const INITIAL_VALUE = 'bar';
+const OPTIONS_LOAD_TIMEOUT = 5_000;
+
+async function waitForSelectValue(page: Page, expected: string, timeout = OPTIONS_LOAD_TIMEOUT) {
+  await page.waitForFunction(
+    ([selector, val]) =>
+      (document.querySelector(selector as string) as any)?.value === val,
+    ['auro-select', expected],
+    { timeout },
+  );
+}
+
+async function waitForOptionsLoaded(page: Page, timeout = OPTIONS_LOAD_TIMEOUT) {
+  await page.waitForSelector('auro-menuoption', { state: 'attached', timeout });
+}
+
+async function waitForSelectReady(page: Page) {
+  await page.waitForFunction(
+    () => customElements.get('auro-select') !== undefined,
+    { timeout: 10_000 },
+  );
+  await waitForOptionsLoaded(page);
+}
+
+export function selectDynamicNavigationSuite(framework: string) {
+  test.describe(`auro-select preselected value with dynamic menu after SPA navigation in ${framework}`, () => {
+    test('value equals preselected value after SPA navigation and dynamic options load', async ({ page }) => {
+      await page.goto('/select-dynamic-navigate');
+
+      await page.waitForURL('**/select-dynamic', { timeout: 5_000 });
+      await waitForSelectReady(page);
+      await waitForSelectValue(page, INITIAL_VALUE);
+
+      const value = await page.locator('auro-select').evaluate((el: any) => el.value);
+      expect(value, 'auro-select.value should equal the preselected value after options load').toBe(INITIAL_VALUE);
+    });
+
+    test('value equals preselected value on direct navigation with dynamic options (control)', async ({ page }) => {
+      await page.goto('/select-dynamic');
+      await waitForSelectReady(page);
+      await waitForSelectValue(page, INITIAL_VALUE);
+
+      const value = await page.locator('auro-select').evaluate((el: any) => el.value);
+      expect(value, 'auro-select.value should equal the preselected value after options load').toBe(INITIAL_VALUE);
+    });
+  });
+}

--- a/apps/svelte-framework/src/routes/+page.svelte
+++ b/apps/svelte-framework/src/routes/+page.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
 	const suites: { label: string; path: string }[] = [
-		{ label: 'auro-select: remount', path: '/select-remount' },
-		{ label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
+		{ label: 'auro-checkbox: interaction', path: '/checkbox-interaction' },
+		{ label: 'auro-combobox: interaction', path: '/combobox-interaction' },
 		{ label: 'auro-combobox: remount', path: '/combobox-remount' },
+		{ label: 'auro-combobox: city search', path: '/combobox-city-search' },
+		{ label: 'auro-combobox: city search (full planbook config)', path: '/combobox-city-search-full' },
+		{ label: 'auro-combobox: city search (preselected)', path: '/combobox-city-search-preselected' },
+		{ label: 'auro-combobox: city search (preselected, auto-navigate)', path: '/combobox-city-search-preselected-navigate' },
 		{ label: 'auro-counter-group: dropdown keyboard', path: '/counter-dropdown' },
+		{ label: 'auro-counter-group: interaction', path: '/counter-interaction' },
 		{ label: 'auro-counter-group: remount', path: '/counter-remount' },
 		{ label: 'auro-counter: remount (single)', path: '/single-counter-remount' },
+		{ label: 'auro-datepicker: fullscreen', path: '/datepicker-fullscreen' },
+		{ label: 'auro-datepicker: interaction', path: '/datepicker-interaction' },
+		{ label: 'auro-dropdown: interaction', path: '/dropdown-interaction' },
+		{ label: 'auro-form: interaction', path: '/form-interaction' },
+		{ label: 'auro-input: interaction', path: '/input-interaction' },
+		{ label: 'auro-menu: interaction', path: '/menu-interaction' },
+		{ label: 'auro-radio: interaction', path: '/radio-interaction' },
+		{ label: 'auro-select: interaction', path: '/select-interaction' },
+		{ label: 'auro-select: remount', path: '/select-remount' },
+		{ label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
+		{ label: 'auro-select: dynamic menu (preselected)', path: '/select-dynamic' },
+		{ label: 'auro-select: dynamic menu (preselected, auto-navigate)', path: '/select-dynamic-navigate' },
 	];
 </script>
 

--- a/apps/svelte-framework/src/routes/combobox-city-search-full/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-city-search-full/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-combobox';
+	import '@aurodesignsystem/auro-formkit/auro-menu';
+
+	interface Station {
+		name: string;
+		shortName?: string;
+		code: string;
+		subStations?: Station[];
+	}
+
+	const MOCK_CITIES: Station[] = [
+		{ name: 'Seattle/Tacoma, WA', code: 'SEA' },
+		{
+			name: 'San Francisco Bay Area (All Airports)',
+			code: 'BA3',
+			shortName: 'SFO+2',
+			subStations: [
+				{ name: 'San Francisco, CA', code: 'SFO' },
+				{ name: 'Oakland, CA', code: 'OAK' },
+				{ name: 'San Jose, CA', code: 'SJC' },
+			],
+		},
+		{ name: 'Portland, OR', code: 'PDX' },
+		{
+			name: 'Los Angeles (All Airports)',
+			code: 'LA4',
+			shortName: 'LAX+3',
+			subStations: [
+				{ name: 'Los Angeles, CA', code: 'LAX' },
+				{ name: 'Burbank, CA', code: 'BUR' },
+				{ name: 'Long Beach, CA', code: 'LGB' },
+				{ name: 'Ontario, CA', code: 'ONT' },
+			],
+		},
+		{ name: 'Anchorage, AK', code: 'ANC' },
+		{
+			name: 'New York (All Airports)',
+			code: 'NYC',
+			subStations: [
+				{ name: 'John F. Kennedy, NY', code: 'JFK' },
+				{ name: 'LaGuardia, NY', code: 'LGA' },
+				{ name: 'Newark, NJ', code: 'EWR' },
+			],
+		},
+		{ name: 'Boston, MA', code: 'BOS' },
+		{ name: 'Denver, CO', code: 'DEN' },
+		{ name: 'Honolulu, HI', code: 'HNL' },
+		{ name: 'Juneau, AK', code: 'JNU' },
+		{ name: 'Fairbanks, AK', code: 'FAI' },
+	];
+
+	function searchCities(query: string): Station[] {
+		const q = query.toLowerCase();
+		return MOCK_CITIES.filter(
+			(city) =>
+				city.name.toLowerCase().includes(q) ||
+				city.code.toLowerCase() === q ||
+				city.subStations?.some(
+					(s) => s.name.toLowerCase().includes(q) || s.code.toLowerCase() === q,
+				),
+		);
+	}
+
+	let comboboxElement = $state({} as any);
+	let stations = $state<Station[]>([]);
+	let loading = $state(false);
+	let hasSearched = $state(false);
+	let selectedValue = $state('');
+	let typedInputValue = $state('');
+	let appearance = $state<'default' | 'inverse'>('default');
+	let showCombobox = $state(true);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const MISSING_FIELD_ERROR = 'Please select a departure city';
+
+	function handleTextInput(event: Event) {
+		const query = (event as CustomEvent<{ value: string }>).detail?.value ?? '';
+
+		if (debounceTimer) clearTimeout(debounceTimer);
+
+		if (!query) {
+			stations = [];
+			loading = false;
+			return;
+		}
+
+		hasSearched = true;
+		loading = true;
+
+		debounceTimer = setTimeout(() => {
+			stations = searchCities(query);
+			loading = false;
+		}, 300);
+	}
+
+	function handleOptionSelected(event: Event) {
+		const el = event.target as any;
+		selectedValue = el?.value ?? '';
+	}
+
+	function triggerValidation() {
+		comboboxElement?.checkValidity?.();
+	}
+
+	function reset() {
+		selectedValue = '';
+		typedInputValue = '';
+		stations = [];
+		hasSearched = false;
+		if (comboboxElement?.reset) comboboxElement.reset();
+	}
+</script>
+
+<div class="page">
+	<div class="controls">
+		<button onclick={() => (appearance = appearance === 'default' ? 'inverse' : 'default')}>
+			Toggle appearance <em>({appearance})</em>
+		</button>
+		<button onclick={triggerValidation}>Validate</button>
+		<button onclick={reset}>Reset</button>
+		<button id="toggle" onclick={() => (showCombobox = !showCombobox)}>
+			{showCombobox ? 'Hide' : 'Show'} Combobox
+		</button>
+	</div>
+
+	<div class="value-display" data-testid="selected-value">
+		Selected value: <strong>{selectedValue || '(none)'}</strong>
+	</div>
+
+	{#if showCombobox}
+		<auro-combobox
+			bind:this={comboboxElement}
+			appearance={appearance}
+			value={selectedValue}
+			typedValue={typedInputValue}
+			oninput={handleOptionSelected}
+			oninputValue={handleTextInput}
+			noFilter={true}
+			setCustomValidityValueMissing={MISSING_FIELD_ERROR}
+			required
+			persistInput
+			dvInputOnly
+			size="lg"
+			shape="snowflake"
+			layout="snowflake"
+			fullscreenBreakpoint="md"
+			autocomplete="off"
+			noFlip
+		>
+			<span slot="label">From</span>
+			<auro-menu loading={loading} hasLoadingPlaceholder>
+				{#each stations as city (city.code)}
+					<auro-menuoption value={city.code}>
+						{city.name}
+						{#if city.shortName}
+							<span slot="displayValue">{city.shortName}</span>
+						{/if}
+					</auro-menuoption>
+					{#if city.subStations}
+						<auro-menu>
+							{#each city.subStations as sub (sub.code)}
+								<auro-menuoption value={sub.code}>
+									{sub.name}
+									<span slot="displayValue">{sub.code}</span>
+								</auro-menuoption>
+							{/each}
+						</auro-menu>
+					{/if}
+				{/each}
+
+				{#if hasSearched && stations.length === 0 && !loading}
+					<auro-menuoption static nomatch data-testid="no-results">No cities found</auro-menuoption>
+				{/if}
+
+				<span slot="loadingText">Loading cities...</span>
+			</auro-menu>
+		</auro-combobox>
+	{/if}
+</div>
+
+<style>
+	.page {
+		padding: 1.5rem;
+		max-width: 600px;
+	}
+	.controls {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+	.value-display {
+		font-family: monospace;
+		font-size: 0.9rem;
+		margin-bottom: 1.25rem;
+		padding: 0.5rem 0.75rem;
+		background: #f5f5f5;
+		border-radius: 4px;
+	}
+</style>

--- a/apps/svelte-framework/src/routes/combobox-city-search-preselected-navigate/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-city-search-preselected-navigate/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	onMount(() => {
+		const timer = setTimeout(() => {
+			goto('/combobox-city-search-preselected');
+		}, 200);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+<p>Navigating to preselected combobox page...</p>

--- a/apps/svelte-framework/src/routes/combobox-city-search-preselected/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-city-search-preselected/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-combobox';
+	import '@aurodesignsystem/auro-formkit/auro-menu';
+
+	interface Station {
+		name: string;
+		shortName?: string;
+		code: string;
+		subStations?: Station[];
+	}
+
+	const MOCK_CITIES: Station[] = [
+		{ name: 'Seattle/Tacoma, WA', code: 'SEA' },
+		{
+			name: 'San Francisco Bay Area (All Airports)',
+			code: 'BA3',
+			shortName: 'SFO+2',
+			subStations: [
+				{ name: 'San Francisco, CA', code: 'SFO' },
+				{ name: 'Oakland, CA', code: 'OAK' },
+				{ name: 'San Jose, CA', code: 'SJC' },
+			],
+		},
+		{ name: 'Portland, OR', code: 'PDX' },
+		{
+			name: 'Los Angeles (All Airports)',
+			code: 'LA4',
+			shortName: 'LAX+3',
+			subStations: [
+				{ name: 'Los Angeles, CA', code: 'LAX' },
+				{ name: 'Burbank, CA', code: 'BUR' },
+				{ name: 'Long Beach, CA', code: 'LGB' },
+				{ name: 'Ontario, CA', code: 'ONT' },
+			],
+		},
+		{ name: 'Anchorage, AK', code: 'ANC' },
+		{
+			name: 'New York (All Airports)',
+			code: 'NYC',
+			subStations: [
+				{ name: 'John F. Kennedy, NY', code: 'JFK' },
+				{ name: 'LaGuardia, NY', code: 'LGA' },
+				{ name: 'Newark, NJ', code: 'EWR' },
+			],
+		},
+		{ name: 'Boston, MA', code: 'BOS' },
+		{ name: 'Denver, CO', code: 'DEN' },
+		{ name: 'Honolulu, HI', code: 'HNL' },
+		{ name: 'Juneau, AK', code: 'JNU' },
+		{ name: 'Fairbanks, AK', code: 'FAI' },
+	];
+
+	function searchCities(query: string): Station[] {
+		const q = query.toLowerCase();
+		return MOCK_CITIES.filter(
+			(city) =>
+				city.name.toLowerCase().includes(q) ||
+				city.code.toLowerCase() === q ||
+				city.subStations?.some(
+					(s) => s.name.toLowerCase().includes(q) || s.code.toLowerCase() === q,
+				),
+		);
+	}
+
+	let comboboxElement = $state({} as any);
+	let stations = $state<Station[]>([]);
+	let loading = $state(false);
+	let hasSearched = $state(false);
+	let selectedValue = $state('SFO');
+	let typedInputValue = $state('');
+	let appearance = $state<'default' | 'inverse'>('default');
+	let showCombobox = $state(true);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const MISSING_FIELD_ERROR = 'Please select a departure city';
+
+	function handleTextInput(event: Event) {
+		const query = (event as CustomEvent<{ value: string }>).detail?.value ?? '';
+
+		if (debounceTimer) clearTimeout(debounceTimer);
+
+		if (!query) {
+			stations = [];
+			loading = false;
+			return;
+		}
+
+		hasSearched = true;
+		loading = true;
+
+		debounceTimer = setTimeout(() => {
+			stations = searchCities(query);
+			loading = false;
+		}, 300);
+	}
+
+	function handleOptionSelected(event: Event) {
+		const el = event.target as any;
+		selectedValue = el?.value ?? '';
+	}
+
+	function triggerValidation() {
+		comboboxElement?.checkValidity?.();
+	}
+
+	function clearSelection() {
+		selectedValue = '';
+		typedInputValue = '';
+		stations = [];
+		hasSearched = false;
+		if (comboboxElement?.reset) comboboxElement.reset();
+	}
+</script>
+
+<div class="page">
+	<div class="controls">
+		<button onclick={() => (appearance = appearance === 'default' ? 'inverse' : 'default')}>
+			Toggle appearance <em>({appearance})</em>
+		</button>
+		<button onclick={triggerValidation}>Validate</button>
+		<button onclick={clearSelection}>Clear selection</button>
+		<button id="toggle" onclick={() => (showCombobox = !showCombobox)}>
+			{showCombobox ? 'Hide' : 'Show'} Combobox
+		</button>
+	</div>
+
+	<div class="value-display" data-testid="selected-value">
+		Selected value: <strong>{selectedValue || '(none)'}</strong>
+	</div>
+
+	{#if showCombobox}
+		<auro-combobox
+			bind:this={comboboxElement}
+			appearance={appearance}
+			value={selectedValue}
+			typedValue={typedInputValue}
+			oninput={handleOptionSelected}
+			oninputValue={handleTextInput}
+			noFilter={true}
+			setCustomValidityValueMissing={MISSING_FIELD_ERROR}
+			required
+			persistInput
+			dvInputOnly
+			size="lg"
+			shape="snowflake"
+			layout="snowflake"
+			fullscreenBreakpoint="md"
+			autocomplete="off"
+			noFlip
+		>
+			<span slot="label">From</span>
+			<auro-menu loading={loading} hasLoadingPlaceholder>
+				{#each stations as city (city.code)}
+					<auro-menuoption value={city.code}>
+						{city.name}
+						{#if city.shortName}
+							<span slot="displayValue">{city.shortName}</span>
+						{/if}
+					</auro-menuoption>
+					{#if city.subStations}
+						<auro-menu>
+							{#each city.subStations as sub (sub.code)}
+								<auro-menuoption value={sub.code}>
+									{sub.name}
+									<span slot="displayValue">{sub.code}</span>
+								</auro-menuoption>
+							{/each}
+						</auro-menu>
+					{/if}
+				{/each}
+
+				{#if hasSearched && stations.length === 0 && !loading}
+					<auro-menuoption static nomatch data-testid="no-results">No cities found</auro-menuoption>
+				{/if}
+
+				<span slot="loadingText">Loading cities...</span>
+			</auro-menu>
+		</auro-combobox>
+	{/if}
+</div>
+
+<style>
+	.page {
+		padding: 1.5rem;
+		max-width: 600px;
+	}
+	.controls {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+	.value-display {
+		font-family: monospace;
+		font-size: 0.9rem;
+		margin-bottom: 1.25rem;
+		padding: 0.5rem 0.75rem;
+		background: #f5f5f5;
+		border-radius: 4px;
+	}
+</style>

--- a/apps/svelte-framework/src/routes/combobox-city-search/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-city-search/+page.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-combobox';
+	import '@aurodesignsystem/auro-formkit/auro-menu';
+
+	interface Station {
+		name: string;
+		shortName?: string;
+		code: string;
+		subStations?: Station[];
+	}
+
+	const MOCK_CITIES: Station[] = [
+		{ name: 'Seattle/Tacoma, WA', code: 'SEA' },
+		{
+			name: 'San Francisco Bay Area (All Airports)',
+			code: 'BA3',
+			shortName: 'SFO+2',
+			subStations: [
+				{ name: 'San Francisco, CA', code: 'SFO' },
+				{ name: 'Oakland, CA', code: 'OAK' },
+				{ name: 'San Jose, CA', code: 'SJC' },
+			],
+		},
+		{ name: 'Portland, OR', code: 'PDX' },
+		{
+			name: 'Los Angeles (All Airports)',
+			code: 'LA4',
+			shortName: 'LAX+3',
+			subStations: [
+				{ name: 'Los Angeles, CA', code: 'LAX' },
+				{ name: 'Burbank, CA', code: 'BUR' },
+				{ name: 'Long Beach, CA', code: 'LGB' },
+				{ name: 'Ontario, CA', code: 'ONT' },
+			],
+		},
+		{ name: 'Anchorage, AK', code: 'ANC' },
+		{
+			name: 'New York (All Airports)',
+			code: 'NYC',
+			subStations: [
+				{ name: 'John F. Kennedy, NY', code: 'JFK' },
+				{ name: 'LaGuardia, NY', code: 'LGA' },
+				{ name: 'Newark, NJ', code: 'EWR' },
+			],
+		},
+		{ name: 'Boston, MA', code: 'BOS' },
+		{ name: 'Denver, CO', code: 'DEN' },
+		{ name: 'Honolulu, HI', code: 'HNL' },
+		{ name: 'Juneau, AK', code: 'JNU' },
+		{ name: 'Fairbanks, AK', code: 'FAI' },
+	];
+
+	function searchCities(query: string): Station[] {
+		const q = query.toLowerCase();
+		return MOCK_CITIES.filter(
+			(city) =>
+				city.name.toLowerCase().includes(q) ||
+				city.code.toLowerCase() === q ||
+				city.subStations?.some(
+					(s) => s.name.toLowerCase().includes(q) || s.code.toLowerCase() === q,
+				),
+		);
+	}
+
+	let stations = $state<Station[]>([]);
+	let loading = $state(false);
+	let hasSearched = $state(false);
+	let selectedValue = $state('');
+	let showCombobox = $state(true);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function handleTextInput(event: Event) {
+		const query = (event as CustomEvent<{ value: string }>).detail?.value ?? '';
+
+		if (debounceTimer) clearTimeout(debounceTimer);
+
+		if (!query) {
+			stations = [];
+			loading = false;
+			return;
+		}
+
+		hasSearched = true;
+		loading = true;
+
+		debounceTimer = setTimeout(() => {
+			stations = searchCities(query);
+			loading = false;
+		}, 300);
+	}
+
+	function handleOptionSelected(event: Event) {
+		const el = event.target as any;
+		selectedValue = el?.value ?? '';
+	}
+</script>
+
+<button id="toggle" onclick={() => (showCombobox = !showCombobox)}>
+	{showCombobox ? 'Hide' : 'Show'} Combobox
+</button>
+
+<div id="selected-value" data-testid="selected-value">{selectedValue}</div>
+
+{#if showCombobox}
+	<auro-combobox
+		noFilter
+		persistInput
+		required
+		autocomplete="off"
+		oninputValue={handleTextInput}
+		oninput={handleOptionSelected}
+	>
+		<span slot="label">From</span>
+		<auro-menu loading={loading} hasLoadingPlaceholder>
+			{#each stations as city (city.code)}
+				<auro-menuoption value={city.code}>
+					{city.name}
+					{#if city.shortName}
+						<span slot="displayValue">{city.shortName}</span>
+					{/if}
+				</auro-menuoption>
+				{#if city.subStations}
+					<auro-menu>
+						{#each city.subStations as sub (sub.code)}
+							<auro-menuoption value={sub.code}>
+								{sub.name}
+								<span slot="displayValue">{sub.code}</span>
+							</auro-menuoption>
+						{/each}
+					</auro-menu>
+				{/if}
+			{/each}
+
+			{#if hasSearched && stations.length === 0 && !loading}
+				<auro-menuoption static nomatch data-testid="no-results">No cities found</auro-menuoption>
+			{/if}
+
+			<span slot="loadingText">Loading cities...</span>
+		</auro-menu>
+	</auro-combobox>
+{/if}

--- a/apps/svelte-framework/src/routes/select-dynamic-navigate/+page.svelte
+++ b/apps/svelte-framework/src/routes/select-dynamic-navigate/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	onMount(() => {
+		const timer = setTimeout(() => {
+			goto('/select-dynamic');
+		}, 200);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+<p>Navigating to select dynamic page...</p>

--- a/apps/svelte-framework/src/routes/select-dynamic/+page.svelte
+++ b/apps/svelte-framework/src/routes/select-dynamic/+page.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-select';
+	import '@aurodesignsystem/auro-formkit/auro-menu';
+	import { onMount } from 'svelte';
+
+	const ALL_OPTIONS: [string, string][] = [
+		['foo', 'Foo'],
+		['bar', 'Bar'],
+		['baz', 'Baz'],
+	];
+
+	let selectValue = $state<string>('bar');
+	let options = $state<[string, string][]>([]);
+	let showSelect = $state<boolean>(true);
+
+	onMount(() => {
+		const timer = setTimeout(() => {
+			options = ALL_OPTIONS;
+		}, 300);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+<button id="toggle" onclick={() => (showSelect = !showSelect)}>
+	{showSelect ? 'Hide' : 'Show'} Select
+</button>
+
+{#if showSelect}
+	<auro-select value={selectValue}>
+		<auro-menu>
+			{#each options as [value, label]}
+				<auro-menuoption {value}>{label}</auro-menuoption>
+			{/each}
+		</auro-menu>
+	</auro-select>
+{/if}

--- a/apps/svelte-framework/tests/combobox-city-search.spec.ts
+++ b/apps/svelte-framework/tests/combobox-city-search.spec.ts
@@ -1,0 +1,3 @@
+import { comboboxCitySearchSuite } from '../../shared/combobox-city-search.suite';
+
+comboboxCitySearchSuite('Svelte');

--- a/apps/svelte-framework/tests/combobox-preselected-navigation.spec.ts
+++ b/apps/svelte-framework/tests/combobox-preselected-navigation.spec.ts
@@ -1,0 +1,3 @@
+import { comboboxPreselectedNavigationSuite } from '../../shared/combobox-preselected-navigation.suite';
+
+comboboxPreselectedNavigationSuite('Svelte');

--- a/apps/svelte-framework/tests/select-dynamic-navigation.spec.ts
+++ b/apps/svelte-framework/tests/select-dynamic-navigation.spec.ts
@@ -1,0 +1,3 @@
+import { selectDynamicNavigationSuite } from '../../shared/select-dynamic-navigation.suite';
+
+selectDynamicNavigationSuite('Svelte');

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -84,7 +84,6 @@ export class AuroCombobox extends AuroElement {
     this.optionActive = null;
     this.persistInput = false;
     this.required = false;
-    this.value = undefined;
     this.typedValue = undefined;
     this.behavior = "suggestion";
     this.clearBtnFocused = false;
@@ -697,6 +696,10 @@ export class AuroCombobox extends AuroElement {
     });
 
     if (this.value && this.input.value && !this.menu.value) {
+      if (this.behavior === 'suggestion' && this.menu.options && this.menu.options.some((opt) => opt.value === this.value)) {
+        this.setMenuValue(this.value);
+      }
+
       this.syncValuesAndStates();
     }
 
@@ -1310,10 +1313,6 @@ export class AuroCombobox extends AuroElement {
     this.configureCombobox();
     this.configureMenu();
 
-    // Set the initial value in auro-menu if defined
-    if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
-      this.menu.value = this.value;
-    }
   }
 
   /**
@@ -1394,10 +1393,18 @@ export class AuroCombobox extends AuroElement {
         this.input.value = this.value;
       }
 
+      if (this.menu && this.hasValue && this.menu.options) {
+        this.menu.options.forEach((opt) => {
+          if (!opt.hasAttribute('static')) {
+            opt.removeAttribute('hidden');
+          }
+        });
+      }
+
       if (this.behavior === 'suggestion') {
-        // if menu has an option that has matched value, then select it,
-        // otherwise clear the menu value since the input value doesn't match any option
-        if (this.menu.options && this.menu.options.filter((opt) => opt.value === this.value).length > 0) {
+        if (!this.menu.options || this.menu.options.length === 0) {
+          // No options loaded yet (async pattern) — don't touch menu.value.
+        } else if (this.menu.options.filter((opt) => opt.value === this.value).length > 0) {
           this.setMenuValue(this.value);
         } else {
           this.menu.value = undefined;

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1408,6 +1408,8 @@ export class AuroCombobox extends AuroElement {
           this.setMenuValue(this.value);
         } else {
           this.menu.value = undefined;
+          // Sync the input display for freeform values that don't match any option
+          this.input.value = this.value;
         }
       } else {
         // Use setMenuValue like select does instead of direct assignment

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -21,6 +21,7 @@ import {
   noFilterFixture,
   inDialogFixture,
   inDrawerFixture,
+  swapFixture,
 } from './testFixtures.js';
 import { setInputValue, getAnnouncementRoot } from './testFunctions.js';
 import { comboboxKeyboardStrategy } from '../src/comboboxKeyboardStrategy.js';
@@ -575,26 +576,7 @@ function runFullTest(mobileView) {
     });
 
     it('should swap values between two comboboxes', async () => {
-      const wrapper = await fixture(html`
-        <div>
-          <auro-combobox id="left">
-            <span slot="label">Left</span>
-            <auro-menu>
-              <auro-menuoption value="Apples">Apples</auro-menuoption>
-              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
-              <auro-menuoption value="Peaches">Peaches</auro-menuoption>
-            </auro-menu>
-          </auro-combobox>
-          <auro-combobox id="right">
-            <span slot="label">Right</span>
-            <auro-menu>
-              <auro-menuoption value="Apples">Apples</auro-menuoption>
-              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
-              <auro-menuoption value="Peaches">Peaches</auro-menuoption>
-            </auro-menu>
-          </auro-combobox>
-        </div>
-      `);
+      const wrapper = await swapFixture(mobileView);
 
       const left = wrapper.querySelector('#left');
       const right = wrapper.querySelector('#right');
@@ -620,6 +602,35 @@ function runFullTest(mobileView) {
       await expect(right.value).to.equal('Apples');
       await expect(left.input.value).to.equal('Oranges');
       await expect(right.input.value).to.equal('Apples');
+    });
+
+    it('should swap freeform typed values between two comboboxes', async () => {
+      const wrapper = await swapFixture(mobileView);
+
+      const left = wrapper.querySelector('#left');
+      const right = wrapper.querySelector('#right');
+
+      // Type freeform values without selecting from menu
+      setInputValue(left, 'a');
+      setInputValue(right, 'b');
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      await expect(left.value).to.equal('a');
+      await expect(right.value).to.equal('b');
+
+      // Swap values programmatically (like the demo swap button)
+      const leftVal = left.value;
+      const rightVal = right.value;
+      left.value = rightVal;
+      right.value = leftVal;
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      await expect(left.value).to.equal('b');
+      await expect(right.value).to.equal('a');
+      await expect(left.input.value).to.equal('b');
+      await expect(right.input.value).to.equal('a');
     });
 
     // These tests require fullscreen (mobile) mode

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -573,6 +573,56 @@ function runFullTest(mobileView) {
         await expect(el.value).to.equal('Apples');
       });
     });
+
+    it('should swap values between two comboboxes', async () => {
+      const wrapper = await fixture(html`
+        <div>
+          <auro-combobox id="left">
+            <span slot="label">Left</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption value="Peaches">Peaches</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+          <auro-combobox id="right">
+            <span slot="label">Right</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption value="Peaches">Peaches</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        </div>
+      `);
+
+      const left = wrapper.querySelector('#left');
+      const right = wrapper.querySelector('#right');
+
+      // Set initial values
+      left.value = 'Apples';
+      right.value = 'Oranges';
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      await expect(left.value).to.equal('Apples');
+      await expect(right.value).to.equal('Oranges');
+
+      // Swap values
+      const leftVal = left.value;
+      const rightVal = right.value;
+      left.value = rightVal;
+      right.value = leftVal;
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      await expect(left.value).to.equal('Oranges');
+      await expect(right.value).to.equal('Apples');
+      await expect(left.input.value).to.equal('Oranges');
+      await expect(right.input.value).to.equal('Apples');
+    });
+
+    // These tests require fullscreen (mobile) mode
   });
 
   describe('Properties', () => {

--- a/components/combobox/test/testFixtures.js
+++ b/components/combobox/test/testFixtures.js
@@ -467,3 +467,42 @@ export async function inDrawerFixture() {
     </auro-drawer>
   `);
 }
+
+/**
+ * Testing fixture with two comboboxes for value swapping tests.
+ * @param {boolean} mobileView - Whether to render the fixture in mobile viewport.
+ * @returns {Promise<HTMLElement>} A wrapper div containing two auro-combobox elements (#left and #right).
+ */
+export async function swapFixture(mobileView) {
+  if (mobileView) {
+    await setViewport({
+      width: 500,
+      height: 800
+    });
+  } else {
+    await setViewport({
+      width: 800,
+      height: 800
+    });
+  }
+  return fixture(html`
+  <div>
+    <auro-combobox id="left">
+      <span slot="label">Left</span>
+      <auro-menu>
+        <auro-menuoption value="Apples">Apples</auro-menuoption>
+        <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+        <auro-menuoption value="Peaches">Peaches</auro-menuoption>
+      </auro-menu>
+    </auro-combobox>
+    <auro-combobox id="right">
+      <span slot="label">Right</span>
+      <auro-menu>
+        <auro-menuoption value="Apples">Apples</auro-menuoption>
+        <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+        <auro-menuoption value="Peaches">Peaches</auro-menuoption>
+      </auro-menu>
+    </auro-combobox>
+  </div>
+  `);
+}

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -22,7 +22,7 @@ The `auro-menu` element provides users a way to select from a list of options.
 | `selectAllMatchingOptions` | `selectAllMatchingOptions` |           | `boolean`             | false       | When true, selects all options that match the provided value/key when setting value and multiselect is enabled. |
 | `selectedOption`           |                            | readonly  | `HTMLElement \| null` |             | Gets the first selected option, or null if none. |
 | `selectedOptions`          |                            | readonly  | `HTMLElement[]`       |             | Gets the currently selected options.             |
-| `value`                    | `value`                    |           | `string`              | "undefined" | The value of the selected option. In multi-select mode, this is a JSON stringified array of selected option values. |
+| `value`                    | `value`                    |           | `string`              |             | The value of the selected option. In multi-select mode, this is a JSON stringified array of selected option values. |
 
 ## Methods
 

--- a/components/menu/src/auro-menu.context.js
+++ b/components/menu/src/auro-menu.context.js
@@ -328,10 +328,13 @@ export class MenuService {
     }
 
     const optionsSet = new Set(optionsToDeselect);
+    const previousCount = this.selectedOptions.length;
     this.selectedOptions = (this.selectedOptions || [])
       .filter(opt => !optionsSet.has(opt));
 
-    this.stageUpdate();
+    if (this.selectedOptions.length < previousCount) {
+      this.stageUpdate();
+    }
   }
 
   /**

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -56,8 +56,6 @@ export class AuroMenu extends AuroElement {
      */
     this.size = "sm";
 
-    // Value of the selected options
-    this.value = undefined;
     // Currently selected option
     this.optionSelected = undefined;
     // String used for highlighting/filtering

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -459,7 +459,7 @@ export class AuroMenuOption extends AuroElement {
    * @private
    */
   handleClick() {
-    if (!this.disabled) {
+    if (!this.disabled && !this.menuService?.disabled) {
       this.dispatchClickEvent();
       this.selected = !this.selected;
     }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Guard deselectOptions to only fire stageUpdate when an option is actually removed, preventing menuoption init from overwriting a programmatic value. Skip clearing menu.value when no options are loaded yet (async pattern), sync menu selection when new options arrive matching the combobox value, and unhide non-static options before selectByValue so filtered options are still findable.

Adds framework test suites for city-search, preselected navigation, and dynamic-option scenarios across React and Svelte. Backfills all missing interaction tests onto the overview/home pages.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve combobox and select value preservation with async menu options and SPA navigation, and expand framework playground coverage for these scenarios.

Bug Fixes:
- Prevent auro-menu deselection updates when no options are actually removed, avoiding unintended value resets.
- Ensure auro-combobox and auro-select retain programmatically set or preselected values across async option loading and initialisation.

Enhancements:
- Sync combobox menu selection with existing values only when options are available and unhide dynamic options before value-based selection, improving async search behavior.
- Add JSX typings for Auro web components in the React framework app for better type safety.

Tests:
- Add city-search, full-config, and preselected combobox scenarios and navigation flows to both React and Svelte framework playgrounds.
- Introduce shared Playwright suites for combobox city search, preselected navigation, and dynamic select menus across frameworks.
- Backfill interaction suites on React and Svelte home pages for multiple formkit components including checkbox, combobox, counter, datepicker, dropdown, form, input, menu, radio, and select.