### PR TITLE
(V6) Select Revert AB#1560488

### DIFF
--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -37,6 +37,7 @@ The `auro-menu` element provides users a way to select from a list of options.
 |-------------------------------|--------------------------------------------------|--------------------------------------------------|
 | `auroMenu-activatedOption`    | `CustomEvent<Element>`                           | Notifies that a menuoption has been made `active`. |
 | `auroMenu-customEventFired`   | `CustomEvent<any>`                               | Notifies that a custom event has been fired.     |
+| `auroMenu-deselectPrevented`  | `CustomEvent<{ values: HTMLElement[] }>`         | Notifies that deselection was prevented and includes the affected options in `detail.values`. |
 | `auroMenu-loadingChange`      | `CustomEvent<{ loading: boolean; hasLoadingPlaceholder: boolean; }>` | Notifies when the loading attribute is changed.  |
 | `auroMenu-optionsChange`      | `CustomEvent<{ options: Element[] \| undefined; }>` |                                                  |
 | `auroMenu-selectValueFailure` | `CustomEvent<any>`                               | Notifies that an attempt to select a menuoption by matching a value has failed. |

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -37,7 +37,6 @@ The `auro-menu` element provides users a way to select from a list of options.
 |-------------------------------|--------------------------------------------------|--------------------------------------------------|
 | `auroMenu-activatedOption`    | `CustomEvent<Element>`                           | Notifies that a menuoption has been made `active`. |
 | `auroMenu-customEventFired`   | `CustomEvent<any>`                               | Notifies that a custom event has been fired.     |
-| `auroMenu-deselectPrevented`  | `CustomEvent<{ values: HTMLElement[] }>`         | Notifies that deselection was prevented and includes the affected options in `detail.values`. |
 | `auroMenu-loadingChange`      | `CustomEvent<{ loading: boolean; hasLoadingPlaceholder: boolean; }>` | Notifies when the loading attribute is changed.  |
 | `auroMenu-optionsChange`      | `CustomEvent<{ options: Element[] \| undefined; }>` |                                                  |
 | `auroMenu-selectValueFailure` | `CustomEvent<any>`                               | Notifies that an attempt to select a menuoption by matching a value has failed. |

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -28,7 +28,6 @@ import { classMap } from "lit/directives/class-map.js";
  * @event {CustomEvent<any>} auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event {CustomEvent<{ loading: boolean; hasLoadingPlaceholder: boolean; }>} auroMenu-loadingChange - Notifies when the loading attribute is changed.
  * @event {CustomEvent<any>} auroMenu-selectValueFailure - Notifies that an attempt to select a menuoption by matching a value has failed.
- * @event {CustomEvent<{ values: HTMLElement[] }>} auroMenu-deselectPrevented - Notifies that deselection was prevented and includes the affected options in `detail.values`.
  * @event {CustomEvent<any>} auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @event {CustomEvent<any>} auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @slot loadingText - Text to show while loading attribute is set
@@ -784,7 +783,6 @@ export class AuroMenu extends AuroElement {
       // Re-selecting the already-selected option in single-select doesn't change
       // state, so updated() won't fire. Notify explicitly so consumers (e.g.
       // auro-select closing its dropdown on Enter) still get the event.
-      dispatchMenuEvent(this, 'auroMenu-deselectPrevented', { values: [option] });
       this.notifySelectionChange();
     }
   }

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -28,6 +28,7 @@ import { classMap } from "lit/directives/class-map.js";
  * @event {CustomEvent<any>} auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event {CustomEvent<{ loading: boolean; hasLoadingPlaceholder: boolean; }>} auroMenu-loadingChange - Notifies when the loading attribute is changed.
  * @event {CustomEvent<any>} auroMenu-selectValueFailure - Notifies that an attempt to select a menuoption by matching a value has failed.
+ * @event {CustomEvent<{ values: HTMLElement[] }>} auroMenu-deselectPrevented - Notifies that deselection was prevented and includes the affected options in `detail.values`.
  * @event {CustomEvent<any>} auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @event {CustomEvent<any>} auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @slot loadingText - Text to show while loading attribute is set
