### PR TITLE
perf: add ctrl modifier key functionality  AB#1550261

### DIFF
--- a/components/combobox/docs/partials/keyboard-behavior/keyEvents.md
+++ b/components/combobox/docs/partials/keyboard-behavior/keyEvents.md
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
     <tr>
-      <td rowspan="6">ArrowDown</td>
+      <td rowspan="8">ArrowDown</td>
       <td rowspan="2">-</td>
       <td>Collapsed, list options have been populated</td>
       <td>
@@ -74,7 +74,32 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="6">ArrowUp</td>
+      <td rowspan="2">Control</td>
+      <td>Collapsed, list options have been populated</td>
+      <td>
+        Trigger input element, <strong>NOT</strong> the trigger input clear button
+      </td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>Expanded</td>
+      <td>
+        Input element, <strong>NOT</strong> the input clear button
+        <div class="note">
+          <strong>Note:</strong> Includes both trigger and bib content inputs.
+        </div>
+      </td>
+      <td>
+        Advances the <code>focused</code> option to the last enabled option in the list.
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="8">ArrowUp</td>
       <td rowspan="2">-</td>
       <td>Collapsed, list options have been populated</td>
       <td>
@@ -121,6 +146,31 @@
         Input element, <strong>NOT</strong> the input clear button
       </td>
       <td>Opens the bib.</td>
+    </tr>
+    <tr>
+      <td>Expanded</td>
+      <td>
+        Input element, <strong>NOT</strong> the input clear button
+        <div class="note">
+          <strong>Note:</strong> Includes both trigger and bib content inputs.
+        </div>
+      </td>
+      <td>
+        Advances the <code>focused</code> option to the first enabled option in the list.
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="2">Control</td>
+      <td>Collapsed, list options have been populated</td>
+      <td>
+        Trigger input element, <strong>NOT</strong> the trigger input clear button
+      </td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+        </div>
+      </td>
     </tr>
     <tr>
       <td>Expanded</td>

--- a/components/combobox/docs/partials/keyboard-behavior/keyEvents.md
+++ b/components/combobox/docs/partials/keyboard-behavior/keyEvents.md
@@ -34,12 +34,17 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Command</td>
+      <td rowspan="2">Meta (Command / Windows key)</td>
       <td>Collapsed, list options have been populated</td>
       <td>
         Trigger input element, <strong>NOT</strong> the trigger input clear button
       </td>
-      <td>Opens the bib.</td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On Windows, <code>Meta</code> + arrow key combinations are reserved by the operating system for window management. Windows users should use <code>Control</code> or <code>Alt</code> instead.
+        </div>
+      </td>
     </tr>
     <tr>
       <td>Expanded</td>
@@ -54,7 +59,7 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Option</td>
+      <td rowspan="2">Alt (Option)</td>
       <td>Collapsed, list options have been populated</td>
       <td>
         Trigger input element, <strong>NOT</strong> the trigger input clear button
@@ -82,7 +87,7 @@
       <td>
         Opens the bib.
         <div class="note">
-          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Meta</code> or <code>Alt</code> instead.
         </div>
       </td>
     </tr>
@@ -120,12 +125,17 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Command</td>
+      <td rowspan="2">Meta (Command / Windows key)</td>
       <td>Collapsed, list options have been populated</td>
       <td>
         Trigger input element, <strong>NOT</strong> the trigger input clear button
       </td>
-      <td>Opens the bib.</td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On Windows, <code>Meta</code> + arrow key combinations are reserved by the operating system for window management. Windows users should use <code>Control</code> or <code>Alt</code> instead.
+        </div>
+      </td>
     </tr>
     <tr>
       <td>Expanded</td>
@@ -140,7 +150,7 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Option</td>
+      <td rowspan="2">Alt (Option)</td>
       <td>Collapsed, list options have been populated</td>
       <td>
         Input element, <strong>NOT</strong> the input clear button
@@ -168,7 +178,7 @@
       <td>
         Opens the bib.
         <div class="note">