@@ -783,6 +784,7 @@ export class AuroMenu extends AuroElement {
       // Re-selecting the already-selected option in single-select doesn't change
       // state, so updated() won't fire. Notify explicitly so consumers (e.g.
       // auro-select closing its dropdown on Enter) still get the event.
+      dispatchMenuEvent(this, 'auroMenu-deselectPrevented', { values: [option] });
       this.notifySelectionChange();
     }
   }

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -417,11 +417,14 @@ export class AuroMenu extends AuroElement {
 
         // If no matching options were found in either mode
         if (!newSelected || (Array.isArray(newSelected) && newSelected.length === 0)) {
-          dispatchMenuEvent(this, 'auroMenu-selectValueFailure');
+          // Clear state BEFORE dispatching so synchronous listeners (e.g. auro-select's
+          // updateDisplayedValue) read fresh `optionSelected` rather than the stale prior
+          // selection and re-render the old label.
           if (this.optionSelected !== undefined) {
             this.optionSelected = undefined;
           }
           this._index = -1;
+          dispatchMenuEvent(this, 'auroMenu-selectValueFailure');
         } else if (!this.selectionEquals(this.optionSelected, newSelected)) {
           this.optionSelected = newSelected;
         }

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -1382,6 +1382,30 @@ function runFullTest(mobileView) {
         const event = await listener;
         expect(event).to.exist;
       });
+
+      it('should have already cleared optionSelected when the event fires', async () => {
+        // Synchronous listeners (e.g. auro-select's updateDisplayedValue) read
+        // menu.optionSelected to decide what to render. If the dispatch happens
+        // before the clear, listeners see the stale prior selection and re-render
+        // the old label.
+        const el = await defaultFixture();
+        const menuEl = el.querySelector('auro-menu');
+
+        // Establish a prior selection so the stale value is observable.
+        menuEl.value = 'option 1';
+        await elementUpdated(menuEl);
+        expect(menuEl.optionSelected, 'precondition: prior selection set').to.exist;
+
+        let optionSelectedAtDispatch = 'unread';
+        menuEl.addEventListener('auroMenu-selectValueFailure', () => {
+          optionSelectedAtDispatch = menuEl.optionSelected;
+        }, { once: true });
+
+        menuEl.value = 'non-existent-value';
+        await elementUpdated(menuEl);
+
+        expect(optionSelectedAtDispatch).to.be.undefined;
+      });
     });
 
     describe('auroMenu-selectValueReset', () => {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -844,9 +844,11 @@ export class AuroSelect extends AuroElement {
 
       this.value = this.menu.value;
 
+      // Clone the multiselect array so external mutation of select.optionSelected
+      // can't reach back into menu's internal state through a shared reference.
       let nextSelected = this.menu.optionSelected;
-      if (this.multiSelect && !Array.isArray(nextSelected)) {
-        nextSelected = [];
+      if (this.multiSelect) {
+        nextSelected = Array.isArray(nextSelected) ? [...nextSelected] : [];
       }
       this.optionSelected = nextSelected;
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -575,7 +575,7 @@ export class AuroSelect extends AuroElement {
             this.menu.updateActiveOption(this.optionSelected[0]);
           } else {
             // If no activeOption has yet to be set, then make the first enabled option active by default
-            const firstActive = this.menu.menuService.menuOptions.find((option) => !option.disabled);
+            const firstActive = this.menu.options.find((option) => !option.disabled);
             this.menu.updateActiveOption(firstActive);
           }
         }
@@ -799,12 +799,23 @@ export class AuroSelect extends AuroElement {
       this.menu.multiSelect = this.multiSelect;
     }
 
+    // Menu's items are populated by initItems() during its firstUpdated/slotchange.
+    // Since the parent select's firstUpdated runs before the child menu's, call initItems()
+    // here so renderNativeSelect can render the native <option> list on first paint.
+    if (typeof this.menu.initItems === 'function') {
+      this.menu.initItems();
+    }
     this.options = this.menu.options;
     this.updateOptionPositions();
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));
 
     this.menu.addEventListener("auroMenu-deselectPrevented", () => {
       this.hideBib();
+    });
+
+    this.menu.addEventListener("auroMenu-selectValueFailure", () => {
+      this.value = undefined;
+      this.optionSelected = this.multiSelect ? [] : undefined;
     });
 
     this.menu.addEventListener('auroMenu-activatedOption', (evt) => {
@@ -826,16 +837,18 @@ export class AuroSelect extends AuroElement {
       }
     });
 
-    this.menu.addEventListener('auroMenu-selectedOption', (event) => {
+    this.menu.addEventListener('auroMenu-selectedOption', () => {
 
       // Update the displayed value
       this.updateDisplayedValue();
 
-      const options = event.detail.options || [];
+      this.value = this.menu.value;
 
-      this.value = event.detail.stringValue;
-
-      this.optionSelected = this.multiSelect ? options : options[0];
+      let nextSelected = this.menu.optionSelected;
+      if (this.multiSelect && !Array.isArray(nextSelected)) {
+        nextSelected = [];
+      }
+      this.optionSelected = nextSelected;
 
       if (this.dropdown.isPopoverVisible && !this.multiSelect) {
         this.dropdown.hide();
@@ -844,7 +857,7 @@ export class AuroSelect extends AuroElement {
 
       // Announce the selection after the dropdown closes so it isn't
       // overridden by VoiceOver's "collapsed" announcement from aria-expanded.
-      const selectedValue = event.detail.stringValue;
+      const selectedValue = this.menu.currentLabel;
       const announcementDelay = 300;
       setTimeout(() => {
         announceToScreenReader(this._getAnnouncementRoot(), `${selectedValue}, selected`);

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -809,13 +809,13 @@ export class AuroSelect extends AuroElement {
     this.updateOptionPositions();
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));
 
-    this.menu.addEventListener("auroMenu-deselectPrevented", () => {
-      this.hideBib();
-    });
-
     this.menu.addEventListener("auroMenu-selectValueFailure", () => {
       this.value = undefined;
       this.optionSelected = this.multiSelect ? [] : undefined;
+      // The trigger label is rendered imperatively into #value, so a property
+      // change alone won't clear it. Refresh so stale text doesn't linger when
+      // a runtime value change fails to match any option.
+      this.updateDisplayedValue();
     });
 
     this.menu.addEventListener('auroMenu-activatedOption', (evt) => {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -20,6 +20,7 @@ import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/util
 
 import { announceToScreenReader, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
 import { selectKeyboardStrategy } from './selectKeyboardStrategy.js';
+import { getEnabledOptions } from './selectUtils.js';
 
 import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
 
@@ -575,7 +576,7 @@ export class AuroSelect extends AuroElement {
             this.menu.updateActiveOption(this.optionSelected[0]);
           } else {
             // If no activeOption has yet to be set, then make the first enabled option active by default
-            const firstActive = this.menu.options.find((option) => !option.disabled);
+            const [firstActive] = getEnabledOptions(this.menu);
             this.menu.updateActiveOption(firstActive);
           }
         }

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -1,5 +1,6 @@
 /* eslint-disable new-cap */
 import { navigateArrow } from '@aurodesignsystem/utils';
+import { getEnabledOptions } from './selectUtils.js';
 
 export const selectKeyboardStrategy = {
   ArrowDown(component, evt, ctx) {
@@ -47,7 +48,8 @@ export const selectKeyboardStrategy = {
     }
     evt.preventDefault();
     evt.stopPropagation();
-    const lastOption = [...component.menu.options].reverse().find((option) => !option.disabled);
+    // `pop()` is safe here: getEnabledOptions returns a fresh filtered array.
+    const lastOption = getEnabledOptions(component.menu).pop();
     if (lastOption) {
       component.menu.updateActiveOption(lastOption);
     }
@@ -69,7 +71,7 @@ export const selectKeyboardStrategy = {
     }
     evt.preventDefault();
     evt.stopPropagation();
-    const firstOption = component.menu.options.find((option) => !option.disabled);
+    const [firstOption] = getEnabledOptions(component.menu);
     if (firstOption) {
       component.menu.updateActiveOption(firstOption);
     }

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -47,7 +47,7 @@ export const selectKeyboardStrategy = {
     }
     evt.preventDefault();
     evt.stopPropagation();
-    const lastOption = [...component.menu.menuService.menuOptions].reverse().find((option) => !option.disabled);
+    const lastOption = [...component.menu.options].reverse().find((option) => !option.disabled);
     if (lastOption) {
       component.menu.updateActiveOption(lastOption);
     }
@@ -69,7 +69,7 @@ export const selectKeyboardStrategy = {
     }
     evt.preventDefault();
     evt.stopPropagation();
-    const firstOption = component.menu.menuService.menuOptions.find((option) => !option.disabled);
+    const firstOption = component.menu.options.find((option) => !option.disabled);
     if (firstOption) {
       component.menu.updateActiveOption(firstOption);
     }

--- a/components/select/src/selectUtils.js
+++ b/components/select/src/selectUtils.js
@@ -1,0 +1,14 @@
+/**
+ * Returns the enabled (non-disabled) options for a menu, safely.
+ *
+ * Auro-menu's `options` getter returns `undefined` when the menu has no items
+ * (initItems sets `items` to undefined for empty menus). Callers that reach for
+ * `.find()` / `[...spread]` would otherwise crash; this helper normalizes the
+ * empty case to `[]` so array methods are always safe.
+ *
+ * @param {HTMLElement} menu - The auro-menu element.
+ * @returns {Array<HTMLElement>} Non-disabled options, empty array when none.
+ */
+export function getEnabledOptions(menu) {
+  return (menu?.options || []).filter((option) => !option.disabled);
+}

--- a/components/select/src/selectUtils.js
+++ b/components/select/src/selectUtils.js
@@ -6,7 +6,7 @@
  * `.find()` / `[...spread]` would otherwise crash; this helper normalizes the
  * empty case to `[]` so array methods are always safe.
  *
- * @param {HTMLElement} menu - The auro-menu element.
+ * @param {HTMLElement | null | undefined} menu - The auro-menu element.
  * @returns {Array<HTMLElement>} Non-disabled options, empty array when none.
  */
 export function getEnabledOptions(menu) {

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -392,7 +392,7 @@ export const SelectFullscreenEnterOnCloseSelectsActiveOption: Story = {
     // synthetic events can't drive the full navigation chain. Set
     // the state directly to exercise the keyboard bridge logic.
     const firstOption = el.querySelector('auro-menuoption[value="stops"]');
-    el.menu.menuService.setHighlightedOption(firstOption);
+    el.menu.updateActiveOption(firstOption);
     bib.hasActiveDescendant = true;
 
     // Get the dialog element where the keyboard bridge listens

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -968,6 +968,26 @@ function runTest(mobileView) {
           await expect(el.optionSelected).to.equal(selectedOption);
         });
 
+        it('should clear the trigger label when value changes to a non-matching string', async () => {
+          // Regression: a runtime value change with no matching option must not
+          // leave the previous selection's label rendered in the trigger.
+          const el = await defaultFixture();
+          const menu = el.querySelector('auro-menu');
+
+          el.value = 'Apples';
+          await elementUpdated(el);
+          await elementUpdated(menu);
+
+          const triggerValueEl = el.shadowRoot.querySelector('#value');
+          expect(triggerValueEl.textContent.trim(), 'precondition: trigger shows prior selection').to.equal('Apples');
+
+          el.value = 'non-existent-value';
+          await elementUpdated(el);
+          await elementUpdated(menu);
+
+          expect(triggerValueEl.textContent.trim()).to.equal('');
+        });
+
         it('should apply value from host attribute on initial render', async () => {
           const el = await fixture(html`
             <auro-select value="bar">

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2935,19 +2935,12 @@ function runTest(mobileView) {
           await expect(selectedOption.selected).to.be.true;
 
           const valueBefore = el.value;
-          let deselectPreventedEvent = null;
-
-          menu.addEventListener('auroMenu-deselectPrevented', (event) => {
-            deselectPreventedEvent = event;
-          }, { once: true });
 
           el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
           await elementUpdated(menu);
+          await new Promise((resolve) => setTimeout(resolve, 0));
           await elementUpdated(el);
-          await waitUntil(() => !!deselectPreventedEvent);
 
-          await expect(deselectPreventedEvent).to.exist;
-          await expect(deselectPreventedEvent.detail.values[0]).to.equal(selectedOption);
           await expect(selectedOption.selected).to.be.true;
           await expect(el.value).to.equal(valueBefore);
           await expect(dropdown.isPopoverVisible).to.be.false;

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -510,6 +510,30 @@ function runTest(mobileView) {
           await expect(el.optionSelected.length).to.equal(0);
         });
 
+        it('should not leak external mutation of select.optionSelected back into menu state', async () => {
+          // Regression: select.optionSelected must be a cloned array in multiselect
+          // mode so consumers mutating it cannot reach back into menu.optionSelected
+          // through a shared reference.
+          const el = await multiSelectFixture();
+          const menu = el.querySelector('auro-menu');
+
+          el.value = '["Apples", "Bananas"]';
+          await elementUpdated(el);
+          await elementUpdated(menu);
+
+          expect(Array.isArray(el.optionSelected)).to.be.true;
+          expect(el.optionSelected.length).to.equal(2);
+          expect(menu.optionSelected.length).to.equal(2);
+          expect(el.optionSelected).to.not.equal(menu.optionSelected);
+
+          // Mutate the consumer-visible array.
+          el.optionSelected.push('intruder');
+          el.optionSelected.pop();
+          el.optionSelected.splice(0, 1);
+
+          expect(menu.optionSelected.length, 'menu state must be insulated from external mutation').to.equal(2);
+        });
+
       });
 
       describe('name', () => {

--- a/components/select/test/selectUtils.test.js
+++ b/components/select/test/selectUtils.test.js
@@ -1,0 +1,37 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { fixture, html, expect } from '@open-wc/testing';
+import '../../menu/src/registered.js';
+import { getEnabledOptions } from '../src/selectUtils.js';
+
+describe('selectUtils', () => {
+  describe('getEnabledOptions', () => {
+    it('returns only non-disabled options when the menu has items', async () => {
+      const menu = await fixture(html`
+        <auro-menu>
+          <auro-menuoption value="a">Apples</auro-menuoption>
+          <auro-menuoption value="b" disabled>Bananas</auro-menuoption>
+          <auro-menuoption value="c">Cherries</auro-menuoption>
+        </auro-menu>
+      `);
+
+      const enabled = getEnabledOptions(menu);
+
+      expect(enabled).to.have.lengthOf(2);
+      expect(enabled.map((opt) => opt.value)).to.deep.equal(['a', 'c']);
+    });
+
+    it('returns an empty array when the menu has no items (options getter is undefined)', async () => {
+      const menu = await fixture(html`<auro-menu></auro-menu>`);
+
+      // Sanity-check the precondition: this is the case the util exists to handle.
+      expect(menu.options).to.be.undefined;
+
+      expect(getEnabledOptions(menu)).to.deep.equal([]);
+    });
+
+    it('returns an empty array when the menu is null or undefined', () => {
+      expect(getEnabledOptions(undefined)).to.deep.equal([]);
+      expect(getEnabledOptions(null)).to.deep.equal([]);
+    });
+  });
+});

--- a/components/select/web-test-runner.config.mjs
+++ b/components/select/web-test-runner.config.mjs
@@ -2,6 +2,10 @@ import config from "@aurodesignsystem/config/wtr";
 
 export default {
   ...config,
+  // Run test files serially in the same browser to avoid cross-file state
+  // collisions (focus handoff, shared component registration). Mirrors the
+  // menu package's local wtr config.
+  concurrency: 1,
   coverageConfig: {
     include: ['src/**/*.js'],
     exclude: [

--- a/docs/post-mortem/1560488.md
+++ b/docs/post-mortem/1560488.md
@@ -1,0 +1,53 @@
+# Post-Mortem: auro-select v6 Revert (AB#1560488 / PR #1486)
+
+**Branch:** `cfriedberg/formkit-v6/select-menu-revert` → `rmenner/formkit-v6/revert-menu`
+**Scope:** Sub-PR 4 of the FormKit v6 reversion — restore `auro-select` to the pre-5.9 distributed state model.
+
+## Reference Documents
+- Execution Plan — [#1463](https://github.com/AlaskaAirlines/auro-formkit/discussions/1463)
+- Implementation Scope — [#1454](https://github.com/AlaskaAirlines/auro-formkit/discussions/1454)
+- Testing Strategy — [#1476](https://github.com/AlaskaAirlines/auro-formkit/discussions/1476)
+
+## What Landed vs. What Was Planned
+
+| Planned (per #1463 / #1454) | Status |
+|---|---|
+| Replace `menu.menuService.menuOptions` reads with distributed state | Done — `auro-select.js`, `selectKeyboardStrategy.js` |
+| Rewrite `auroMenu-selectedOption` handler to read from `menu` directly | Done — uses `menu.value`, `menu.optionSelected`, `menu.currentLabel` |
+| Drop `allowDeselect` plumbing and the `auroMenu-deselectPrevented` event | Done — replaced with `auroMenu-selectValueFailure` wiring |
+| Fix the story that reached into `menuService` | Done — `component.stories.ts` uses `menu.updateActiveOption()` |
+| All `auro-select.test.js` rows green; cross-framework remount green | Done — 372/372 select wtr, React/Svelte remount 8/8 |
+| 100% coverage target (per #1476 clarification) | Near target — 99.94% select, 97.19% menu |
+
+## What Was Not in the Plan but Also Shipped
+
+Five behavioral bugs surfaced once the MenuService crutch was removed. None were called out in #1454 or #1463; all required source changes beyond a pure revert.
+
+1. **Native `<select>` mirror rendered empty on first paint.** Menu's `initItems()` runs in its own `firstUpdated`, which fires *after* the parent select's. Fix: eagerly call `menu.initItems()` during `configureMenu`. (`auro-select.js:803`)
+2. **`menu.options` is `undefined` for empty menus**, crashing `.find()` and spread reads in keyboard handlers. Fix: new `selectUtils.getEnabledOptions()` helper that normalizes to `[]`. Not anticipated by the plan.
+3. **`auroMenu-selectValueFailure` was dispatched *before* `optionSelected` was cleared**, so synchronous listeners (the select's `updateDisplayedValue`) re-rendered the stale label. Fix: reorder clear-then-dispatch in `auro-menu.js`, locked in by an explicit invariant test.
+4. **Trigger label lingered on a non-matching runtime `value` change.** The label is rendered imperatively into `#value`, so a property change alone didn't clear it. Fix: call `updateDisplayedValue()` from the failure handler.
+5. **Multiselect `optionSelected` shared a reference with menu state**, letting consumer mutations leak back into the menu. Fix: clone the array on assignment, with a regression test.
+
+## What the Plan Got Right
+- Sequencing (menu → menuoption → select) held: the menu changes from #1482 were stable enough to revert against.
+- The call-out in #1463 that `selectKeyboardStrategy.js` had been refactored post-plan (commit `6369afba`) was accurate — the handler shape matched and the swap was mechanical.
+- Restoring direct event subscription proved straightforward; the MenuService removal itself was a small diff (~35 lines in `auro-select.js`).
+
+## What the Plan Missed
+- **Sibling-component lifecycle ordering.** #1454 listed "manual property propagation" as a behavior to restore but didn't anticipate that parent-before-child `firstUpdated` would leave the native mirror unpopulated. This was a foreseeable consequence of dropping the context bridge.
+- **Empty-state guards.** The plan treated `menu.options` as a safe substitute for `menuService.menuOptions`, but they have different undefined semantics. A short audit of every menu getter the select reaches for would have caught this before the keyboard tests started crashing.
+- **State-mutation contract.** The pre-5.9 baseline appears to have leaked menu state to consumers via shared references. The plan said "restore pre-5.9 behavior" without flagging whether bugs in that baseline should be carried forward. We chose to fix; worth documenting as a deliberate deviation.
+- **Test ordering / concurrency.** Needed `concurrency: 1` in `web-test-runner.config.mjs` to stop cross-file collisions. Not predicted by #1476.
+
+## Testing Strategy Adherence
+#1476 prescribed a tests-first cadence (PR 1 lands failing tests; subsequent PRs turn them green). This branch did the opposite for the five bugs above — fix-first, then add a locking regression test in the same commit or the next. Pragmatic given that the bugs weren't known until the revert was attempted, but it means the "failing tests turn green" progress signal didn't apply to this slice.
+
+## Recommendations for the Remaining Sub-PRs
+1. Before starting Sub-PR 5 (combobox), grep for every `menuService` reach and every assumption about menu's getters returning arrays. Empty-state and undefined returns are the likely landmines.
+2. Verify lifecycle ordering: if combobox renders anything derived from menu state in its `firstUpdated`, expect the same first-paint gap and plan for it.
+3. If the menu/menuoption baseline has other shared-reference leaks, decide *now* whether v6 carries them or fixes them — don't defer to discovery during the revert.
+4. Keep `concurrency: 1` in mind for combobox wtr config if cross-file collisions appear.
+
+## Outcome
+Shipped: 10 commits, 9 files, +158/−21. Tests green, coverage near the 100% target. Five latent bugs in the pre-5.9 architecture got fixed in passing rather than carried forward.


### PR DESCRIPTION
**BREAKING CHANGE:** Removes `auro-select's` coupling to the 5.9 MenuService API.

Consumers reaching into `select.menu.menuService` or relying on the `auroMenu-deselectPrevented` event will need to update.

### Overview

This pull request reverts auro-select to align with the pre-5.9 distributed menu architecture restored in #1482.

The select once again reads menu state via the public surface (`menu.options`, `menu.value`, `menu.optionSelected`, `menu.currentLabel`) instead of the MenuService, and drops the 5.9-only `auroMenu-deselectPrevented` event from the menu's public API.

### Related TRDs

- [#1463 — Formkit v6 Revert: Execution Plan](https://github.com/AlaskaAirlines/auro-formkit/discussions/1463) (Sub-PR 4 — select revert)
- [#1454 — Formkit v6 Revert: Implementation Scope](https://github.com/AlaskaAirlines/auro-formkit/discussions/1454) (§4 — test rewrite directive for `auroMenu-deselectPrevented`)
- [#1476 — Formkit v6 Revert: Testing Strategy](https://github.com/AlaskaAirlines/auro-formkit/discussions/1476) (Decision 1 — JSON-stringified array contract for multiSelect)

### TRD Acceptance Criteria Satisfied

**From #1463 Sub-PR 4 (Execution Plan):**
- ✅ auro-select restored to local state — no MenuService imports remain in `auro-select.js` or `selectKeyboardStrategy.js`
- ✅ Story file (`component.stories.ts`) updated to use the pre-5.9 menu public API (`updateActiveOption()`)
- ✅ All `auro-select.test.js` rows green (372/372)

**From #1454 §4 (Implementation Scope):**
- ✅ `auroMenu-deselectPrevented` event removed from menu (5.9-specific surface tied to `allowDeselect`)
- ✅ `auro-select.test.js:2632–2663` (Enter re-selection test) rewritten with behavioral assertions only — value unchanged, option still selected, bib closed — mirroring the click-based pattern at line 2157
- ✅ multiSelect JSON-contract tests at lines 419, 425, 436, 453, 500, 2195 preserved (per @jason-capsule42  review)

**From #1476 Decision 1 (Testing Strategy):**
- ✅ JSON-stringified array contract for `multiSelect` `value` preserved — verified by cross-framework `select-remount.spec.ts` passing in React (8/8) and Svelte (8/8), with assertions at `apps/shared/select-remount.suite.ts:49-50, 72-73`

### Source Changes

- Replace `menu.menuService.menuOptions` reads with `menu.options` in auro-select.js and selectKeyboardStrategy.js (End/Home key handlers)
- Rewrite the `auroMenu-selectedOption` handler in auro-select to pull `value`, `optionSelected`, and the announcement label directly from menu state
- Add an `auroMenu-selectValueFailure` listener so select clears its own `value` / `optionSelected` when the menu can't match a preset value
- Eagerly call `menu.initItems()` during select's `configureMenu` so the native `<select>` shadow mirror has options on first paint (parent's `firstUpdated` runs before child menu's)
- Drop the 5.9-only `auroMenu-deselectPrevented` event from auro-menu (JSDoc + dispatch). The existing `notifySelectionChange()` call in the single-select re-selection branch still fires `auroMenu-selectedOption`, which is what closes the bib on Enter.
- Update the emphasized story to use `menu.updateActiveOption()` instead of `menu.menuService.setHighlightedOption()`

### Test Changes

- Rewrite the "Enter on already-selected menuoption" test (auro-select.test.js:2683) to use behavioral assertions only — value unchanged, option still selected, bib closed — mirroring the click-based equivalent at line 2157 (per implementation scope §4)

### Bug Fixes Found During Revert

- Fix native `<select>` shadow mirror rendering empty on first paint when menu items hadn't yet been initialized
- Fix `optionSelected` not being normalized to `[]` in multiselect mode when menu state is null/undefined
- Fix bib not closing on Enter when re-selecting an already-selected single-select option (lost when `updated()` no longer fires for no-op state changes)

### Review & Testing Checklists

- Update follows CONTRIBUTING guidelines
- Self-review completed
- All select wtr tests green (372/372, 99.94% coverage)
- All menu wtr tests green (348/348, 97.19% coverage)
- Cross-framework `select-remount.spec.ts` green in React (8/8) and Svelte (8/8), confirming the JSON-stringified array contract for multiSelect is preserved (Decision 1)
- Browser testing across Android (Chrome, Firefox), iOS (Chrome, Firefox, Safari), and Desktop (Chrome, Firefox, Safari, Edge)
- Validated linked issues with reporting team
- Test coverage reviewed

## Summary by Sourcery

Revert auro-select to use auro-menu’s public distributed menu state instead of the 5.9 MenuService API, while preserving multi-select value behavior and fixing regressions uncovered during the revert.

Bug Fixes:
- Ensure the native <select> shadow mirror renders its options on first paint by initializing menu items during select configuration.
- Normalize multiselect optionSelected to an empty array when menu state is null or undefined to avoid inconsistent selection state.
- Restore closing of the bib on Enter when re-selecting an already-selected single-select option.

Enhancements:
- Update auro-select to read selection and label state directly from the menu (options, value, optionSelected, currentLabel) and to clear its own selection when the menu cannot match a preset value.
- Adjust keyboard navigation for Home/End and storybook examples to use the menu’s public options and updateActiveOption API instead of MenuService internals.
- Simplify the auroMenu-selectedOption handling to rely on menu state and a label-based screen reader announcement rather than event payload fields.

Tests:
- Rewrite the Enter-on-already-selected-option test to verify behavior via selection state, value, and bib visibility rather than relying on the removed auroMenu-deselectPrevented event.