-          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Meta</code> or <code>Alt</code> instead.
         </div>
       </td>
     </tr>

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -43,7 +43,7 @@ export const comboboxKeyboardStrategy = {
 
       // navigate if bib is open otherwise open it
       if (component.dropdown.isPopoverVisible) {
-        if (evt.altKey || evt.metaKey) {
+        if (evt.altKey || evt.ctrlKey || evt.metaKey) {
           component.activateLastEnabledAvailableOption();
         } else {
           navigateArrow(component, 'down');
@@ -66,7 +66,7 @@ export const comboboxKeyboardStrategy = {
 
       // navigate if bib is open otherwise open it
       if (component.dropdown.isPopoverVisible) {
-        if (evt.altKey || evt.metaKey) {
+        if (evt.altKey || evt.ctrlKey || evt.metaKey) {
           component.activateFirstEnabledAvailableOption();
         } else {
           navigateArrow(component, 'up');

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -3573,6 +3573,108 @@ function runFullTest(mobileView) {
         await expect(el.dropdown.isPopoverVisible).to.be.true;
       });
 
+      it('should skip disabled last option with Alt+ArrowDown', async () => {
+        const el = await fixture(html`
+          <auro-combobox>
+            <span slot="label">Name</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption value="Grapes" disabled>Grapes</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        `);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          altKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
+        const lastEnabledOption = enabledOptions[enabledOptions.length - 1];
+        await expect(el.optionActive).to.equal(lastEnabledOption);
+      });
+
+      it('should skip disabled last option with Meta+ArrowDown', async () => {
+        const el = await fixture(html`
+          <auro-combobox>
+            <span slot="label">Name</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption value="Grapes" disabled>Grapes</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        `);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
+        const lastEnabledOption = enabledOptions[enabledOptions.length - 1];
+        await expect(el.optionActive).to.equal(lastEnabledOption);
+      });
+
+      it('should skip disabled last option with Ctrl+ArrowDown', async () => {
+        const el = await fixture(html`
+          <auro-combobox>
+            <span slot="label">Name</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption value="Grapes" disabled>Grapes</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        `);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
+        const lastEnabledOption = enabledOptions[enabledOptions.length - 1];
+        await expect(el.optionActive).to.equal(lastEnabledOption);
+      });
+
       it('should not navigate when clear button has focus', async () => {
         const el = await defaultFixture(mobileView);
 
@@ -3859,6 +3961,93 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('should skip disabled first option with Alt+ArrowUp', async () => {
+        const el = await shiftTabDisabledFirstFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        // Navigate away from the first enabled option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          altKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
+        await expect(el.optionActive).to.equal(enabledOptions[0]);
+        await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
+      });
+
+      it('should skip disabled first option with Meta+ArrowUp', async () => {
+        const el = await shiftTabDisabledFirstFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        // Navigate away from the first enabled option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
+        await expect(el.optionActive).to.equal(enabledOptions[0]);
+        await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
+      });
+
+      it('should skip disabled first option with Ctrl+ArrowUp', async () => {
+        const el = await shiftTabDisabledFirstFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        // Navigate away from the first enabled option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
+        await expect(el.optionActive).to.equal(enabledOptions[0]);
+        await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
       });
     });
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -3479,6 +3479,100 @@ function runFullTest(mobileView) {
         await expect(el.optionActive).to.equal(lastOption);
       });
 
+      it('should activate the last enabled option with Ctrl+ArrowDown', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
+        const lastOption = menuOptions[menuOptions.length - 1];
+        await expect(el.optionActive).to.equal(lastOption);
+      });
+
+      it('should open the bib when collapsed with Alt+ArrowDown', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+
+        el.hideBib();
+        await elementUpdated(el);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          altKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('should open the bib when collapsed with Meta+ArrowDown', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+
+        el.hideBib();
+        await elementUpdated(el);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('should open the bib when collapsed with Ctrl+ArrowDown', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+
+        el.hideBib();
+        await elementUpdated(el);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
       it('should not navigate when clear button has focus', async () => {
         const el = await defaultFixture(mobileView);
 
@@ -3644,6 +3738,36 @@ function runFullTest(mobileView) {
         await expect(el.optionActive).to.equal(menuOptions[0]);
       });
 
+      it('should activate the first enabled option with Ctrl+ArrowUp', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        if (mobileView) {
+          el.inputInBib.focus();
+          await waitUntil(() => el.shadowRoot.activeElement === el.inputInBib);
+        }
+
+        // Navigate away from first option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
+        await expect(el.optionActive).to.equal(menuOptions[0]);
+      });
+
       it('should open the bib when ArrowUp is pressed and bib is closed', async () => {
         const el = await defaultFixture(mobileView);
 
@@ -3660,6 +3784,75 @@ function runFullTest(mobileView) {
         // ArrowUp should open it
         el.dispatchEvent(new KeyboardEvent('keydown', {
           key: 'ArrowUp',
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('should open the bib when collapsed with Alt+ArrowUp', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+
+        el.hideBib();
+        await elementUpdated(el);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          altKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('should open the bib when collapsed with Meta+ArrowUp', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+
+        el.hideBib();
+        await elementUpdated(el);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true
+        }));
+        await elementUpdated(el);
+
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('should open the bib when collapsed with Ctrl+ArrowUp', async () => {
+        const el = await shiftTabFixture(mobileView);
+
+        setInputValue(el, 'a');
+        await elementUpdated(el);
+
+        el.hideBib();
+        await elementUpdated(el);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+        el.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          ctrlKey: true,
           bubbles: true,
           cancelable: true
         }));

--- a/components/select/docs/partials/keyboard-behavior/keyEvents.md
+++ b/components/select/docs/partials/keyboard-behavior/keyEvents.md
@@ -24,10 +24,15 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Command</td>
+      <td rowspan="2">Meta (Command / Windows key)</td>
       <td>Collapsed</td>
       <td>Trigger element</td>
-      <td>Opens the bib.</td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On Windows, <code>Meta</code> + arrow key combinations are reserved by the operating system for window management. Windows users should use <code>Control</code> or <code>Alt</code> instead.
+        </div>
+      </td>
     </tr>
     <tr>
       <td>Expanded</td>
@@ -37,7 +42,7 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Option</td>
+      <td rowspan="2">Alt (Option)</td>
       <td>Collapsed</td>
       <td>Trigger element</td>
       <td>Opens the bib.</td>
@@ -56,7 +61,7 @@
       <td>
         Opens the bib.
         <div class="note">
-          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Meta</code> or <code>Alt</code> instead.
         </div>
       </td>
     </tr>
@@ -82,10 +87,15 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Command</td>
+      <td rowspan="2">Meta (Command / Windows key)</td>
       <td>Collapsed</td>
       <td>Trigger element</td>
-      <td>Opens the bib.</td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On Windows, <code>Meta</code> + arrow key combinations are reserved by the operating system for window management. Windows users should use <code>Control</code> or <code>Alt</code> instead.
+        </div>
+      </td>
     </tr>
     <tr>
       <td>Expanded</td>
@@ -95,7 +105,7 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="2">Option</td>
+      <td rowspan="2">Alt (Option)</td>
       <td>Collapsed</td>
       <td>Trigger element</td>
       <td>Opens the bib.</td>
@@ -114,7 +124,7 @@
       <td>
         Opens the bib.
         <div class="note">
-          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Meta</code> or <code>Alt</code> instead.
         </div>
       </td>
     </tr>

--- a/components/select/docs/partials/keyboard-behavior/keyEvents.md
+++ b/components/select/docs/partials/keyboard-behavior/keyEvents.md
@@ -10,7 +10,7 @@
   </thead>
   <tbody>
     <tr>
-      <td rowspan="6">ArrowDown</td>
+      <td rowspan="8">ArrowDown</td>
       <td rowspan="2">-</td>
       <td>Collapsed</td>
       <td>Trigger element</td>
@@ -50,7 +50,25 @@
       </td>
     </tr>
     <tr>
-      <td rowspan="6">ArrowUp</td>
+      <td rowspan="2">Control</td>
+      <td>Collapsed</td>
+      <td>Trigger element</td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td>Expanded</td>
+      <td>Trigger element</td>
+      <td>
+        Advances the <code>focused</code> option to the last enabled option in the list.
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="8">ArrowUp</td>
       <td rowspan="2">-</td>
       <td>Collapsed</td>
       <td>Trigger element</td>
@@ -81,6 +99,24 @@
       <td>Collapsed</td>
       <td>Trigger element</td>
       <td>Opens the bib.</td>
+    </tr>
+    <tr>
+      <td>Expanded</td>
+      <td>Trigger element</td>
+      <td>
+        Advances the <code>focused</code> option to the first enabled option in the list.
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="2">Control</td>
+      <td>Collapsed</td>
+      <td>Trigger element</td>
+      <td>
+        Opens the bib.
+        <div class="note">
+          <strong>Note:</strong> On macOS, <code>Control</code> + arrow key combinations are reserved by the operating system for Mission Control and Application Windows. macOS users should use <code>Command</code> or <code>Option</code> instead.
+        </div>
+      </td>
     </tr>
     <tr>
       <td>Expanded</td>

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -4,28 +4,30 @@ import { navigateArrow } from '@aurodesignsystem/utils';
 export const selectKeyboardStrategy = {
   ArrowDown(component, evt, ctx) {
     evt.preventDefault();
-    if (evt.altKey || evt.metaKey) {
-      // navigate to last enabled option
-      selectKeyboardStrategy.End(component, evt, ctx);
-      return;
+    if (ctx.isExpanded) {
+      if (evt.altKey || evt.ctrlKey || evt.metaKey) {
+        // navigate to last enabled option
+        selectKeyboardStrategy.End(component, evt, ctx);
+      } else {
+        navigateArrow(component, 'down', { ctx });
+      }
+    } else {
+      component.dropdown.show();
     }
-    navigateArrow(component, 'down', {
-      ctx,
-      showFn: () => component.dropdown.show(),
-    });
   },
 
   ArrowUp(component, evt, ctx) {
     evt.preventDefault();
-    if (evt.altKey || evt.metaKey) {
-      // navigate to first enabled option
-      selectKeyboardStrategy.Home(component, evt, ctx);
-      return;
+    if (ctx.isExpanded) {
+      if (evt.altKey || evt.ctrlKey || evt.metaKey) {
+        // navigate to first enabled option
+        selectKeyboardStrategy.Home(component, evt, ctx);
+      } else {
+        navigateArrow(component, 'up', { ctx });
+      }
+    } else {
+      component.dropdown.show();
     }
-    navigateArrow(component, 'up', {
-      ctx,
-      showFn: () => component.dropdown.show(),
-    });
   },
 
   Escape(component, evt, ctx) {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2564,6 +2564,36 @@ function runTest(mobileView) {
 
             await expect(el.optionActive === firstOption).to.equal(true);
           });
+
+          it('should skip disabled options', async () => {
+            const el = await fixture(html`
+              <auro-select>
+                <span slot="bib.fullscreen.headline">Bib Headline</span>
+                <span slot="label">Name</span>
+                <auro-menu>
+                  <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
+                  <auro-menuoption value="Price">Price</auro-menuoption>
+                  <auro-menuoption value="Duration">Duration</auro-menuoption>
+                </auro-menu>
+              </auro-select>
+            `);
+
+            await elementUpdated(el);
+            el.showBib();
+            await elementUpdated(el);
+
+            // Move away from the first enabled option
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+
+            const menu = el.querySelector('auro-menu');
+            const firstEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', metaKey: true }));
+            await elementUpdated(el);
+
+            await expect(el.optionActive === firstEnabledOption).to.equal(true);
+          });
         });
 
         describe('Alt', () => {
@@ -2600,6 +2630,36 @@ function runTest(mobileView) {
 
             await expect(el.optionActive === firstOption).to.equal(true);
           });
+
+          it('should skip disabled options', async () => {
+            const el = await fixture(html`
+              <auro-select>
+                <span slot="bib.fullscreen.headline">Bib Headline</span>
+                <span slot="label">Name</span>
+                <auro-menu>
+                  <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
+                  <auro-menuoption value="Price">Price</auro-menuoption>
+                  <auro-menuoption value="Duration">Duration</auro-menuoption>
+                </auro-menu>
+              </auro-select>
+            `);
+
+            await elementUpdated(el);
+            el.showBib();
+            await elementUpdated(el);
+
+            // Move away from the first enabled option
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+
+            const menu = el.querySelector('auro-menu');
+            const firstEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true }));
+            await elementUpdated(el);
+
+            await expect(el.optionActive === firstEnabledOption).to.equal(true);
+          });
         });
 
         describe('Ctrl', () => {
@@ -2635,6 +2695,36 @@ function runTest(mobileView) {
             await elementUpdated(el);
 
             await expect(el.optionActive === firstOption).to.equal(true);
+          });
+
+          it('should skip disabled options', async () => {
+            const el = await fixture(html`
+              <auro-select>
+                <span slot="bib.fullscreen.headline">Bib Headline</span>
+                <span slot="label">Name</span>
+                <auro-menu>
+                  <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
+                  <auro-menuoption value="Price">Price</auro-menuoption>
+                  <auro-menuoption value="Duration">Duration</auro-menuoption>
+                </auro-menu>
+              </auro-select>
+            `);
+
+            await elementUpdated(el);
+            el.showBib();
+            await elementUpdated(el);
+
+            // Move away from the first enabled option
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+
+            const menu = el.querySelector('auro-menu');
+            const firstEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', ctrlKey: true }));
+            await elementUpdated(el);
+
+            await expect(el.optionActive === firstEnabledOption).to.equal(true);
           });
         });
       });

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2343,6 +2343,20 @@ function runTest(mobileView) {
         });
 
         describe('Meta', () => {
+          it('should open the bib when collapsed', async () => {
+            const el = await defaultFixture();
+
+            await elementUpdated(el);
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', metaKey: true }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
           it('should jump to the last enabled option', async () => {
             const el = await defaultFixture();
 
@@ -2387,6 +2401,20 @@ function runTest(mobileView) {
         });
 
         describe('Alt', () => {
+          it('should open the bib when collapsed', async () => {
+            const el = await defaultFixture();
+
+            await elementUpdated(el);
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
           it('should jump to the last enabled option', async () => {
             const el = await defaultFixture();
 
@@ -2429,6 +2457,64 @@ function runTest(mobileView) {
             await expect(el.optionActive === lastEnabledOption).to.equal(true);
           });
         });
+
+        describe('Ctrl', () => {
+          it('should open the bib when collapsed', async () => {
+            const el = await defaultFixture();
+
+            await elementUpdated(el);
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
+          it('should jump to the last enabled option', async () => {
+            const el = await defaultFixture();
+
+            await elementUpdated(el);
+            el.showBib();
+            await elementUpdated(el);
+
+            const menu = el.querySelector('auro-menu');
+            const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+            await elementUpdated(el);
+
+            await expect(el.optionActive === lastOption).to.equal(true);
+          });
+
+          it('should skip disabled options', async () => {
+            const el = await fixture(html`
+              <auro-select>
+                <span slot="bib.fullscreen.headline">Bib Headline</span>
+                <span slot="label">Name</span>
+                <auro-menu>
+                  <auro-menuoption value="Stops">Stops</auro-menuoption>
+                  <auro-menuoption value="Price">Price</auro-menuoption>
+                  <auro-menuoption value="Duration" disabled>Duration</auro-menuoption>
+                </auro-menu>
+              </auro-select>
+            `);
+
+            await elementUpdated(el);
+            el.showBib();
+            await elementUpdated(el);
+
+            const menu = el.querySelector('auro-menu');
+            const lastEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+            await elementUpdated(el);
+
+            await expect(el.optionActive === lastEnabledOption).to.equal(true);
+          });
+        });
       });
 
       describe('ArrowUp', () => {
@@ -2445,6 +2531,18 @@ function runTest(mobileView) {
         });
 
         describe('Meta', () => {
+          it('should open the bib when collapsed', async () => {
+            const el = await defaultFixture();
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', metaKey: true }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
           it('should jump to the first enabled option', async () => {
             const el = await defaultFixture();
 
@@ -2469,6 +2567,18 @@ function runTest(mobileView) {
         });
 
         describe('Alt', () => {
+          it('should open the bib when collapsed', async () => {
+            const el = await defaultFixture();
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
           it('should jump to the first enabled option', async () => {
             const el = await defaultFixture();
 
@@ -2486,6 +2596,42 @@ function runTest(mobileView) {
             const firstOption = menu.querySelector('auro-menuoption[value="Apples"]');
 
             el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true }));
+            await elementUpdated(el);
+
+            await expect(el.optionActive === firstOption).to.equal(true);
+          });
+        });
+
+        describe('Ctrl', () => {
+          it('should open the bib when collapsed', async () => {
+            const el = await defaultFixture();
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', ctrlKey: true }));
+            await elementUpdated(el);
+
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
+          it('should jump to the first enabled option', async () => {
+            const el = await defaultFixture();
+
+            await elementUpdated(el);
+            el.showBib();
+            await elementUpdated(el);
+
+            // Move away from first option
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+
+            const menu = el.querySelector('auro-menu');
+            const firstOption = menu.querySelector('auro-menuoption[value="Apples"]');
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', ctrlKey: true }));
             await elementUpdated(el);
 
             await expect(el.optionActive === firstOption).to.equal(true);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add Control+ArrowUp/ArrowDown navigation support to select and combobox components and document the updated keyboard behavior.

New Features:
- Enable Control+ArrowDown to move focus to the last enabled option in select and combobox dropdowns when open.
- Enable Control+ArrowUp to move focus to the first enabled option in select and combobox dropdowns when open.

Documentation:
- Document Control+ArrowUp/ArrowDown keyboard behavior for select and combobox components, including macOS-specific notes about OS-level shortcuts.

Tests:
- Add keyboard interaction tests for Control+ArrowUp/ArrowDown behavior in select and combobox components to ensure correct focus movement and skipping of disabled options.