### PR TITLE
(V6) Combobox Revert AB#1560490

### DIFF
--- a/apps/react-framework/src/pages/ComboboxCitySearch.tsx
+++ b/apps/react-framework/src/pages/ComboboxCitySearch.tsx
@@ -120,7 +120,7 @@ function ComboboxWrapper({ onSelectedValueChange }: ComboboxWrapperProps) {
     <>
       <auro-combobox ref={comboboxRef} noFilter persistInput required autocomplete="off" dvInputOnly>
         <span slot="label">From</span>
-        <auro-menu ref={menuRef} hasLoadingPlaceholder>
+        <auro-menu ref={menuRef}>
           {stations.map((city) => (
             <Fragment key={city.code}>
               <auro-menuoption value={city.code}>

--- a/apps/react-framework/src/pages/ComboboxCitySearchFull.tsx
+++ b/apps/react-framework/src/pages/ComboboxCitySearchFull.tsx
@@ -171,7 +171,7 @@ export function ComboboxFullWrapper({ initialValue = '', initialTypedValue = '' 
         setCustomValidityValueMissing={MISSING_FIELD_ERROR}
       >
         <span slot="label">From</span>
-        <auro-menu ref={menuRef} hasLoadingPlaceholder>
+        <auro-menu ref={menuRef}>
           {stations.map((city) => (
             <Fragment key={city.code}>
               <auro-menuoption value={city.code}>

--- a/apps/shared/menu-interaction.suite.ts
+++ b/apps/shared/menu-interaction.suite.ts
@@ -107,10 +107,8 @@ export function menuInteractionSuite(framework: string) {
       test('fires selectedOption event on click', async ({ page }) => {
         await menu(page, 'default').evaluate((el: any) => {
           (el as any).__selectedFired = false;
-          (el as any).__selectedDetail = null;
-          el.addEventListener('auroMenu-selectedOption', (e: any) => {
+          el.addEventListener('auroMenu-selectedOption', () => {
             (el as any).__selectedFired = true;
-            (el as any).__selectedDetail = e.detail;
           }, { once: true });
         });
 
@@ -120,8 +118,8 @@ export function menuInteractionSuite(framework: string) {
           menu(page, 'default').evaluate((el: any) => (el as any).__selectedFired),
         ).toBe(true);
 
-        const detail = await menu(page, 'default').evaluate((el: any) => (el as any).__selectedDetail);
-        expect(detail.value).toBe('Grapes');
+        const value = await menu(page, 'default').evaluate((el: any) => el.value);
+        expect(value).toBe('Grapes');
       });
     });
 

--- a/components/combobox/apiExamples/css-parts.html
+++ b/components/combobox/apiExamples/css-parts.html
@@ -15,7 +15,9 @@
 <auro-combobox class="css-parts-demo">
   <span slot="label">CSS Parts Example</span>
   <span slot="helpText">This combobox has custom styles applied via CSS Shadow Parts.</span>
-  <auro-menuoption value="one">Option One</auro-menuoption>
-  <auro-menuoption value="two">Option Two</auro-menuoption>
-  <auro-menuoption value="three">Option Three</auro-menuoption>
+  <auro-menu>
+    <auro-menuoption value="one">Option One</auro-menuoption>
+    <auro-menuoption value="two">Option Two</auro-menuoption>
+    <auro-menuoption value="three">Option Three</auro-menuoption>
+  </auro-menu>
 </auro-combobox>

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -3,7 +3,7 @@
 
 // ---------------------------------------------------------------------
 
-/* eslint-disable complexity, max-lines, lit/binding-positions, lit/no-invalid-html, no-underscore-dangle, no-extra-parens */
+/* eslint-disable complexity, max-lines, max-depth, lit/binding-positions, lit/no-invalid-html, no-underscore-dangle, no-extra-parens */
 
 // If using litElement base class
 import { css } from "lit";
@@ -42,6 +42,25 @@ import { ifDefined } from "lit/directives/if-defined.js";
 function normalizeFilterValue(value) {
   const raw = value || '';
   return raw.trim() ? raw.trimEnd() : raw;
+}
+
+/**
+ * Returns the option's plain-text label suitable for input.value, with
+ * HTML-indentation whitespace collapsed and the displayValue slot text
+ * removed (the slot renders separately in the trigger).
+ * @param {HTMLElement} option - An auro-menuoption element.
+ * @returns {string} Normalized label.
+ */
+function getOptionLabel(option) {
+  if (!option) {
+    return '';
+  }
+  const clone = option.cloneNode(true);
+  const displayValueEl = clone.querySelector('[slot="displayValue"]');
+  if (displayValueEl) {
+    displayValueEl.remove();
+  }
+  return (clone.textContent || '').replace(/\s+/gu, ' ').trim();
 }
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
@@ -171,7 +190,19 @@ export class AuroCombobox extends AuroElement {
       availableOptions: {
         state: true,
         type: Array,
-        reflect: false
+        reflect: false,
+        hasChanged(newVal, oldVal) {
+          if (!oldVal && !newVal) {
+            return false;
+          }
+          if (!oldVal || !newVal) {
+            return true;
+          }
+          if (newVal.length !== oldVal.length) {
+            return true;
+          }
+          return newVal.some((opt, idx) => opt !== oldVal[idx]);
+        }
       },
 
       /**
@@ -579,7 +610,16 @@ export class AuroCombobox extends AuroElement {
   updateFilter() {
     // Reset available options if noFilter is set to false after being true.
     if (this.noFilter) {
-      this.availableOptions = [...this.options];
+      // nomatch options have no purpose when filtering is delegated to the
+      // consumer — exclude them so "No matching option" rows don't surface
+      // alongside the real results.
+      this.availableOptions = this.options.filter((option) => {
+        if (option.hasAttribute('nomatch')) {
+          option.setAttribute('hidden', '');
+          return false;
+        }
+        return true;
+      });
       return;
     }
 
@@ -602,18 +642,15 @@ export class AuroCombobox extends AuroElement {
         matchString = `${matchString} ${option.getAttribute('suggest')}`.toLowerCase();
       }
 
-      // If input is empty, show all options (except static ones)
-      if (!filterValue) {
-        if (!option.hasAttribute('static')) {
-          option.removeAttribute('hidden');
-          this.availableOptions.push(option);
-        }
-      } else if (matchString.includes(filterValue) && !option.hasAttribute('static')) {
-        // only count options that match the typed input value AND are not static
+      if (!filterValue && option.hasAttribute('static')) {
+        // Static options are shown when the input is empty so consumers can
+        // surface headers / "add new" rows when no filter is active.
+        option.removeAttribute('hidden');
+        this.availableOptions.push(option);
+      } else if (filterValue && matchString.includes(filterValue) && !option.hasAttribute('static')) {
         option.removeAttribute('hidden');
         this.availableOptions.push(option);
       } else if (!option.hasAttribute('persistent')) {
-        // Hide all other non-persistent options
         option.setAttribute('hidden', '');
         option.removeAttribute('aria-setsize');
         option.removeAttribute('aria-posinset');
@@ -621,7 +658,9 @@ export class AuroCombobox extends AuroElement {
     });
 
     if (this.availableOptions.length === 0) {
-      if (this.noMatchOption) {
+      // Only surface the nomatch option once the user has actually typed
+      // something. Empty input is handled by the bib being closed.
+      if (this.noMatchOption && filterValue) {
         this.noMatchOption.removeAttribute('hidden');
       } else if (!this.menu.loading || this.isHiddenWhileLoading) {
         this.hideBib();
@@ -637,11 +676,14 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   syncValuesAndStates() {
-    // Only sync matchWord, don't set menu.value here since setMenuValue should handle that
+    // Do NOT call setMenuValue here — the caller (handleMenuOptions) already
+    // guards setMenuValue with an option-match check. Calling it unconditionally
+    // sets free-form values on the menu, triggering clearSelection which resets
+    // _index and breaks subsequent makeSelection calls.
     if (this.menu) {
       this.menu.matchWord = normalizeFilterValue(this.input.value);
     }
-    const label = this.menu.currentLabel;
+    const label = getOptionLabel(this.menu.optionSelected) || this.menu.currentLabel;
     this.updateTriggerTextDisplay(label || this.value);
   }
 
@@ -656,7 +698,39 @@ export class AuroCombobox extends AuroElement {
     const isInputFocusedWithNoSelection = !this.menu.value && (this.input.matches(':focus-within') || (this.inputInBib && this.inputInBib.matches(':focus-within')));
 
     if (!this.persistInput && !(this.behavior === 'suggestion' && isInputFocusedWithNoSelection)) {
-      this.input.value = label || this.value;
+      const nextValue = label || this.value;
+      // Only set the flag when there's an actual write to suppress —
+      // syncValuesAndStates re-enters here during typing when both inputs
+      // already match, and a no-op flag flip would make the bib branch's
+      // bail eat legitimate user-input events.
+      const triggerNeedsSync = this.input.value !== nextValue;
+      const bibNeedsSync = Boolean(this.inputInBib && this.inputInBib !== this.input && this.inputInBib.value !== nextValue);
+      if (triggerNeedsSync || bibNeedsSync) {
+        this._syncingDisplayValue = true;
+        if (triggerNeedsSync) {
+          this.input.value = nextValue;
+        }
+        if (bibNeedsSync) {
+          this.inputInBib.value = nextValue;
+        }
+        const pending = [];
+        if (triggerNeedsSync) {
+          pending.push(this.input.updateComplete);
+        }
+        if (bibNeedsSync) {
+          pending.push(this.inputInBib.updateComplete);
+        }
+        Promise.all(pending).then(() => {
+          // imask reasserts otherwise, and handleBlur reverts to its stale value.
+          if (triggerNeedsSync && this.input.maskInstance && typeof this.input.maskInstance.updateValue === 'function') {
+            this.input.maskInstance.updateValue();
+          }
+          if (bibNeedsSync && this.inputInBib && this.inputInBib.maskInstance && typeof this.inputInBib.maskInstance.updateValue === 'function') {
+            this.inputInBib.maskInstance.updateValue();
+          }
+          this._syncingDisplayValue = false;
+        });
+      }
     }
 
     // update the displayValue in the trigger if displayValue slot content is present
@@ -670,6 +744,14 @@ export class AuroCombobox extends AuroElement {
       const displayValueEl = this.menu.optionSelected.querySelector("[slot='displayValue']");
       if (displayValueEl) {
         this.input.appendChild(displayValueEl.cloneNode(true));
+        // auro-input's hasDisplayValueContent is non-reactive; nudge it to
+        // re-evaluate the slot and re-render so the displayValue wrapper
+        // gets its hasContent class. Without this, the apple/icon stays
+        // hidden when input.value is set in the same tick as the append.
+        if (typeof this.input.checkDisplayValueSlotChange === 'function') {
+          this.input.checkDisplayValueSlotChange();
+          this.input.requestUpdate();
+        }
       }
     }
 
@@ -703,7 +785,10 @@ export class AuroCombobox extends AuroElement {
       this.syncValuesAndStates();
     }
 
-    if (!this.availableOptions.includes(this.menu.optionActive)) {
+    // Re-activate when optionActive is no longer visible, or when _index has
+    // been reset (e.g. by clearSelection in an async update) so that
+    // makeSelection() can find the correct option.
+    if (!this.availableOptions.includes(this.menu.optionActive) || this.menu._index < 0) {
       this.activateFirstEnabledAvailableOption();
     }
   }
@@ -828,8 +913,13 @@ export class AuroCombobox extends AuroElement {
 
           guardTouchPassthrough(this.menu);
 
-          // Wait for the bibtemplate to fully render across
-          // multiple Lit update cycles before moving focus into the bib
+          // The dialog's showModal() steals focus from the trigger.
+          // A single rAF is enough for the dialog DOM to be painted and
+          // focusable, then doubleRaf finalizes the transition.
+          requestAnimationFrame(() => {
+            this.setInputFocus();
+          });
+
           doubleRaf(() => {
             this.setInputFocus();
             this._inFullscreenTransition = false;
@@ -910,10 +1000,30 @@ export class AuroCombobox extends AuroElement {
    */
   setInputFocus() {
     if (this.dropdown.isBibFullscreen && this.dropdown.isPopoverVisible) {
-      this.inputInBib.focus();
+      // Sync the native input value synchronously before focusing.
+      // Lit's property-to-attribute sync is async (microtask), so the
+      // native <input> inside inputInBib may still hold a stale value
+      // when focus moves here during the fullscreen transition. Without
+      // this, keystrokes (e.g. Backspace) operate on the wrong content.
+      const nativeInput = this.inputInBib.inputElement;
+      const triggerNativeInput = this.input.inputElement;
+      if (nativeInput && triggerNativeInput && nativeInput.value !== triggerNativeInput.value) {
+        this.inputInBib.skipNextProgrammaticInputEvent = true;
+        nativeInput.value = triggerNativeInput.value || '';
+      }
+
+      // Focus the native input directly to ensure it receives keystrokes
+      // after the fullscreen dialog opens. The dialog's showModal() may
+      // have moved focus to the dialog element itself; focusing the
+      // auro-input custom element doesn't always reach the native input
+      // when the dialog DOM isn't fully painted.
+      if (nativeInput) {
+        nativeInput.focus();
+      } else {
+        this.inputInBib.focus();
+      }
 
       // Place cursor at end of existing text so the user can continue editing
-      const nativeInput = this.inputInBib.inputElement;
       if (nativeInput && nativeInput.value) {
         const len = nativeInput.value.length;
         nativeInput.setSelectionRange(len, len);
@@ -1021,51 +1131,89 @@ export class AuroCombobox extends AuroElement {
       this.menu.setAttribute('nocheckmark', '');
     }
 
-    this.menu.addEventListener("auroMenu-deselectPrevented", () => {
-      this.hideBib();
-    });
+    // Handle menu option selection
+    this.menu.addEventListener('auroMenu-selectedOption', (evt) => {
+      // Capture before the consumption below — true means this event is the
+      // echo of our own setMenuValue (programmatic value sync), false means
+      // a fresh user selection.
+      const isEcho = this._pendingMenuValueSync === true;
 
-    // Handle menu option selection like select does
-    this.menu.addEventListener('auroMenu-selectedOption', (event) => {
-      // Update the optionSelected from the event details, not manually
-      [this.optionSelected] = event.detail.options;
+      if (this.menu.optionSelected) {
+        const selected = this.menu.optionSelected;
 
-      // Update the internal value to match the menu's value
-      this.value = event.detail.stringValue;
+        if (!this.optionSelected || this.optionSelected !== selected) {
+          this.optionSelected = selected;
+        }
 
-      // Update display
-      this.updateTriggerTextDisplay(event.detail.label || event.detail.value);
+        // Skip writeback when this event is the echo of our own setMenuValue —
+        // otherwise it cascades against handleInputValueChange in suggestion mode.
+        if (this._pendingMenuValueSync) {
+          this._pendingMenuValueSync = false;
+        } else if (!this.value || this.value !== this.optionSelected.value) {
+          this.value = this.optionSelected.value;
+        }
 
-      // Update match word for filtering
-      const trimmedInput = normalizeFilterValue(this.input.value);
-      if (this.menu.matchWord !== trimmedInput) {
-        this.menu.matchWord = trimmedInput;
+        // Update display
+        this.updateTriggerTextDisplay(getOptionLabel(this.optionSelected) || this.menu.value);
+
+        // Update match word for filtering
+        const trimmedInput = normalizeFilterValue(this.input.value);
+        if (this.menu.matchWord !== trimmedInput) {
+          this.menu.matchWord = trimmedInput;
+        }
       }
 
-      // Update available options based on selection
-      this.handleMenuOptions();
-
       // Hide dropdown on selection (except during slot changes)
-      if (event.detail && event.detail.source !== 'slotchange') {
-        setTimeout(() => {
-          // do not close while typing in suggestion mode with no value selected, to allow freeform input
-          if (this.menu.value || this.behavior !== 'suggestion') {
-            this.hideBib();
-          }
-        }, 0);
+      if (evt.detail && evt.detail.source !== 'slotchange') {
+        // do not close while typing in suggestion mode with no value selected, to allow freeform input
+        if (this.menu.value || this.behavior !== 'suggestion') {
+          this.hideBib();
+        }
 
         // Announce the selection after the dropdown closes so it isn't
         // overridden by VoiceOver's "collapsed" announcement from aria-expanded.
-        const selectedValue = event.detail.stringValue;
+        const selectedValue = this.menu.value;
         const announcementDelay = 300;
         setTimeout(() => {
           announceToScreenReader(this._getAnnouncementRoot(), `${selectedValue}, selected`);
         }, announcementDelay);
       }
+
+      // Programmatic value syncs leave availableOptions stale because
+      // updateTriggerTextDisplay sets input.value with _syncingDisplayValue
+      // and handleInputValueChange bails. Refresh the filter on echo events
+      // only — fresh user selections take the existing hideBib path.
+      if (isEcho && this.menu.optionSelected) {
+        this._programmaticFilterRefresh = true;
+        this.handleMenuOptions();
+        setTimeout(() => {
+          this._programmaticFilterRefresh = false;
+        }, 0);
+      }
+
+      // base-input skips auto-validate when focus is inside its own shadow,
+      // which it is after setTriggerInputFocus — re-run so prior tooShort
+      // clears. processCreditCard reasserts errorMessage on every render.
+      if (!isEcho && this.menu.optionSelected && this.input.validate) {
+        this.input.updateComplete.then(() => {
+          this.input.validate(true);
+          if (this.input.validity === 'valid') {
+            this.input.errorMessage = '';
+          }
+        });
+      }
     });
 
     this.menu.addEventListener('auroMenu-customEventFired', () => {
       this.hideBib();
+    });
+
+    // When the menu cannot match a programmatic value to any option,
+    // clear the combobox selection state so it doesn't reference a
+    // stale option. Safe from re-entrancy because any resulting
+    // input.value changes dispatch isProgrammatic events.
+    this.menu.addEventListener('auroMenu-selectValueFailure', () => {
+      this.optionSelected = undefined;
     });
 
     this.menu.addEventListener('auroMenu-activatedOption', (evt) => {
@@ -1168,11 +1316,12 @@ export class AuroCombobox extends AuroElement {
     // event from the trigger. The _syncingBibValue guard persists across the
     // async boundary and prevents that re-entrant event from running the
     // non-fullscreen path (which would call clear() → hideBib()).
-    // When the event comes from the fullscreen bib input, sync the value to
-    // the trigger and run filtering, but suppress the re-entrant input event
-    // that the trigger fires (via Lit updated() → notifyValueChanged()) so
-    // the non-fullscreen hide/clear logic doesn't close the dialog.
     if (event.target === this.inputInBib) {
+      // Mirror the trigger-branch bail below — programmatic inputInBib writes
+      // notify back into this branch via Lit's notifyValueChanged.
+      if (this._syncingDisplayValue) {
+        return;
+      }
       this._syncingBibValue = true;
       this.input.value = this.inputInBib.value;
       this.input.updateComplete.then(() => {
@@ -1182,17 +1331,36 @@ export class AuroCombobox extends AuroElement {
       // Run filtering inline — the re-entrant event won't reach this code.
       this.menu.matchWord = normalizeFilterValue(this.inputInBib.value);
       this.optionActive = null;
+
+      // In suggestion mode, keep the combobox value in sync with the typed
+      // text so that freeform values are captured (mirroring the non-fullscreen
+      // path). Clear the selection when the input is emptied.
+      if (this.behavior === 'suggestion') {
+        this.value = this.inputInBib.value || undefined;
+      }
+
       this.handleMenuOptions();
       this.dispatchEvent(new CustomEvent('inputValue', { detail: { value: this.inputValue } }));
       return;
     }
 
-    // Ignore re-entrant input events caused by the bib→trigger sync above.
-    if (this._syncingBibValue) {
+    // Ignore re-entrant input events caused by programmatic value sets.
+    if (this._syncingBibValue || this._syncingDisplayValue) {
       return;
     }
 
     this.inputInBib.value = this.input.value;
+
+    // Also sync the native input immediately so keystrokes arriving
+    // before Lit's async update cycle (e.g. rapid Backspaces during a
+    // fullscreen transition) operate on the correct content.
+    // Skip the next programmatic input event to prevent the patched setter
+    // from re-entering handleInputValueChange via the bib path.
+    const bibNativeInput = this.inputInBib.inputElement;
+    if (bibNativeInput && bibNativeInput.value !== this.input.value) {
+      this.inputInBib.skipNextProgrammaticInputEvent = true;
+      bibNativeInput.value = this.input.value || '';
+    }
 
     this.menu.matchWord = normalizeFilterValue(this.input.value);
     this.optionActive = null;
@@ -1201,7 +1369,7 @@ export class AuroCombobox extends AuroElement {
       this.value = this.input.value;
     }
 
-    if (!this.input.value) {
+    if (!this.input.value && !this._clearing) {
       this.clear();
     }
     this.handleMenuOptions();
@@ -1331,10 +1499,18 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   setMenuValue(value) {
-    if (!this.menu) {
+    if (!this.menu || this.menu.value === value) {
       return;
     }
+    // One-shot flag consumed by the auroMenu-selectedOption listener so the
+    // echo of this sync doesn't propagate back to this.value.
+    this._pendingMenuValueSync = true;
     this.menu.value = value;
+    // Backup clear: if menu.value === menu.optionSelected.value already, the
+    // listener won't fire and the flag would swallow the next user click.
+    setTimeout(() => {
+      this._pendingMenuValueSync = false;
+    }, 0);
   }
 
   /**
@@ -1356,16 +1532,24 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   clear() {
-    // Clear combobox state first
-    this.optionSelected = undefined;
-    this.value = undefined;
-
-    // Then clear input and menu
-    if (this.input.value) {
-      this.input.clear();
+    // input.clear() fires an input event that re-enters handleInputValueChange
+    // → which calls clear() again on empty input. Guard against that loop.
+    if (this._clearing) {
+      return;
     }
-    if (this.menu.value || this.menu.optionSelected) {
-      this.menu.reset();
+    this._clearing = true;
+    try {
+      this.optionSelected = undefined;
+      this.value = undefined;
+
+      if (this.input.value) {
+        this.input.clear();
+      }
+      if (this.menu.value || this.menu.optionSelected) {
+        this.menu.reset();
+      }
+    } finally {
+      this._clearing = false;
     }
   }
 
@@ -1393,30 +1577,57 @@ export class AuroCombobox extends AuroElement {
         this.input.value = this.value;
       }
 
-      if (this.menu && this.hasValue && this.menu.options) {
-        this.menu.options.forEach((opt) => {
-          if (!opt.hasAttribute('static')) {
-            opt.removeAttribute('hidden');
-          }
-        });
-      }
-
-      if (this.behavior === 'suggestion') {
-        if (!this.menu.options || this.menu.options.length === 0) {
-          // No options loaded yet (async pattern) — don't touch menu.value.
-        } else if (this.menu.options.filter((opt) => opt.value === this.value).length > 0) {
+      // Sync menu.value only when an option actually matches; otherwise clear it.
+      if (this.menu.options && this.menu.options.length > 0) {
+        if (this.menu.options.some((opt) => opt.value === this.value)) {
           this.setMenuValue(this.value);
         } else {
-          this.menu.value = undefined;
-          // Sync the input display for freeform values that don't match any option
-          this.input.value = this.value;
+          if (this.menu.value) {
+            this.menu.value = undefined;
+          }
+          // Sync the display for programmatic freeform value changes (e.g. the
+          // swap-values pattern). Guard with _syncingDisplayValue so that the
+          // re-entrant input event from base-input.notifyValueChanged() is
+          // ignored by handleInputValueChange. Skip the sync when input already
+          // matches to avoid spurious events during the normal typing path.
+          const nextValue = this.value || '';
+          const triggerNeedsSync = this.input.value !== nextValue;
+          const bibNeedsSync = Boolean(this.inputInBib && this.inputInBib !== this.input && this.inputInBib.value !== nextValue);
+          if (triggerNeedsSync || bibNeedsSync) {
+            this._syncingDisplayValue = true;
+            if (triggerNeedsSync) {
+              this.input.value = nextValue;
+            }
+            if (bibNeedsSync) {
+              this.inputInBib.value = nextValue;
+            }
+            const pending = [];
+            if (triggerNeedsSync) {
+              pending.push(this.input.updateComplete);
+            }
+            if (bibNeedsSync) {
+              pending.push(this.inputInBib.updateComplete);
+            }
+            Promise.all(pending).then(() => {
+              if (triggerNeedsSync && this.input.maskInstance && typeof this.input.maskInstance.updateValue === 'function') {
+                this.input.maskInstance.updateValue();
+              }
+              if (bibNeedsSync && this.inputInBib && this.inputInBib.maskInstance && typeof this.inputInBib.maskInstance.updateValue === 'function') {
+                this.inputInBib.maskInstance.updateValue();
+              }
+              this._syncingDisplayValue = false;
+              // handleInputValueChange bailed on the flag — refresh the filter.
+              this._programmaticFilterRefresh = true;
+              this.handleMenuOptions();
+              setTimeout(() => {
+                this._programmaticFilterRefresh = false;
+              }, 0);
+            });
+          }
         }
-      } else {
-        // Use setMenuValue like select does instead of direct assignment
-        this.setMenuValue(this.value);
-        if (!this.value) {
-          this.clear();
-        }
+      }
+      if (!this.value) {
+        this.clear();
       }
       if (this.value && !this.componentHasFocus) {
         // If the value got set programmatically make sure we hide the bib
@@ -1454,12 +1665,18 @@ export class AuroCombobox extends AuroElement {
       // branch from calling hideBib() when the dropdown was just opened but
       // :focus-within hasn't propagated through the top-layer dialog's nested
       // shadow DOM boundaries.
-      if ((this.availableOptions.length > 0 && (this.componentHasFocus || this.dropdownOpen)) || (this.menu && this.menu.loading) || (this.availableOptions.length === 0 && this.noMatchOption)) {
+      // Skip the show/hide side effects when the availableOptions change came
+      // from a programmatic filter refresh after a value swap — the user
+      // didn't interact, so we shouldn't auto-open the bib (especially for
+      // the no-match path where the existing condition unconditionally fires).
+      if (this._programmaticFilterRefresh) {
+        this._programmaticFilterRefresh = false;
+      } else if ((this.availableOptions.length > 0 && (this.componentHasFocus || this.dropdownOpen)) || (this.menu && this.menu.loading) || (this.availableOptions.length === 0 && this.noMatchOption)) {
         this.showBib();
         if (!this.availableOptions.includes(this.menu.optionActive)) {
           this.activateFirstEnabledAvailableOption();
         }
-      } else {
+      } else if (this.dropdown && this.dropdown.isPopoverVisible) {
         this.hideBib();
       }
     }

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -610,16 +610,7 @@ export class AuroCombobox extends AuroElement {
   updateFilter() {
     // Reset available options if noFilter is set to false after being true.
     if (this.noFilter) {
-      // nomatch options have no purpose when filtering is delegated to the
-      // consumer — exclude them so "No matching option" rows don't surface
-      // alongside the real results.
-      this.availableOptions = this.options.filter((option) => {
-        if (option.hasAttribute('nomatch')) {
-          option.setAttribute('hidden', '');
-          return false;
-        }
-        return true;
-      });
+      this.availableOptions = [...this.options];
       return;
     }
 
@@ -1213,6 +1204,7 @@ export class AuroCombobox extends AuroElement {
     // stale option. Safe from re-entrancy because any resulting
     // input.value changes dispatch isProgrammatic events.
     this.menu.addEventListener('auroMenu-selectValueFailure', () => {
+      this.value = undefined;
       this.optionSelected = undefined;
     });
 
@@ -1580,6 +1572,12 @@ export class AuroCombobox extends AuroElement {
       // Sync menu.value only when an option actually matches; otherwise clear it.
       if (this.menu.options && this.menu.options.length > 0) {
         if (this.menu.options.some((opt) => opt.value === this.value)) {
+          this.setMenuValue(this.value);
+        } else if (this.behavior === 'filter') {
+          // In filter mode, freeform values aren't allowed. Push the unmatched
+          // value through setMenuValue so menu dispatches auroMenu-selectValueFailure
+          // and the listener at line 1206 clears combobox.value (mirrors select's
+          // pattern). Bypassing setMenuValue here would skip the failure cascade.
           this.setMenuValue(this.value);
         } else {
           if (this.menu.value) {

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -30,6 +30,21 @@ function isClearBtnFocused(ctx, clearBtn = getClearBtn(ctx)) {
   return isFocused;
 }
 
+/**
+ * Reconcile the menu `_index` from `optionActive` so subsequent `makeSelection` calls find the correct option after async clearSelection has reset it.
+ * @param {Object} menu - The menu component.
+ */
+function reconcileMenuIndex(menu) {
+  // eslint-disable-next-line no-underscore-dangle
+  if (menu._index < 0 && menu.optionActive && menu.items) {
+    const idx = menu.items.indexOf(menu.optionActive);
+    if (idx >= 0) {
+      // eslint-disable-next-line no-underscore-dangle
+      menu._index = idx;
+    }
+  }
+}
+
 export const comboboxKeyboardStrategy = {
   ArrowDown(component, evt, ctx) {
     // If the clear button has focus, let the browser handle ArrowDown normally.
@@ -93,6 +108,7 @@ export const comboboxKeyboardStrategy = {
       // block the browser's built-in "Enter activates focused button" behavior.
       evt.stopPropagation();
     } else if (ctx.isExpanded && component.menu.optionActive) {
+      reconcileMenuIndex(component.menu);
       component.menu.makeSelection();
 
       if (ctx.isModal) {
@@ -140,6 +156,7 @@ export const comboboxKeyboardStrategy = {
       // When the clear button is focused, Tab events do not bubble out of
       // its shadow DOM, so this handler only fires when the clear button
       // is NOT focused. In that case, select the active option and close.
+      reconcileMenuIndex(component.menu);
       component.menu.makeSelection();
       component.hideBib();
 

--- a/components/combobox/stories/grouped-api-examples.stories.ts
+++ b/components/combobox/stories/grouped-api-examples.stories.ts
@@ -2,8 +2,12 @@
 
 import { Meta, StoryObj } from '@storybook/web-components-vite';
 import { generateGroupedStory } from '@aurodesignsystem/utils';
+import { AuroMenu, AuroMenuOption } from '../../menu/src/index.js';
 import '../../menu/src/registered';
 import '../src/registered';
+
+AuroMenu.register('cusom-menu');
+AuroMenuOption.register('custom-menuoption');
 
 // Import all HTML files from apiExamples
 const apiExamples = import.meta.glob('../apiExamples/*.html', { query: '?raw', import: 'default', eager: true });

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -172,7 +172,7 @@ function runFullTest(mobileView) {
       await expect(el.availableOptions).to.not.include(staticOption);
     });
 
-    it('should exclude static options when input is empty and bib is open', async () => {
+    it('should include static options when input is empty and bib is open', async () => {
       const el = await fixture(html`
         <auro-combobox>
           <span slot="label">Name</span>
@@ -183,7 +183,9 @@ function runFullTest(mobileView) {
         </auro-combobox>
       `);
 
-      // With empty input, all non-static options are shown
+      // With empty input, static options are surfaced (per the documented
+      // behavior — they let consumers display headers / "add new" rows when
+      // no filter is active). Typed input excludes them again.
       setInputValue(el, '');
       el.showBib();
       await elementUpdated(el);
@@ -191,7 +193,7 @@ function runFullTest(mobileView) {
       const menu = el.querySelector('auro-menu');
       const staticOption = menu.querySelector('#option-static');
 
-      await expect(el.availableOptions).to.not.include(staticOption);
+      await expect(el.availableOptions.includes(staticOption)).to.be.true;
     });
 
     it('should report static options as not active via isActive', async () => {
@@ -204,6 +206,11 @@ function runFullTest(mobileView) {
           </auro-menu>
         </auro-combobox>
       `);
+
+      // Type a matching character so availableOptions is populated and the
+      // first non-static option becomes active.
+      setInputValue(el, 'a');
+      await elementUpdated(el);
 
       const menu = el.querySelector('auro-menu');
       const staticOption = menu.querySelector('#option-static');
@@ -406,11 +413,17 @@ function runFullTest(mobileView) {
       await expect(el.dropdown.isPopoverVisible).to.be.false;
     });
 
-    it('should set the first menu option as active when the dropdown opens without a selection', async () => {
+    it('should set the first menu option as active when the dropdown opens with a matching filter', async () => {
       const el = await defaultFixture(mobileView);
       const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
 
-      // Simulate dropdown opening with no value set
+      // Type a matching character so options populate. Pre-5.9 combobox only
+      // surfaces options that match the typed input — opening the bib with an
+      // empty input intentionally shows no options.
+      setInputValue(el, 'a');
+      await elementUpdated(el);
+
+      // Simulate dropdown opening
       el.dropdown.dispatchEvent(new CustomEvent('auroDropdown-toggled', {
         detail: { expanded: true }
       }));
@@ -419,8 +432,13 @@ function runFullTest(mobileView) {
       await new Promise((res) => setTimeout(res, 200));
       await elementUpdated(el);
 
-      await expect(el.optionActive).to.equal(menuOptions[0]);
+      // Under the pre-5.9 menu, programmatic index assignment sets
+      // menu.index synchronously but does not fire auroMenu-activatedOption
+      // until the user interacts (arrow key, click). menu.index is the
+      // source of truth for the active slot; optionActive is the cached
+      // event payload, which stays null until the menu emits.
       await expect(el.menu.index).to.equal(0);
+      await expect(el.availableOptions[0] === menuOptions[0], 'first available option should be menuOptions[0]').to.be.true;
     });
 
     it('should preserve leading space — " a" does not match options', async () => {
@@ -631,6 +649,160 @@ function runFullTest(mobileView) {
       await expect(right.value).to.equal('a');
       await expect(left.input.value).to.equal('b');
       await expect(right.input.value).to.equal('a');
+    });
+
+    // Regression: programmatic value/input mutations in noFilter + persistInput
+    // + suggestion mode (the dynamic-menu apiExample swap pattern) used to pump
+    // a ~125-update cascade between handleInputValueChange and the
+    // auroMenu-selectedOption listener, pinning the main thread for seconds.
+    it('should not cascade when value and input diverge across matching menu options', async () => {
+      if (mobileView) {
+        await setViewport({ width: 500, height: 800 });
+      } else {
+        await setViewport({ width: 800, height: 800 });
+      }
+
+      const el = await fixture(html`
+        <auro-combobox noFilter persistInput value="A">
+          <span slot="label">Test</span>
+          <auro-menu>
+            <auro-menuoption value="A">Alpha</auro-menuoption>
+            <auro-menuoption value="B">Bravo</auro-menuoption>
+            <auro-menuoption value="C">Charlie</auro-menuoption>
+          </auro-menu>
+        </auro-combobox>
+      `);
+      await elementUpdated(el);
+
+      let updateCount = 0;
+      const origPerformUpdate = el.performUpdate.bind(el);
+      // Circuit-break inside the spy so a regression surfaces as a thrown
+      // error in <50 updates rather than hitting WTR's 120s testsFinishTimeout
+      // (which reports "0 passed, 0 failed" and looks like infra flakiness).
+      el.performUpdate = function() {
+        updateCount += 1;
+        if (updateCount > 50) {
+          throw new Error(`cascade: performUpdate ran ${updateCount} times`);
+        }
+        return origPerformUpdate();
+      };
+
+      // Reproduce the dynamic-menu swap shape: value and input.value point at
+      // different menu options simultaneously.
+      el.value = 'B';
+      el.input.value = 'C';
+      await elementUpdated(el);
+      await el.menu.updateComplete;
+      // Lit can swallow throws from performUpdate and resolve updateComplete
+      // before queued cascade updates run. The macrotask wait lets them drain.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Pre-fix this would trip the circuit breaker. Bounded at 20 to leave
+      // headroom for legitimate update batching.
+      expect(updateCount).to.be.below(20);
+    });
+
+    // Regression: after a programmatic value swap, the bib's availableOptions
+    // would stay frozen at the pre-swap input.value because
+    // updateTriggerTextDisplay and the value-branch ELSE write set input.value
+    // with _syncingDisplayValue, which made handleInputValueChange bail
+    // without re-running updateFilter.
+    it('should refresh availableOptions after a programmatic value swap', async () => {
+      if (mobileView) {
+        await setViewport({ width: 500, height: 800 });
+      } else {
+        await setViewport({ width: 800, height: 800 });
+      }
+
+      const wrapper = await swapFixture(mobileView);
+      const left = wrapper.querySelector('#left');
+      const right = wrapper.querySelector('#right');
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      // Left ends with a matching option; right ends with a non-matching
+      // freeform value (suggestion mode allows it).
+      setInputValue(left, 'Apples');
+      setInputValue(right, 'xyz');
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      // Swap values the way the apiExample button does.
+      const leftVal = left.value;
+      const rightVal = right.value;
+      left.value = rightVal;
+      right.value = leftVal;
+      await elementUpdated(left);
+      await elementUpdated(right);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // After swap: left holds 'xyz' (no match), right holds 'Apples' (match).
+      // The filter must follow the input.value, not stay frozen at pre-swap.
+      expect(left.availableOptions.length).to.equal(0);
+      expect(right.availableOptions.some((o) => o.value === 'Apples')).to.be.true;
+    });
+
+    // Regression: the filter-refresh introduced for the swap pattern was
+    // pushing reactive availableOptions changes through updated()'s
+    // availableOptions branch, which would auto-open the bib for the no-match
+    // case (availableOptions.length === 0 && noMatchOption fires showBib
+    // unconditionally). The _programmaticFilterRefresh flag suppresses that
+    // side effect since the user hasn't interacted.
+    it('should not auto-open the bib for a no-match input after a programmatic swap', async () => {
+      if (mobileView) {
+        await setViewport({ width: 500, height: 800 });
+      } else {
+        await setViewport({ width: 800, height: 800 });
+      }
+
+      const wrapper = await fixture(html`
+        <div>
+          <auro-combobox id="left">
+            <span slot="label">Left</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption static nomatch>No matching option</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+          <auro-combobox id="right">
+            <span slot="label">Right</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+              <auro-menuoption static nomatch>No matching option</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        </div>
+      `);
+      const left = wrapper.querySelector('#left');
+      const right = wrapper.querySelector('#right');
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      // Type a matching value in left, a non-matching freeform value in right.
+      setInputValue(left, 'Apples');
+      setInputValue(right, 'xyz');
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      // Move focus off both before the swap so neither bib is interactive.
+      document.body.focus();
+      await elementUpdated(left);
+      await elementUpdated(right);
+
+      // Swap programmatically.
+      const leftVal = left.value;
+      const rightVal = right.value;
+      left.value = rightVal;
+      right.value = leftVal;
+      await elementUpdated(left);
+      await elementUpdated(right);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Neither bib should auto-open — the user didn't interact.
+      expect(left.dropdown.isPopoverVisible).to.be.false;
+      expect(right.dropdown.isPopoverVisible).to.be.false;
     });
 
     // These tests require fullscreen (mobile) mode
@@ -1644,6 +1816,32 @@ function runFullTest(mobileView) {
 
         await expect(slotContent).to.exist;
       });
+
+      // Regression: optionSelected.textContent was assigned to input.value
+      // verbatim, so HTML-indentation whitespace and the displayValue slot's
+      // text (e.g. emoji icons) leaked into the input.
+      it('should not leak displayValue slot text or HTML indentation into input.value', async () => {
+        const el = await fixture(html`
+          <auro-combobox value="Apples">
+            <span slot="label">Name</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">
+                Apples
+                <span slot="displayValue">🍎</span>
+              </auro-menuoption>
+              <auro-menuoption value="Oranges">
+                Oranges
+                <span slot="displayValue">🍊</span>
+              </auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        `);
+        await elementUpdated(el);
+        await el.menu.updateComplete;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        await expect(el.input.value).to.equal('Apples');
+      });
     });
 
   });
@@ -1777,6 +1975,41 @@ function runFullTest(mobileView) {
 
         await expect(el.menu.value).to.equal('Oranges');
       });
+
+      it('should not propagate the menu-selection echo back to value', async () => {
+        const el = await defaultFixture(mobileView);
+        await elementUpdated(el);
+
+        el.setMenuValue('Oranges');
+        // Flag is armed synchronously by setMenuValue.
+        await expect(el._pendingMenuValueSync).to.be.true;
+
+        await elementUpdated(el);
+        await el.menu.updateComplete;
+
+        // Listener consumes the flag on the echo event so the writeback to
+        // this.value is skipped (the closing edge of the cascade loop).
+        await expect(el._pendingMenuValueSync).to.be.false;
+      });
+
+      it('should clear the menu-sync flag even when the menu does not fire selectedOption', async () => {
+        const el = await defaultFixture(mobileView);
+        await elementUpdated(el);
+
+        // Setting menu.value to a string that matches no option fires
+        // auroMenu-selectValueFailure instead of auroMenu-selectedOption, so
+        // the listener never runs and never consumes the flag. The
+        // setTimeout(0) backup clear in setMenuValue must still release it
+        // before the next user-click selection arrives.
+        el.setMenuValue('NotAnOption');
+        await expect(el._pendingMenuValueSync).to.be.true;
+
+        await elementUpdated(el);
+        await el.menu.updateComplete;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        await expect(el._pendingMenuValueSync).to.be.false;
+      });
     });
 
     describe('reset', () => {
@@ -1839,6 +2072,37 @@ function runFullTest(mobileView) {
 
         await expect(el.hasAttribute('validity')).to.be.false;
       });
+
+      // Regression: typing a partial credit-card digit triggered the input's
+      // tooShort validity, but selecting a full-length option from the bib
+      // didn't re-run validation, so the error message persisted on the
+      // trigger even though the new input.value passed the length check.
+      it('should re-run input validation when a fresh user selection lands', async () => {
+        const el = await fixture(html`
+          <auro-combobox type="credit-card">
+            <span slot="label">Card</span>
+            <auro-menu>
+              <auro-menuoption value="4500000000000000" id="opt-cc">
+                4000 0000 0000 0000
+              </auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        `);
+        await elementUpdated(el);
+
+        setInputValue(el, '4');
+        el.input.validate(true);
+        await elementUpdated(el);
+        await expect(el.input.validity).to.equal('tooShort');
+
+        const option = el.menu.options.find((o) => o.id === 'opt-cc');
+        option.click();
+        await elementUpdated(el);
+        await el.input.updateComplete;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        await expect(el.input.validity).to.equal('valid');
+      });
     });
 
     describe('updateActiveOption', () => {
@@ -1853,7 +2117,7 @@ function runFullTest(mobileView) {
         el.updateActiveOption(0);
         await elementUpdated(el);
 
-        await expect(el.optionActive).to.equal(el.availableOptions[0]);
+        await expect(el.optionActive === el.availableOptions[0], `expected el.optionActive to equal el.availableOptions[0]`).to.be.true;
       });
     });
 
@@ -2338,10 +2602,12 @@ function runFullTest(mobileView) {
       const el = await defaultFixture(mobileView);
       await elementUpdated(el);
 
-      // Clear input value and remove menu options so the guard passes
+      // Clear input value and remove menu options from the DOM so the guard passes
       el.input.value = undefined;
-      const origOptions = el.menu.options;
-      el.menu.options = [];
+      const menu = el.querySelector('auro-menu');
+      const removedOptions = [...menu.querySelectorAll('auro-menuoption')];
+      removedOptions.forEach((opt) => opt.remove());
+      await elementUpdated(el);
 
       // Set value to trigger updated() with changedProperties containing 'value'
       el.value = 'programmatic-value';
@@ -2350,7 +2616,7 @@ function runFullTest(mobileView) {
       expect(el.input.value).to.equal('programmatic-value');
 
       // Restore
-      el.menu.options = origOptions;
+      removedOptions.forEach((opt) => menu.appendChild(opt));
     });
 
     it('updated calls clear() in filter mode when value is set to falsy', async () => {
@@ -3858,7 +4124,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
-        await expect(el.optionActive).to.equal(menuOptions[0]);
+        await expect(el.optionActive === menuOptions[0], `expected el.optionActive to equal menuOptions[0]`).to.be.true;
       });
 
       it('should activate the first enabled option with Meta+ArrowUp', async () => {
@@ -3888,7 +4154,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
-        await expect(el.optionActive).to.equal(menuOptions[0]);
+        await expect(el.optionActive === menuOptions[0], `expected el.optionActive to equal menuOptions[0]`).to.be.true;
       });
 
       it('should activate the first enabled option with Ctrl+ArrowUp', async () => {
@@ -3918,7 +4184,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption');
-        await expect(el.optionActive).to.equal(menuOptions[0]);
+        await expect(el.optionActive === menuOptions[0], `expected el.optionActive to equal menuOptions[0]`).to.be.true;
       });
 
       it('should open the bib when ArrowUp is pressed and bib is closed', async () => {
@@ -4039,7 +4305,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
-        await expect(el.optionActive).to.equal(enabledOptions[0]);
+        await expect(el.optionActive === enabledOptions[0], `expected el.optionActive to equal enabledOptions[0]`).to.be.true;
         await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
       });
 
@@ -4068,7 +4334,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
-        await expect(el.optionActive).to.equal(enabledOptions[0]);
+        await expect(el.optionActive === enabledOptions[0], `expected el.optionActive to equal enabledOptions[0]`).to.be.true;
         await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
       });
 
@@ -4097,7 +4363,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const enabledOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
-        await expect(el.optionActive).to.equal(enabledOptions[0]);
+        await expect(el.optionActive === enabledOptions[0], `expected el.optionActive to equal enabledOptions[0]`).to.be.true;
         await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
       });
     });
@@ -4132,7 +4398,7 @@ function runFullTest(mobileView) {
         }));
         await elementUpdated(el);
 
-        await expect(el.optionActive).to.equal(menuOptions[0]);
+        await expect(el.optionActive === menuOptions[0], `expected el.optionActive to equal menuOptions[0]`).to.be.true;
         await expect(el.dropdown.isPopoverVisible).to.be.true;
       });
 
@@ -4161,7 +4427,7 @@ function runFullTest(mobileView) {
         await elementUpdated(el);
 
         const menuOptions = el.querySelector('auro-menu').querySelectorAll('auro-menuoption:not([disabled])');
-        await expect(el.optionActive).to.equal(menuOptions[0]);
+        await expect(el.optionActive === menuOptions[0], `expected el.optionActive to equal menuOptions[0]`).to.be.true;
         await expect(el.optionActive.hasAttribute('disabled')).to.be.false;
       });
 

--- a/components/form/test/auro-form-interactions.test.js
+++ b/components/form/test/auro-form-interactions.test.js
@@ -286,6 +286,27 @@ function runFullTest(mobileView) {
 
       await expect(form.value.selectExample).to.deep.equal(JSON.stringify(['stops']));
     });
+
+    it('should store multi-select value as a string when assigned a pre-stringified array', async () => {
+      const form = await fixture(componentTemplate);
+      const [select] = form._elements;
+      select.multiSelect = true;
+      await elementUpdated(select);
+
+      const selectEvent = new Promise((resolve) => {
+        select.addEventListener('input', (event) => {
+          if (event.target.getAttribute('name') === 'selectExample') {
+            resolve(event);
+          }
+        });
+      });
+
+      select.value = JSON.stringify(['stops']);
+      await selectEvent;
+      await elementUpdated(form);
+
+      await expect(form.value.selectExample).to.deep.equal(JSON.stringify(['stops']));
+    });
   });
 }
 

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -733,6 +733,14 @@ export class AuroMenu extends AuroElement {
    * @param {HTMLElement} menu - Root menu element.
    */
   handleNestedMenus(menu) {
+    // Slot changes can fire on a menu mid-teardown (e.g. while a parent menu
+    // is removing children to rebuild its content). In that window the menu
+    // is detached and parentElement is null. Skip — handleNestedMenus will
+    // run again when the menu is reattached.
+    if (!menu.parentElement) {
+      return;
+    }
+
     menu.level = menu.parentElement.level >= 0 ? menu.parentElement.level + 1 : 0;
 
     if (menu.level > 0) {

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -496,14 +496,20 @@ export class AuroMenu extends AuroElement {
       });
     }
 
-    // Handle layout propagation to all menus and options
+    // Handle layout propagation to all menus and options.
+    // Skip elements that had size/shape set by the author (marked in initItems);
+    // explicit per-option overrides must survive menu-level propagation.
     const propagationTargets = this.querySelectorAll('auro-menu, [auro-menu], auro-menuoption, [auro-menuoption]');
     [
       'size',
       'shape'
     ].forEach((prop) => {
       if (changedProperties.has(prop)) {
+        const explicitKey = prop === 'size' ? '_explicitSize' : '_explicitShape';
         propagationTargets.forEach((el) => {
+          if (el[explicitKey]) {
+            return;
+          }
           el.setAttribute(prop, this[prop]);
         });
       }
@@ -611,6 +617,18 @@ export class AuroMenu extends AuroElement {
   initItems() {
     const found = Array.from(this.querySelectorAll('auro-menuoption, [auro-menuoption]'));
     this.items = found.length > 0 ? found : undefined;
+
+    // Record whether each propagation target had an author-set size/shape attribute
+    // BEFORE menu has had a chance to propagate. Marker is set once per element so a
+    // later menu-driven setAttribute doesn't re-flag the element as "explicit".
+    this.querySelectorAll('auro-menu, [auro-menu], auro-menuoption, [auro-menuoption]').forEach((el) => {
+      if (el._explicitSize === undefined) {
+        el._explicitSize = el.hasAttribute('size');
+      }
+      if (el._explicitShape === undefined) {
+        el._explicitShape = el.hasAttribute('shape');
+      }
+    });
 
     if (this.noCheckmark) {
       this.updateItemsState(new Map([

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-underscore-dangle, no-magic-numbers, max-lines, no-extra-parens */
+/* eslint-disable no-underscore-dangle, no-magic-numbers, max-lines, no-extra-parens, max-depth */
 // Copyright (c) 2025 Alaska Airlines. All right reserved. Licensed under the Apache-2.0 license
 // See LICENSE in the project root for license information.
 
@@ -417,14 +417,21 @@ export class AuroMenu extends AuroElement {
 
         // If no matching options were found in either mode
         if (!newSelected || (Array.isArray(newSelected) && newSelected.length === 0)) {
-          // Clear state BEFORE dispatching so synchronous listeners (e.g. auro-select's
-          // updateDisplayedValue) read fresh `optionSelected` rather than the stale prior
-          // selection and re-render the old label.
-          if (this.optionSelected !== undefined) {
-            this.optionSelected = undefined;
+          // Defer failure when no options are loaded yet (async pattern: parent sets
+          // value before slotted options render). handleSlotChange re-runs matching
+          // once items arrive. Without this guard, a valid preselected value gets
+          // cleared by the failure listener before options ever exist to match against.
+          const hasItemsToMatch = this.items && this.items.length > 0;
+          if (hasItemsToMatch) {
+            // Clear state BEFORE dispatching so synchronous listeners (e.g. auro-select's
+            // updateDisplayedValue) read fresh `optionSelected` rather than the stale prior
+            // selection and re-render the old label.
+            if (this.optionSelected !== undefined) {
+              this.optionSelected = undefined;
+            }
+            this._index = -1;
+            dispatchMenuEvent(this, 'auroMenu-selectValueFailure');
           }
-          this._index = -1;
-          dispatchMenuEvent(this, 'auroMenu-selectValueFailure');
         } else if (!this.selectionEquals(this.optionSelected, newSelected)) {
           this.optionSelected = newSelected;
         }
@@ -890,6 +897,16 @@ export class AuroMenu extends AuroElement {
     // Nested menus must also reinitialize so items, level, role="group", and aria-label refresh on content changes.
     // Root-specific attributes (listbox/root/aria-multiselectable) remain gated by `rootMenu` inside initializeMenu.
     this.initializeMenu();
+
+    // When options arrive after `value` was set (async option load), re-run matching
+    // against the now-populated items. The earlier updated('value') call deferred
+    // the failure dispatch because items were empty; this triggers the match now.
+    const hasPendingValue = this.value !== undefined &&
+      this.value !== null &&
+      !(typeof this.value === 'string' && this.value.trim() === '');
+    if (hasPendingValue && this.items && this.items.length > 0 && this.optionSelected === undefined) {
+      this.requestUpdate('value', undefined);
+    }
   }
 
   /**

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -153,11 +153,15 @@ export class AuroMenuOption extends AuroElement {
   firstUpdated() {
     this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
 
+    // firstUpdated can fire on an option that was detached before the first
+    // render completed (e.g. dynamic-menu rebuilds clear and repopulate the
+    // menu mid-cycle). parentElement is null in that case — fall back to
+    // defaults; the next render after re-attachment will pick up real values.
     if (!this.hasAttribute('size')) {
-      this.size = this.parentElement.getAttribute('size') || 'sm';
+      this.size = this.parentElement ? this.parentElement.getAttribute('size') || 'sm' : 'sm';
     }
     if (!this.hasAttribute('shape')) {
-      this.shape = this.parentElement.getAttribute('shape') || 'box';
+      this.shape = this.parentElement ? this.parentElement.getAttribute('shape') || 'box' : 'box';
     }
 
     if (!this.id) {

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -2007,6 +2007,54 @@ function runFullTest(mobileView) {
     });
   });
 
+  describe('size/shape propagation', () => {
+    it('should propagate size and shape from menu to menuoptions that have neither set', async () => {
+      const el = await fixture(html`
+        <auro-menu size="md" shape="rounded" aria-label="test">
+          <auro-menuoption value="opt1">Opt 1</auro-menuoption>
+          <auro-menuoption value="opt2">Opt 2</auro-menuoption>
+        </auro-menu>
+      `);
+      await elementUpdated(el);
+
+      const options = el.querySelectorAll('auro-menuoption');
+      options.forEach((opt) => {
+        expect(opt.getAttribute('size')).to.equal('md');
+        expect(opt.getAttribute('shape')).to.equal('rounded');
+      });
+    });
+
+    it('should not override size/shape on a menuoption that already has them set', async () => {
+      const el = await fixture(html`
+        <auro-menu size="md" shape="rounded" aria-label="test">
+          <auro-menuoption value="opt1" size="lg" shape="pill">Opt 1</auro-menuoption>
+          <auro-menuoption value="opt2">Opt 2</auro-menuoption>
+        </auro-menu>
+      `);
+      await elementUpdated(el);
+
+      const [explicit, inherited] = el.querySelectorAll('auro-menuoption');
+
+      // Author-set values are preserved
+      expect(explicit.getAttribute('size')).to.equal('lg');
+      expect(explicit.getAttribute('shape')).to.equal('pill');
+
+      // Siblings without explicit values still inherit from the menu
+      expect(inherited.getAttribute('size')).to.equal('md');
+      expect(inherited.getAttribute('shape')).to.equal('rounded');
+
+      // Subsequent menu-level changes still skip the explicit option
+      el.size = 'xl';
+      el.shape = 'box';
+      await elementUpdated(el);
+
+      expect(explicit.getAttribute('size')).to.equal('lg');
+      expect(explicit.getAttribute('shape')).to.equal('pill');
+      expect(inherited.getAttribute('size')).to.equal('xl');
+      expect(inherited.getAttribute('shape')).to.equal('box');
+    });
+  });
+
   describe('noCheckmark property propagation', () => {
     it('should propagate noCheckmark to child options when set via property', async () => {
       const el = await fixture(html`

--- a/components/select/apiExamples/css-parts.html
+++ b/components/select/apiExamples/css-parts.html
@@ -15,7 +15,9 @@
 <auro-select class="css-parts-demo">
   <span slot="label">CSS Parts Example</span>
   <span slot="helpText">This select has custom styles applied via CSS Shadow Parts.</span>
-  <auro-menuoption value="one">Option One</auro-menuoption>
-  <auro-menuoption value="two">Option Two</auro-menuoption>
-  <auro-menuoption value="three">Option Three</auro-menuoption>
+  <auro-menu>
+    <auro-menuoption value="one">Option One</auro-menuoption>
+    <auro-menuoption value="two">Option Two</auro-menuoption>
+    <auro-menuoption value="three">Option Three</auro-menuoption>
+  </auro-menu>
 </auro-select>

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1056,7 +1056,7 @@ export class AuroSelect extends AuroElement {
 
   setMenuValue(value) {
     if (!this.menu) return;
-    this.menu.value = value;
+    this.menu.selectByValue(value);
   }
 
   /**

--- a/docs/post-mortem/1560481.md
+++ b/docs/post-mortem/1560481.md
@@ -1,0 +1,95 @@
+# Post-Mortem: Tests Baseline (AB#1560481)
+
+**Scope:** Sub-PR 1 of the FormKit v6 reversion — land tests describing pre-5.9 behavior on `breaking/formkit-v6` so the failing-test list becomes the work-remaining tracker for Sub-PRs 3–6.
+
+## Reference Documents
+- Execution Plan — [#1463](https://github.com/AlaskaAirlines/auro-formkit/discussions/1463)
+- Implementation Scope — [#1454](https://github.com/AlaskaAirlines/auro-formkit/discussions/1454)
+- Test Impact Inventory — [#1458](https://github.com/AlaskaAirlines/auro-formkit/discussions/1458)
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| Test baseline asserts the same event payload current `HEAD` dispatches | Baseline was transcribed from current source instead of the literal baseline commit. Diff every assertion against `a0661d42` before staging. |
+| Test references a menu method (`selectByValue`, `currentLabel`, `selectedOptions`) that doesn't exist on the pre-5.9 source | Expected — Sub-PR 3 ships compatibility shims for these. Don't strip the test; flag it for the source PR. |
+| Asked to test `disabled` propagation from select/combobox to menu | Don't. Dropdown gates user access; menu is unreachable when host is disabled. |
+| `size` / `shape` propagation test asserts identity pass-through | Wrong contract. `updateMenuShapeSize()` transforms by layout (classic → `box`/`md`, emphasized → host values, default → pass-through). Assert the transformation. |
+| Sub-PR 1 is opening with CI green | Something is wrong. The point of Sub-PR 1 is failing rows = work-remaining for Sub-PRs 3–6. |
+
+## What Landed vs. What Was Planned
+
+| Planned (per #1463 / #1458) | Status |
+|---|---|
+| Cut `breaking/formkit-v6` from `dev` at `a0661d42` | Done |
+| Quarantine 5.9-only tests (`selectAllMatchingOptions`, `allowDeselect`, `key`, `deselectPrevented`, MenuService coverage) | Done — moved to `quarantine/5-9-multiselect-tests/`, not deleted |
+| Edit-in-place tests where payload shape changes | Done |
+| Add 12 gap-closure tests (event payloads, property propagation, public-method triplets, dynamic lifecycle, `noCheckmark`) | Done |
+| Cross-framework parity (React ↔ Svelte demo pages) | Done — both stripped `allowDeselect` |
+| INVESTIGATE triage decisions documented in PR | Done — combobox fixtures all KEEP, Tab matches baseline, `selectValueReset` has null detail |
+
+## What Was Not in the Plan but Also Shipped
+
+1. **Baseline payload verification turned up encoded-HEAD assertions.** A pass-by-pass diff against `a0661d42` caught that the test file as initially staged had encoded *current* payloads for `customEventFired`, `selectValueFailure`, and `selectedOption` — not baseline. Corrected to `null` / `{ source: undefined }` etc. and the expected failure count went up by 8 (10 `selectByValue` → 18 total). Without the rerun the test baseline would have silently mirrored the architecture we were reverting away from.
+2. **`disabled` does not propagate to menu.** The plan listed disabled as a propagation property to test. The dropdown gates user access — if the host is disabled the dropdown won't open, so the menu is unreachable. Removed the assertion rather than encoding a contract that doesn't exist.
+3. **`size`/`shape` propagation is layout-dependent.** `updateMenuShapeSize()` transforms these (classic → `box`/`md`, emphasized → component's own values, default → pass-through). Tests now assert the transformation, not pass-through.
+4. **Quarantine root reorganized.** Started under `test/quarantine/multiselect-5.9/`, moved to a shared top-level `quarantine/5-9-multiselect-tests/` so Sub-PR 2's surface-level quarantine bundle had a sibling home. Only edits were relative-import depth corrections.
+
+## What the Plan Got Right
+- Tests-first cadence gave a clean progress signal: 18 known menu failures became Sub-PR 3's work list, not a bug-hunt mid-revert.
+- INVESTIGATE rows were correctly identified — the actual triage was mechanical once each fixture was opened.
+- The quarantine-not-delete pattern preserved the 5.9 contract for future reference without leaving dead code in the active suite.
+
+## What the Plan Missed
+- **Baseline payload assumptions need verification, not transcription.** Several payload shapes in #1458 turned out to encode HEAD behavior because the inventory was built by reading current source. The verification step against `a0661d42` should be called out explicitly in any future "land failing tests" sub-PR.
+- **multiSelect value contract decision blocked the inventory.** Resolved inside this PR (JSON-stringified array, e.g. `'["Apples"]'`) — which made most JSON.parse assertions in select/form/SPA tests `KEEP_AS_IS`. Decisions like this should land *before* the test inventory ships, not during.
+- **Combobox filter assertions were deferred.** Empty-input behavior diverges between baseline (no options shown) and 5.9 (show all). Sub-PR 1 couldn't write assertions without baseline-verifying which path tests would land on. Deferred to Sub-PR 5 — which then absorbed the cost in its own discovery cycle.
+
+## Outcome
+324/324 menu wtr at the end of the menu source revert, 18 expected failures against HEAD at the end of this PR. Quarantine bundle reusable for the surface-removal pass. Multi-select contract decision documented and locked.
+
+## Recommendations for Future Tests-First Sub-PRs
+1. Diff every payload assertion against the literal baseline commit before staging. The convenient "read current source" path produces inverted contracts.
+2. Resolve decisions like "what's the value contract" *before* writing the inventory, not during the implementation PR.
+3. When in doubt about whether a property propagates, write the assertion against the actual transformation function, not the property name.
+
+## Receipts
+
+**Branch:** `breaking/formkit-v6` cut from `dev` at `a0661d42` ("Merge pull request #1224 from AlaskaAirlines/rc/1223").
+
+**Commits (most recent first):**
+- [`89ed3c64`](https://github.com/AlaskaAirlines/auro-formkit/commit/89ed3c640) `fix(menu): update event detail expectations to include only source`
+- [`42ef46f4`](https://github.com/AlaskaAirlines/auro-formkit/commit/42ef46f42) `test(menu): establish pre-5.9 test baseline for formkit v6 revert`
+- [`e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/commit/e57981a93) `chore: reorganize the quarantined 5.9 multiSelect tests into a new root folder` (moves the quarantine from `test/quarantine/multiselect-5.9/` → `quarantine/5-9-multiselect-tests/`)
+
+**Final quarantine structure:** [`quarantine/5-9-multiselect-tests/` @ `e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/tree/e57981a93/quarantine/5-9-multiselect-tests) — `auro-menu.multiselect.spec.js`, `auro-menuoption.multiselect.spec.js`, `testFixtures.multiselect.js`, `apps-shared/select-remount.multiselect.suite.ts`, `apps-shared/menu-interaction.multiselect.suite.ts`, plus `README.md`.
+
+**Quarantined describe blocks — anchored at `cc1e03e2` (parent of [`42ef46f4`](https://github.com/AlaskaAirlines/auro-formkit/commit/42ef46f42), where the deleted lines still live in the active suite):**
+- [`auro-menu.test.js:540-567 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menu.test.js#L540-L567) — `selectAllMatchingOptions` (multiSelect programmatic updates)
+- [`auro-menu.test.js:597-665 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menu.test.js#L597-L665) — `allowDeselect` it-blocks (value states)
+- [`auro-menu.test.js:803-831 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menu.test.js#L803-L831) — `allowDeselect` describe (Properties)
+- [`auro-menu.test.js:1005-1024 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menu.test.js#L1005-L1024) — `selectAllMatchingOptions` describe (Properties)
+- [`auro-menu.test.js:1493-1511 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menu.test.js#L1493-L1511) — `auroMenu-deselectPrevented` event tests
+- [`auro-menu.test.js:1849-1971 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menu.test.js#L1849-L1971) — MenuService coverage block (rewritten as "Public API coverage" against restored public methods)
+- [`auro-menuoption.test.js:74-90 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/auro-menuoption.test.js#L74-L90) — `key` describe
+- [`testFixtures.js:21 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/testFixtures.js#L21) — `multiSelectDuplicateValuesFixture()`
+- [`testFixtures.js:37 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/components/menu/test/testFixtures.js#L37) — `multiSelectDuplicateValuesSelectAllFixture()`
+
+**Cross-framework parity edits (verified at `cc1e03e2`):**
+- [`MenuInteraction.tsx:7 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/apps/react-framework/src/pages/MenuInteraction.tsx#L7) — `allowDeselect?: boolean | ''` interface declaration removed
+- [`MenuInteraction.tsx:66 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/apps/react-framework/src/pages/MenuInteraction.tsx#L66) — `<auro-menu allowDeselect>` JSX usage removed
+- [`+page.svelte:46 @ cc1e03e2`](https://github.com/AlaskaAirlines/auro-formkit/blob/cc1e03e2/apps/svelte-framework/src/routes/menu-interaction/+page.svelte#L46) — `<auro-menu allowDeselect>` usage removed
+
+**Baseline payload corrections (encoded HEAD → corrected to `a0661d42`) — landed in [`89ed3c64`](https://github.com/AlaskaAirlines/auro-formkit/commit/89ed3c640):**
+- `auroMenu-customEventFired` — corrected to `evt.detail === null`
+- `auroMenu-selectValueFailure` — corrected to `evt.detail === null`
+- `auroMenu-selectValueReset` — corrected to `evt.detail === null`
+- `auroMenu-selectedOption` — corrected to `evt.detail = { source: undefined }`
+- `auroMenu-activatedOption` — `evt.detail` is the HTMLElement directly, not wrapped
+- `auroMenu-loadingChange` — extended to include `hasLoadingPlaceholder`
+
+**12 gap-closure tests added:** 6 event-payload exact-shape tests (above), property propagation tests on select + combobox (`size`, `shape`, `noCheckmark`), public-method triplets (`reset()`, `selectByValue()`, `updateActiveOption()`, `makeSelection()`), dynamic option lifecycle (remove/reslot), and `noCheckmark` propagation.
+
+**Resolved decision — multiSelect value contract:** JSON-stringified array (e.g. `'["Apples"]'`). Most `JSON.parse`/`JSON.stringify` assertions in `select`, `form`, and SPA tests are `KEEP_AS_IS` under this contract.
+
+**Expected-failing-test count at PR close:** 18 menu rows against HEAD (10 `selectByValue is not a function` + 8 event payload mismatches). These became the Sub-PR 3 work list.

--- a/docs/post-mortem/1560484.md
+++ b/docs/post-mortem/1560484.md
@@ -1,0 +1,90 @@
+# Post-Mortem: Surface Removal (AB#1560484)
+
+**Scope:** Sub-PR 2 of the FormKit v6 reversion — delete 5.9-only API examples, story exports, and doc entries for `allowDeselect`, `selectAllMatchingOptions`, and `key`. No source code or test logic changes.
+
+## Reference Documents
+- Execution Plan — [#1463](https://github.com/AlaskaAirlines/auro-formkit/discussions/1463)
+- Implementation Scope — [#1454](https://github.com/AlaskaAirlines/auro-formkit/discussions/1454)
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| Plan lists a file to edit but the file has no 5.9-only content on inspection | Don't touch it. Five planned-but-empty files were no-ops this PR — verify before staging. |
+| `docs/api.md` temporarily lists properties that exist in source, or vice versa | Expected during a multi-PR revert. Document the boundary in the PR description rather than reconciling early. |
+| Should I delete a 5.9 apiExample / story / demo? | Default to quarantine — `quarantine/5-9-surface/` — so `git mv` can restore it. Deletion forces git archaeology to recover. |
+| Failing-test count from Sub-PR 1 changed after a docs PR | Something is wrong. Surface removal must not move test logic. |
+
+## What Landed vs. What Was Planned
+
+| Planned (per #1463 §3) | Status |
+|---|---|
+| Delete 5.9-only apiExample files | Quarantined instead — moved to `quarantine/5-9-surface/`, preserves recovery without git archaeology |
+| Edit menu/select api.md + customize.md to drop 5.9-only property rows + nav anchors | Done |
+| Drop story exports (`AllowDeselect`, `Keys`, `SelectAllMatchingOptions`, `DuplicateValues`) | Done |
+| Edit framework demo pages | Already absorbed by Sub-PR 1 (cross-framework parity for `allowDeselect`) |
+| Failing-test count from Sub-PR 1 unchanged or reduced | Done — no source-logic changes |
+| Storybook builds clean | Done |
+
+## What Was Not in the Plan but Also Shipped
+
+1. **Quarantined, not deleted.** Sub-PR 1 created `quarantine/5-9-multiselect-tests/`. Sub-PR 2 added a sibling `quarantine/5-9-surface/` so 5.9 documentation, examples, and stories are recoverable without going through `git log`. The restoration guide in the PR description listed exact `git mv` commands per file.
+2. **Five planned files turned out to be no-ops.** `components/menu/demo/index.js`, `menu/demo/index.html`, `select/docs/api.md`, `combobox/docs/api.md`, and `menu/docs/partials/{api,index}.md` were on the task list but had no 5.9-only references on inspection. Documented in PR rather than touched.
+
+## What the Plan Got Right
+- Sequencing held: removing surface before source meant the source revert (Sub-PRs 3–5) didn't have to maintain example markup that was about to disappear.
+- "No source-logic changes" was a real constraint — the PR was reviewable by docs/storybook reviewers without architectural context.
+- Scope boundary call-out (docs/api.md temporarily out of sync with source until Sub-PR 3 lands) was the right way to handle the intermediate state. Reviewers were not surprised.
+
+## What the Plan Missed
+- **The "delete" instruction didn't account for restoration cost.** Quarantine costs nothing extra to maintain, and recovers everything via `git mv`. Future surface-removal sub-PRs should default to quarantine, not delete.
+- **The planned file list was built from inventory, not inspection.** Five entries didn't apply. Cheap to discover, but it would have shortened review if the planning pass had grep'd each candidate.
+
+## Outcome
+6 apiExample files quarantined, 6 doc files edited, 2 stories files pruned. No source or test logic changes. Sub-PR 1's expected-failure count unchanged. Storybook clean.
+
+## Recommendations for Future Surface-Removal Sub-PRs
+1. Default to `quarantine/` over delete when the artifact has independent recovery value (examples, stories, demo pages). Disk cost is negligible; recovery friction matters.
+2. Inspect every candidate file before adding it to the task list. A 30-second grep saves a PR-time discovery cycle.
+3. Document scope-boundary inconsistencies (docs ahead of source, or vice versa) in the PR description rather than trying to keep both in sync mid-sequence.
+
+## Receipts
+
+All blob links pinned to the commit's parent (`e57981a9`) — the pre-removal state, where the deleted lines still exist.
+
+**Commit:** [`3e223860`](https://github.com/AlaskaAirlines/auro-formkit/commit/3e2238609) `chore: quarantine 5.9-only API examples and remove story exports and doc entries`
+
+**Quarantine tree:** [`quarantine/5-9-surface/` @ `3e223860`](https://github.com/AlaskaAirlines/auro-formkit/tree/3e2238609/quarantine/5-9-surface)
+
+**Files quarantined (6) — `git mv` restoration paths:**
+- `quarantine/5-9-surface/menu-apiExamples/allow-deselect.html` → `components/menu/apiExamples/allow-deselect.html`
+- `quarantine/5-9-surface/menu-apiExamples/keys.html` → `components/menu/apiExamples/keys.html`
+- `quarantine/5-9-surface/menu-apiExamples/keys.js` → `components/menu/apiExamples/keys.js`
+- `quarantine/5-9-surface/menu-apiExamples/select-all-matching-options.html` → `components/menu/apiExamples/select-all-matching-options.html`
+- `quarantine/5-9-surface/menu-apiExamples/select-all-matching-options.js` → `components/menu/apiExamples/select-all-matching-options.js`
+- `quarantine/5-9-surface/select-apiExamples/duplicateValues.html` → `components/select/apiExamples/duplicateValues.html`
+
+**Files edited — verified line removals at `e57981a9` (pre-removal):**
+- [`components/menu/docs/api.md:9 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/docs/api.md#L9) — `allowDeselect` row
+- [`components/menu/docs/api.md:22 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/docs/api.md#L22) — `selectAllMatchingOptions` row
+- [`components/menu/docs/api.md:67 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/docs/api.md#L67) — `key` row (auro-menuoption)
+- [`components/menu/docs/pages/customize.md:21 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/docs/pages/customize.md#L21) — `<auro-anchorlink fluid href="#allowDeselect">` nav anchor
+- [`components/menu/docs/pages/customize.md:165-175 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/docs/pages/customize.md#L165-L175) — "Allow Deselect" section (header + description + AURO-GENERATED-CONTENT refs)
+- [`components/menu/stories/individual-api-examples.stories.ts:91 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/stories/individual-api-examples.stories.ts#L91) — `AllowDeselect` export
+- [`components/menu/stories/individual-api-examples.stories.ts:98 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/stories/individual-api-examples.stories.ts#L98) — `Keys` export
+- [`components/menu/stories/individual-api-examples.stories.ts:110 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/menu/stories/individual-api-examples.stories.ts#L110) — `SelectAllMatchingOptions` export
+- [`components/select/stories/individual-api-examples.stories.ts:124 @ e57981a9`](https://github.com/AlaskaAirlines/auro-formkit/blob/e57981a9/components/select/stories/individual-api-examples.stories.ts#L124) — `DuplicateValues` export
+
+**Correction vs. planning doc:** Sub-PR 2 progress doc listed edits to `components/menu/demo/api.md` and `components/menu/demo/customize.md`. Neither file exists in git history — they're generated artifacts. The commit `git diff --stat` confirms only the four source files above were modified.
+
+**Scope-boundary call-outs left in source (out of scope until Sub-PR 3):**
+- `auroMenu-deselectPrevented` event still emitted by `auro-menu.js`.
+- `unsubscribe` property on menuoption.
+- `MenuService` methods: `attachTo()`, `handleMenuChange()`, `setInternalSelected()`.
+
+**Files on task list that needed no changes (5):**
+- `components/menu/demo/index.js` (no `initKeysExample` or `initSelectAllMatchingOptionsExample` calls)
+- `components/menu/demo/index.html` (no `auro-button` script tag to remove)
+- `components/select/docs/api.md` (no 5.9-only entries)
+- `components/combobox/docs/api.md` (no 5.9-only entries)
+- `components/menu/docs/partials/{api,index}.md` (paths don't exist)

--- a/docs/post-mortem/1560485.md
+++ b/docs/post-mortem/1560485.md
@@ -1,0 +1,116 @@
+# Post-Mortem: auro-menu + auro-menuoption v6 Revert (AB#1560485)
+
+**Branch:** `rmenner/formkit-v6/revert-menu`
+**Scope:** Sub-PR 3 of the FormKit v6 reversion — delete `auro-menu.context.js`, restore `auro-menu.js` to direct state management, restore `auro-menuoption.js` to direct event handling. Provider + consumer ship atomically.
+
+## Reference Documents
+- Execution Plan — [#1463](https://github.com/AlaskaAirlines/auro-formkit/discussions/1463)
+- Implementation Scope §3a (menu), §3b (menuoption) — [#1454](https://github.com/AlaskaAirlines/auro-formkit/discussions/1454)
+- Sub-PR 1 test baseline — [[1560481]]
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| WTR hangs on an ArrowUp / keyboard-navigation test with no assertion log | WTR can't surface async assertion failures inside `elementUpdated` patterns. Run the same flow against the deployed component on the public docs site via Playwright and diff state. |
+| `navigateOptions('up')` returns the second-to-last item when called from `_index === -1` | Wrap-around math `(-1 + -1 + length) % length` is off by one. Start the loop from `items.length` so the first decrement lands on `length - 1`. |
+| `auroMenu-selectedOption` or `optionSelected` fires twice on a single programmatic value change | `notifySelectionChange()` is being called from both the `optionSelected` change handler and the value handler in `updated()`. Remove the duplicate. |
+| `aria-busy` is missing on a loading menu that has no options | The `loading` block is below the `if (!this.items) return` guard in `updateItemsState()`. Hoist it above. |
+| WTR timeout when programmatic `optionSelected` is reassigned to a new array reference with identical contents | Cascading Lit updates. Use the `selectionEquals()` helper to compare contents before reassignment. |
+| A test calls `menu.selectByValue(...)`, `menu.currentLabel`, `menu.selectedOptions`, or `menu.updateActiveOption(element)` and the method/getter doesn't exist | Add the compatibility shim, don't strip the test. Sub-PR 1 encoded a post-5.9 API surface that the pre-5.9 source didn't expose. |
+| Lit dev-mode warning "Element auro-menu scheduled an update after an update completed" during `firstUpdated` | Benign. `handleNestedMenus()` sets the `level` property; the cascade settles after one cycle. |
+| Menuoption multiSelect toggle does the wrong thing (selects when it should deselect or vice versa) | The menu's synchronous event handler is corrupting `this.selected` before `handleClick()` finishes. Capture `newSelected = !this.selected` *before* dispatching the event, then apply after. |
+
+## What Landed vs. What Was Planned
+
+| Planned (per #1463 / #1454) | Status |
+|---|---|
+| Delete `auro-menu.context.js` (MenuService + MenuContext) | Done — 714 lines removed |
+| Restore `auro-menu.js` distributed state (items, `_index`, value, optionSelected) + keyboard/mouse/slot handlers | Done |
+| Restore `auro-menuoption.js` to direct click/mouseover dispatch | Done |
+| Preserve post-5.9 non-context changes: `noMatch`, monotonic IDs, `aria-multiselectable`, nested-menu arrow fix | Done |
+| `auro-menu-utils.js` and `index.js` reconciled with baseline | Verified unchanged — no edits needed |
+| All wtr rows from Sub-PR 1 turn green | 324/324, lint clean, 96.09% coverage |
+
+## What Was Not in the Plan but Also Shipped
+
+Five behavioral bugs surfaced during the revert. None were called out in #1454 or #1463; all required source changes beyond a pure transcription of the baseline.
+
+1. **`navigateOptions('up')` off-by-one when `_index === -1`.** Wrap-around math `(-1 + -1 + length) % length` landed on the second-to-last item, not the last. Found by running the same call against the production component on the public docs site via Playwright and comparing. Fix: start the loop from `items.length` when direction is `'up'` and `_index === -1` so the first decrement lands on `items.length - 1`. The bug was almost invisible — the symptom was a WTR hang, not an assertion failure.
+2. **`handleKeyDown()` accidentally omitted.** Lost during the file rewrite, breaking all keyboard navigation. Restored.
+3. **Double event firing on programmatic value change.** `notifySelectionChange()` fired once from the `optionSelected` change handler and once from the value handler in `updated()`. Fix: removed the duplicate from the value handler.
+4. **`aria-busy` never set on loading menus with no options.** The early-return guard in `updateItemsState()` skipped the loading handler. Fix: hoist the loading block above the guard.
+5. **Cascading Lit updates from new `optionSelected` array references.** Even when contents were identical, a new array reference re-triggered `updated()`. Symptom: WTR test timeout. Fix: `selectionEquals()` helper compares contents before reassignment.
+
+Four compatibility shims were also added because Sub-PR 1's baseline references APIs the pre-5.9 code didn't expose: `options` (alias for `items`), `index` getter/setter, `selectedOption(s)`, `currentLabel`, and `selectByValue(value)`. Plus stub methods on menuoption (`handleMenuChange`, `setSelected`, `updateActive`, `attachTo`) for downstream consumers that hadn't been updated yet.
+
+## What the Plan Got Right
+- **Provider + consumer atomic shipping was load-bearing.** Sub-PR 3 was scoped exactly right — deleting the context provider while the consumer still subscribed would have caused silent failures across menuoption.
+- **Post-5.9 preservation list** (#1454 §3a) was accurate. `noMatch`, monotonic IDs, `aria-multiselectable`, and the nested-menu arrow fix all carried forward cleanly.
+- **`auro-menu-utils.js` / `index.js` verification call-out** saved time — both were already at baseline, no edits needed.
+
+## What the Plan Missed
+- **The pre-5.9 baseline has its own bugs.** Three of the five fixes above (navigateOptions wrap-around, double event firing, missing aria-busy on empty loading menus) existed in the 5.8.1 source. The plan said "restore pre-5.9 behavior" without flagging whether known baseline bugs should be carried forward. We chose to fix; documented here as a deliberate deviation from "pure revert."
+- **Sub-PR 1's test baseline assumed APIs the pre-5.9 code didn't expose.** `selectByValue`, `options`, `selectedOptions`, `currentLabel`, and `updateActiveOption(element)` are all post-5.9 names that Sub-PR 1 encoded in the test baseline. Required thin compatibility shims to keep the new test contract. This should have been called out as part of #1458's gap analysis.
+- **WTR's failure-handling for async updates can mask root causes.** The ArrowUp test "hang" was actually an assertion failure that WTR could not surface — `(-1 + -1 + length) % length` returned `length - 2`, the assertion failed, and the async update pattern with `elementUpdated()` deadlocked the test runner. Diagnosed by running the same call against production via Playwright and diffing. Pattern recurs in Sub-PR 5 with chai's diff inspector deadlocking on DOM-element comparisons.
+
+## Testing Strategy Adherence
+Sub-PR 3 turned green what Sub-PR 1 had landed red — the failing-test-to-passing-test progress signal worked exactly as #1476 specified. The five behavioral bugs above were *additionally* fixed beyond the planned scope, with regression tests added inline. Lit dev-mode "scheduled an update after an update completed" warnings still appear on `firstUpdated` (the `level` property set by `handleNestedMenus`), are benign, and were not pursued.
+
+## Outcome
+2 source files rewritten (~+1.5k lines of restored logic), 1 file deleted (714 lines), `@lit/context` no longer imported by menu source. 324/324 wtr at 96.09% coverage. Five latent bugs in the pre-5.9 architecture fixed in passing rather than carried forward.
+
+## Recommendations for Future Source Reverts
+1. **Diff against production behavior, not just source.** When a wtr test hangs without an assertion log, run the same flow against the deployed component and compare state. The deployed code is the ground truth for what "pre-5.9 should do."
+2. **Audit the test baseline's API surface before the source PR opens.** If the test PR encoded post-5.9 method names, the source PR will need shims. Cheaper to flag in the test PR than to discover during source revert.
+3. **Carry-forward decisions need a flag.** When the baseline has known bugs, the plan should mark each one as "carry forward" or "fix during revert" so the source PR doesn't have to re-litigate every quirky baseline behavior under time pressure.
+
+## Receipts
+
+**Branch:** `rmenner/formkit-v6/revert-menu`
+
+**Commit:** [`7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/commit/7b1929ca8) `fix(menu): revert to pre-5.9 distributed state architecture` — 4 files, +689/−1345.
+
+All blob links below pin to `7b1929ca8` (post-revert) or `3e223860` (parent, where the deleted context file still lives).
+
+**Deleted:**
+- [`auro-menu.context.js` @ `3e223860`](https://github.com/AlaskaAirlines/auro-formkit/blob/3e223860/components/menu/src/auro-menu.context.js) — `MenuService` + `MenuContext`, 714 lines. Entire file removed; no pre-5.9 equivalent exists.
+
+**Compatibility shims (added at revert — required by Sub-PR 1's test baseline):**
+- [`auro-menu.js:215 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L215) — `get options()` (alias for `this.items`)
+- [`auro-menu.js:222 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L222) — `get index()` / setter (calls `updateActiveOption()`)
+- [`auro-menu.js:237 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L237) — `get selectedOptions()` (array from `optionSelected`)
+- [`auro-menu.js:251 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L251) — `get selectedOption()` (first selected or `null`)
+- [`auro-menu.js:260 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L260) — `get currentLabel()` (`textContent` of selected option(s))
+- [`auro-menu.js:294 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L294) — `selectByValue(value)` (delegates to `this.value = value` with empty-value handling)
+
+**Stub methods on `auro-menuoption` (for downstream consumers not yet aware of revert):**
+- [`auro-menuoption.js:197 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L197) — `handleMenuChange()` no-op
+- [`auro-menuoption.js:201 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L201) — `setSelected(value)`
+- [`auro-menuoption.js:205 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L205) — `updateActive(active)`
+- [`auro-menuoption.js:214 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L214) — `attachTo()` no-op
+
+**Bugs fixed during revert — verified line anchors at `7b1929ca8`:**
+- [`auro-menu.js:842-878 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L842-L878) — `navigateOptions(direction)`. Wrap-around fix at L849-851: `if (newIndex === -1 && direction === 'up') { newIndex = this.items.length; }` so the first decrement lands on `length - 1`.
+- [`auro-menu.js:762 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L762) — `handleKeyDown(event)` definition. Was accidentally omitted from the initial revert; restored. Bind at [L74](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L74), listener wiring at [L313](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L313).
+- [`auro-menu.js:439-455 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L439-L455) — `updateItemsState(changedProperties)`. `loading` block (L441-447) sits **above** the `if (!this.items) return` guard (L450-452) so `aria-busy` gets set on loading menus with no options.
+- [`auro-menu.js:932-946 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L932-L946) — `selectionEquals(current, next)` helper. Used at [L398](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L398) to prevent cascading Lit updates when a new `optionSelected` array reference has identical contents.
+- [`auro-menu.js:922 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menu.js#L922) — `notifySelectionChange(source = undefined)` definition. Duplicate call removed from the value handler in `updated()` — only the `optionSelected` change handler fires now.
+
+**Menuoption "dumb option" model — verified at `7b1929ca8`:**
+- [`auro-menuoption.js:70 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L70) — click listener wiring.
+- [`auro-menuoption.js:222-234 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L222-L234) — `handleClick()` with toggle-before-dispatch. Captures `const newSelected = !this.selected` at L224, dispatches `auroMenuOption-click` with `detail: this` at L226-231, then writes `this.selected = newSelected` at L233. The order matters — applying the new value before dispatching lets the menu's synchronous handler corrupt the toggle. Reverse and the bug is back.
+- [`auro-menuoption.js:141 @ 7b1929ca`](https://github.com/AlaskaAirlines/auro-formkit/blob/7b1929ca8/components/menu/src/auro-menuoption.js#L141) — `get isActive()` (preserved post-5.9).
+
+**Verified unchanged from baseline (no edits at `7b1929ca8`):**
+- `components/menu/src/auro-menu-utils.js`
+- `components/menu/src/index.js`
+
+**Preserved post-5.9 (non-context) items — kept across the revert:**
+- `noMatch` property on menuoption (originally from `479b620e`, used by combobox)
+- Auto-generated monotonic IDs (originally from `f07bc5f2`)
+- `aria-multiselectable` handling (originally from `8a3fab01`)
+- `handleNestedMenus` arrow-key nav fix (originally from `40af10ba`)
+- `setTagAttribute()`, `hasLoadingPlaceholder` getter, `wrapperClasses` getter, `renderLayout()`
+
+**Final state:** 324/324 wtr (162 desktop + 162 mobile), 0 failed, lint clean, 96.09% coverage, ~4s runtime.

--- a/docs/post-mortem/1560488.md
+++ b/docs/post-mortem/1560488.md
@@ -28,6 +28,7 @@ Five behavioral bugs surfaced once the MenuService crutch was removed. None were
 3. **`auroMenu-selectValueFailure` was dispatched *before* `optionSelected` was cleared**, so synchronous listeners (the select's `updateDisplayedValue`) re-rendered the stale label. Fix: reorder clear-then-dispatch in `auro-menu.js`, locked in by an explicit invariant test.
 4. **Trigger label lingered on a non-matching runtime `value` change.** The label is rendered imperatively into `#value`, so a property change alone didn't clear it. Fix: call `updateDisplayedValue()` from the failure handler.
 5. **Multiselect `optionSelected` shared a reference with menu state**, letting consumer mutations leak back into the menu. Fix: clone the array on assignment, with a regression test.
+6. **`setMenuValue` bypassed the menu's stringify guard.** Replacing `this.value = event.detail.stringValue` with `this.value = this.menu.value` was safe only when `menu.value` was pre-stringified. The new `setMenuValue` wrote `this.menu.value` directly, skipping `menu.selectByValue()` and leaving arrays unstringified — `auro-form` then stored an array instead of the documented JSON string (`auro-menu.js:181`). Fix: route `setMenuValue` through `menu.selectByValue()` so the contract is honored at the menu's documented entry point. Locked in by a new test that assigns a pre-stringified array to `select.value` and asserts the form stores the string.
 
 ## What the Plan Got Right
 - Sequencing (menu → menuoption → select) held: the menu changes from #1482 were stable enough to revert against.

--- a/docs/post-mortem/1560490.md
+++ b/docs/post-mortem/1560490.md
@@ -1,0 +1,155 @@
+# Post-Mortem: auro-combobox v6 Revert (AB#1560490)
+
+**Branch:** `rmenner/formkit-v6/revert-combobox`
+**Scope:** Sub-PR 5 of the FormKit v6 reversion — restore `auro-combobox.js` to direct menu-event binding, revert empty-input filter to pre-5.9 behavior, confirm `comboboxKeyboardStrategy.js` independence. Also absorbed a multi-session stream of behavioral fixes that surfaced once the MenuService crutch was removed.
+
+## Reference Documents
+- Execution Plan — [#1463](https://github.com/AlaskaAirlines/auro-formkit/discussions/1463)
+- Implementation Scope §3d — [#1454](https://github.com/AlaskaAirlines/auro-formkit/discussions/1454)
+- Prior sub-PRs — [[1560481]] tests baseline, [[1560485]] menu revert, [[1560488]] select revert
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| WTR reports `0 passed, 0 failed` after the full 120s `testsFinishTimeout` | Most likely chai's diff inspector deadlocking on `expect(null).to.equal(domElement)` with a custom element. Not a Lit cascade. Rewrite affected assertions as `expect(a === b).to.be.true` so they fail fast. |
+| ~41 mobile combobox tests fail with `waitUntil` timeouts on `el.shadowRoot.activeElement === el.inputInBib` | WTR's `rootDir` is **CWD-relative**, not config-relative. Running from repo root 404s design-token CSS, mobile fullscreen never activates, `inputInBib` never receives focus. Run from the component directory. |
+| React framework tests fail with `Cannot set property hasLoadingPlaceholder of #<AuroMenu> which has only a getter` and combobox `firstUpdated` never finishes | React 19's `'propName' in element` check picks up read-only getters and attempts assignment. Remove the dead JSX attribute from React fixtures — Svelte silently no-ops via `setAttribute`, React throws. |
+| Dynamic-menu Swap-values demo pegs the main thread for ~5s after a swap | Two writers (`setMenuValue` and the `auroMenu-selectedOption` listener) are fighting over `combobox.value`. Use a one-shot `_pendingMenuValueSync` flag set by `setMenuValue` and consumed by the listener on its first event. Promise-based clears race the cascade — only the one-shot works, with a `setTimeout(0)` backup-clear. |
+| `combobox.value` oscillates between two values after a programmatic swap | Same root cause as above — the listener's `this.value = this.optionSelected.value` write echoes back through `setMenuValue`. Echo detection via `_pendingMenuValueSync`. |
+| Combobox's `auroMenu-selectedOption` handler reads `undefined` from `event.detail.options` / `stringValue` / `label` | Post-revert menu dispatches `{ source }` only. Read state from `this.menu.optionSelected` and `this.menu.value` directly, not from `event.detail`. |
+| `combobox.input.value` contains leading whitespace, HTML indentation, or duplicates the `[slot="displayValue"]` text (emoji / icon) | The listener wrote `this.optionSelected.textContent` directly. Use `getOptionLabel(option)` — clone the option, strip the displayValue child, normalize whitespace. |
+| Bib auto-opens on a no-match-side combobox after a programmatic swap, without user interaction | `handleMenuOptions()` is being called during the programmatic sync, which triggers the unconditional `availableOptions.length === 0 && this.noMatchOption → showBib()` clause in `updated()`. Suppress with a `_programmaticFilterRefresh` one-shot consumed by the availableOptions branch. |
+| Bib filter is stale after a programmatic value swap (left input shows "f" but bib lists all options) | `_syncingDisplayValue` is correctly suppressing re-entrancy but also suppressing the legitimate filter refresh. Capture `isEcho = this._pendingMenuValueSync` at the top of the listener (before the cascade-fix code consumes it) and call `handleMenuOptions()` when `isEcho` is true. |
+| Credit-card combobox stuck at `validity: tooShort` after selecting a valid option | `inputInBib` is dispatching `auroFormElement-validated` with stale `validity`, the listener writes it to `this.input.validity`, then `validation.js:380` reads back the polluted state. Fix the root cause with symmetric trigger↔bib sync in `updateTriggerTextDisplay` — once both inputs always agree, the `bibOpen`-aware listener filter and the explicit `this.validity = undefined` in `reset()` become dead code. |
+| Bib helpText shows the error message even though the input has no error styling | Same root cause as the validity bug — `inputInBib` is on a stale value driving stale `validity` → stale `errorMessage` → helpText. Symmetric sync resolves it. |
+| Fullscreen mobile: type "Apples", Tab to select, backspace 6 times only deletes one character | `showModal()` steals focus, `trigger.inert = true` removes it, `doubleRaf` (~32ms) is too slow for the recover. Add a single `requestAnimationFrame` (~16ms) before the `doubleRaf` and a native-input value sync (`bibNativeInput.value = this.input.value`) for the Lit-property-to-native async gap. |
+| Setting `combobox.value = 'invalid-option'` twice in a row in `behavior='filter'` doesn't clear the value the second time | The post-revert no-match else branch bypassed `setMenuValue` entirely. For `behavior='filter'`, route through `setMenuValue` so the failure cascade fires every time — the same-value guard would otherwise swallow the second call. |
+| Framework tests report a regression that doesn't reproduce in wtr after a source change | Framework apps consume `dist`, not `src`. Rebuild before re-running. |
+| Test passes vacuously even though browser logs show 50+ `performUpdate` calls | `await el.menu.updateComplete` resolves before queued cascade updates run. Add a circuit-breaker on `LitElement.prototype.performUpdate` (throw at >50 calls) plus a 50ms macrotask settle before the assertion. Without the breaker, a regression looks identical to WTR infra flake. |
+
+## What Landed vs. What Was Planned
+
+| Planned (per #1463 / #1454 §3d) | Status |
+|---|---|
+| Restore `auro-combobox.js` direct menu-event binding | Done — `auroMenu-selectedOption` handler reads `this.menu.optionSelected` / `this.menu.value` instead of stale event-detail fields |
+| Revert empty-input filter to pre-5.9 (no options shown, bib closes) | Done — empty input → `availableOptions = []` |
+| Confirm `comboboxKeyboardStrategy.js` independence | Confirmed — but needed `reconcileMenuIndex()` helper for Enter/Tab paths |
+| All `auro-combobox.test.js` rows green | 467/467 wtr, 8.7s, no hangs |
+| No `queuePendingValue` remnants | Done |
+| Post-plan bug-fix commits assessed and re-implemented where needed | Done — 9 of the 11 commits called out in #1463 §8 Q4 had to be re-ported onto the reverted architecture |
+
+## What Was Not in the Plan but Also Shipped
+
+A cascade of behavioral bugs surfaced once the pre-5.9 event payloads were back in play and the cross-component sync paths reverted. Each required source changes and a locking regression test.
+
+1. **`auroMenu-selectedOption` payload shape change broke 56 tests at once.** The reverted menu sends `{ source }` only; the 5.9 handler read `event.detail.options/stringValue/label`. Fix: read state directly from `this.menu`.
+2. **Re-entrant input events from `base-input.notifyValueChanged()`.** Setting `this.input.value` programmatically dispatches a native `input` event into `handleInputValueChange`, which can re-write `this.input.value` and loop. Fix: `_syncingDisplayValue` flag, set only when a real write is queued, cleared after `updateComplete`. Coarse-flagging (set unconditionally) broke 13 small-viewport tests — the guard is load-bearing.
+3. **State oscillation in dynamic-menu swap.** Two writers (`combobox.value` and `auroMenu-selectedOption` listener) fought over `combobox.value` after `swapValues()`, pinning the main thread at ~125 Lit `performUpdate` calls. Fix: one-shot `_pendingMenuValueSync` flag set by `setMenuValue` and consumed by the listener on its first event. Backed up by `setTimeout(0)` so the flag doesn't outlive a no-op `setMenuValue`. Promise-based clears raced the cascade — only the one-shot worked.
+4. **Stale bib filter after programmatic value swap.** `_syncingDisplayValue` correctly suppressed re-entrancy but also suppressed the legitimate `handleMenuOptions()` refresh. Fix: capture `isEcho = this._pendingMenuValueSync` at the top of the listener (before the cascade-fix code consumes it) and call `handleMenuOptions()` when `isEcho` is true. Paired with `_programmaticFilterRefresh` so the no-match auto-open clause in `updated()` skips programmatic syncs.
+5. **`input.value` leaked `displayValue` slot text and HTML indentation.** The listener wrote `this.optionSelected.textContent` into `input.value`, double-counting the `[slot="displayValue"]` content and including whitespace. Fix: `getOptionLabel()` helper clones the option, strips the displayValue child, normalizes whitespace.
+6. **Validation cascade pollution.** The combobox listener applied `inputInBib`-dispatched `auroFormElement-validated` events to `this.input.validity`. When `inputInBib` was stale (un-focused, value undefined), it dispatched `validity = undefined`, polluting the trigger's just-computed `valueMissing`. `validation.js:380` then read back the polluted state. Fix: symmetric `updateTriggerTextDisplay` that writes both inputs, plus a bail in `handleInputValueChange`'s bib branch on `_syncingDisplayValue`. After the symmetric sync, the `bibOpen`-aware listener filter and the explicit `this.validity = undefined` in `reset()` were verified dead and removed.
+7. **Fullscreen focus loss during transition.** `showModal()` steals focus; `trigger.inert = true` removes it; `doubleRaf` (~32ms) was too slow to recover. Fix: an additional single `requestAnimationFrame` (~16ms) before the `doubleRaf` plus a native-input value sync (`bibNativeInput.value = this.input.value`) to handle Lit's async property-to-native sync gap.
+8. **`auro-select`'s `setMenuValue` bypass.** Post-merge of Sub-PR 4, the `setMenuValue` path was writing `this.menu.value = value` directly, skipping `menu.selectByValue()`'s stringify guard and storing arrays unstringified in `auro-form`. Fixed in this branch on the select side (1-line). Documented in [[1560488]] as item 6.
+9. **`auroMenu-selectedOption` framework test asserted on `{ value }` payload.** The post-revert detail is `{ source }` only. Rewrote the test to read `menu.value` directly. Briefly extended the menu's payload and broke 6 wtr rows — the `{ source }`-only contract is deliberate.
+10. **Async-option load + early `value` bind race.** Framework tests render `<auro-select value="bar">` and load `<auro-menuoption>` children 300ms later. Pre-5.9 menu hit the no-match path before items arrived and `auroMenu-selectValueFailure` nulled `select.value`. Fix in `auro-menu.js`: defer failure when `items` is empty; on slotchange, re-trigger value matching against newly-arrived items.
+
+## What the Plan Got Right
+- `comboboxKeyboardStrategy.js` was architecturally independent of MenuService as #1463 predicted.
+- The "post-plan bug-fix commits will be lost" warning in #1463 §8 Q4 was accurate. Most were re-ported; the freeform-swap commit (`31b22499`) needed a behavioral rewrite, not a transcription.
+- Sequencing (menu → select → combobox) held — the menu/select changes from Sub-PRs 3 and 4 were stable enough to revert against.
+
+## What the Plan Missed
+- **The "filter hang" was not a Lit cascade.** Three sessions chased a re-entrant update loop. The actual cause: `expect(null).to.equal(domElement)` deadlocks chai's diff inspector for the full 120s WTR `testsFinishTimeout` when the element is a custom element with shadow DOM. Mocha never reports the failure; WTR reports `0 passed, 0 failed`. Pattern is identical to a runaway loop. Filed to memory as `project_combobox-filter-hang-is-chai`. Mechanical fix: rewrite affected assertions with strict equality (`expect(a === b).to.be.true`) which fails fast with a normal message.
+- **WTR `rootDir` is CWD-relative.** `packages/config/src/web-test-runner.config.mjs` sets `rootDir: '../../'` which resolves relative to **CWD**, not the config file. From the repo root, leading-slash `/node_modules/...` paths 404, design-token CSS never loads, the `--ds-grid-breakpoint-sm` token resolves empty, `mobileFullscreenBreakpoint` returns undefined, mobile fullscreen never activates, ~41 mobile tests fail with `waitUntil` timeouts on `el.shadowRoot.activeElement === el.inputInBib`. Filed to memory as `project_wtr-rootdir-cwd`. Always run from the component directory.
+- **React 19 throws on getter-only custom-element props.** React 19's `'propName' in element` check picks up read-only getters and tries `el.hasLoadingPlaceholder = true`, throwing `TypeError` in strict mode. Svelte's compiler falls through to `setAttribute` and silently no-ops. Symptom in React framework tests: 10 hard fails on `waitForFunction(combobox?.input != null)` because the throw bubbles out of the React render and the combobox child never finishes `firstUpdated`. Fix: remove dead `hasLoadingPlaceholder` JSX attribute from React fixtures — the getter derives state from the `loadingText` slot which is already present.
+- **Symmetric trigger ↔ bib sync replaced compensating filters.** Before symmetric sync, a `bibOpen`-aware listener filter and an explicit `this.validity = undefined` in `reset()` compensated for the validation pollution cascade. After symmetric sync both became verifiably dead code and were removed. The cleanup is fragile — a future "consolidate flag-setting" refactor could re-introduce the cascade. Filed to memory as `project_combobox-validity-cascade` with the rationale for the `!==` guard.
+- **Framework apps consume `dist`, not `src`.** A "regression" report on Session 9 was a stale dist build — rebuilding fixed it. Always confirm freshness before chasing.
+
+## Testing Strategy Adherence
+#1476 prescribed tests-first; this PR did fix-first for nearly every bug above because none were predictable from the test baseline. Each fix landed with a locking regression test in the same or next commit. Test count grew from 425 baseline → 467 final, all green.
+
+A few regression tests required defensive instrumentation: the cascade-prevention test was passing vacuously until a circuit-breaker (`throw at >50 performUpdate calls`) and a 50ms macrotask settle were added. Without the circuit-breaker, a regression manifested as WTR's `0 passed, 0 failed` 120s timeout — the same shape as infrastructure flake.
+
+## Outcome
+3 source files changed in `components/combobox/` plus the menu async-defer patch and the select `setMenuValue` fix. 467/467 wtr in ~8.7s. Cascade dropped from ~125 Lit updates to 7. React framework 358/358, Svelte 354/2 (2 pre-existing flakes). 10+ behavioral bugs landed beyond the planned scope, each with a regression test.
+
+## Recommendations for the Remaining Sub-PR (`@lit/context` removal)
+1. Verify no remaining imports across all components, packages, and apps before deleting the dependency. The previous sub-PRs each missed a downstream consumer in initial discovery.
+2. When a wtr suite reports `0 passed, 0 failed` after a long delay, suspect chai's diff inspector before suspecting a Lit cascade. Quick check: does any failing assertion compare a DOM element to a non-DOM value?
+3. Always run wtr from the component directory. Run-from-root failures look like real regressions and burn diagnosis time.
+4. Frontend framework consumers diverge in how they hand off props to custom elements. Read-only getters are a React 19 footgun. When restoring or removing a property on a public element, audit React fixtures explicitly.
+
+## Receipts
+
+**Branch:** `rmenner/formkit-v6/revert-combobox`
+
+All blob links below pin to `ba39cb43` unless otherwise noted (most recent commit on the branch, where all current code lives). Earlier session-by-session work was squashed into `9860d86d` — references to commits like `58a38ccf9`, `a336c2715`, etc. that appear in narrative are not on this branch's ancestry; they were exploratory iterations.
+
+**Commits on branch:**
+- [`ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/commit/ba39cb433) `fix(combobox,menu): finalize sub-pr-5 framework-test gaps` — restored noFilter `[...this.options]`, `selectValueFailure` clears `this.value`, `behavior='filter'` routes unmatched values through `setMenuValue`. Menu: async-defer + slotchange-rematch.
+- [`2de871f5`](https://github.com/AlaskaAirlines/auro-formkit/commit/2de871f51) `fix(select): route setMenuValue through menu.selectByValue` (AB#1560488) — cross-component fix surfaced during this work; also documented in [[1560488]] item 6.
+- [`9860d86d`](https://github.com/AlaskaAirlines/auro-formkit/commit/9860d86df) `fix(combobox): revert to pre-5.9 architecture` — the squashed combobox revert containing all of Sessions 1–7's iteration.
+
+**Combobox file:line anchors @ `ba39cb43`:**
+- [`auro-combobox.js:54 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L54) — module-scope `getOptionLabel(option)` helper. Clones, strips `[slot="displayValue"]` child, normalizes whitespace with `/\s+/gu` → ` `.
+- [`auro-combobox.js:610-624 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L610-L624) — `updateFilter()`. noFilter branch restored to `this.availableOptions = [...this.options]` (one-liner) — was incorrectly hiding `nomatch` options when consumer-rendered.
+- [`auro-combobox.js:686-735 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L686-L735) — `updateTriggerTextDisplay(label)`. Symmetric trigger ↔ bib write with `!==` guards on each input; `_syncingDisplayValue` flag set at L700, cleared after `Promise.all([...updateComplete])` at L722. The `!==` guards are load-bearing — see [[project_combobox-validity-cascade]].
+- [`auro-combobox.js:910 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L910) — single `requestAnimationFrame` fullscreen focus call. Sits above the existing `doubleRaf` so focus lands in `inputInBib` ~16ms after `showModal()` instead of ~32ms.
+- [`auro-combobox.js:1126-1185 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1126-L1185) — `auroMenu-selectedOption` listener. Captures `isEcho = this._pendingMenuValueSync` at [L1130](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1130) **before** the cascade-fix code consumes it. The echo-suppression branch at [L1141-1142](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1141-L1142) skips writeback. `updateTriggerTextDisplay(getOptionLabel(this.optionSelected) || this.menu.value)` at [L1148](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1148) — the displayValue-slot leak fix. Filter refresh on echo events at [L1178](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1178), suppressed via `_programmaticFilterRefresh`.
+- [`auro-combobox.js:1206-1209 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1206-L1209) — `auroMenu-selectValueFailure` listener. Clears both `this.value` and `this.optionSelected` (mirrors select).
+- [`auro-combobox.js:1304-1320 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1304-L1320) — `handleInputValueChange(event)`. Bib branch bail on `_syncingDisplayValue` at [L1314](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1314); trigger branch bail at [L1340](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1340) (`_syncingBibValue || _syncingDisplayValue`).
+- [`auro-combobox.js:1493-1506 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1493-L1506) — `setMenuValue(value)`. Same-value guard at L1494; `_pendingMenuValueSync = true` at L1499; backup-clear via `setTimeout(0)` at L1503-1505. Backup is required because if `menu.value === menu.optionSelected.value` the listener never fires and the flag would swallow the next user click.
+- [`auro-combobox.js:1576-1581 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1576-L1581) — `updated('value')` no-match else branch. `behavior === 'filter'` route forces unmatched values through `setMenuValue` so the failure cascade fires; bypassing would skip the cascade and break the second `combobox.value = 'invalid'` call via the same-value guard.
+- [`auro-combobox.js:1585-1605 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/combobox/src/auro-combobox.js#L1585-L1605) — programmatic freeform display sync (swap-values pattern). Conditional `triggerNeedsSync` / `bibNeedsSync` based on `!==` against `nextValue`; `_syncingDisplayValue` only set when there's a real write to suppress.
+
+**Combobox keyboard strategy:**
+- `comboboxKeyboardStrategy.js` — `reconcileMenuIndex(menu)` called before `makeSelection()` in Enter and Tab handlers. Restores `menu._index` from `menu.optionActive` when `_index < 0` but `optionActive` is still valid (async update cycles can desync them).
+
+**Menu file:line anchors @ `ba39cb43`:**
+- [`auro-menu.js:181 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/menu/src/auro-menu.js#L181) — JSON-string `value` contract JSDoc. The documented contract that the select setMenuValue bypass violated.
+- [`auro-menu.js:309-323 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/menu/src/auro-menu.js#L309-L323) — `selectByValue(value)`. Stringify guard at L321: `Array.isArray(value) ? JSON.stringify(value) : value`. This is the entry point select's `setMenuValue` must route through.
+- [`auro-menu.js:419-435 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/menu/src/auro-menu.js#L419-L435) — no-match path in `updated('value')`. Gated on `hasItemsToMatch = this.items && this.items.length > 0` (L424) so the failure dispatch defers when items are empty. Avoids the async-load race where preselected `value` gets cleared before options arrive.
+- [`auro-menu.js:892-910 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/menu/src/auro-menu.js#L892-L910) — `handleSlotChange()`. After `initializeMenu()`, if `hasPendingValue && this.items && this.items.length > 0 && this.optionSelected === undefined`, calls `this.requestUpdate('value', undefined)` to re-trigger matching against newly-arrived items.
+- [`auro-menu.js:1047 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/menu/src/auro-menu.js#L1047) — `get hasLoadingPlaceholder()` — the React 19 footgun. Read-only getter; passes React's `'in' element` check; React 19 attempts assignment in strict mode → `TypeError`.
+
+**Select cross-component fix:**
+- [`auro-select.js:1057-1060 @ 2de871f5`](https://github.com/AlaskaAirlines/auro-formkit/blob/2de871f51/components/select/src/auro-select.js#L1057-L1060) — `setMenuValue(value)`. Routes through `this.menu.selectByValue(value)` so array values get stringified per the documented contract before `auro-form.sharedInputListener` reads them.
+
+**React framework fixture changes (verified line at pre-removal SHA):**
+- [`ComboboxCitySearch.tsx:123 @ 2de871f5`](https://github.com/AlaskaAirlines/auro-formkit/blob/2de871f51/apps/react-framework/src/pages/ComboboxCitySearch.tsx#L123) — `<auro-menu ref={menuRef} hasLoadingPlaceholder>` removed.
+- [`ComboboxCitySearchFull.tsx:174 @ 2de871f5`](https://github.com/AlaskaAirlines/auro-formkit/blob/2de871f51/apps/react-framework/src/pages/ComboboxCitySearchFull.tsx#L174) — same attribute removed.
+
+**Cross-file anchors — the validation pollution cascade:**
+- [`base-input.js:726 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/input/src/base-input.js#L726) — `notifyValueChanged()` call in `updated()`. Fires for every `value` property change.
+- [`base-input.js:800-809 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/components/input/src/base-input.js#L800-L809) — `notifyValueChanged()` definition. Dispatches the native `input` event that re-enters `handleInputValueChange`.
+- [`validation.js:380-381 @ ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/packages/form-validation/src/validation.js#L380-L381) — `elem.validity = this.auroInputElements[0].validity; elem.errorMessage = this.auroInputElements[0].errorMessage;`. Reads back whatever the listener wrote to `this.input.validity`. Symmetric sync makes the input always agree with the trigger so this read can't pollute.
+
+**WTR run command (must be from component dir):**
+```
+cd components/combobox
+npx wtr --config "../../packages/config/src/web-test-runner.config.mjs" --port 7703
+```
+`rootDir: '../../'` in [`packages/config/src/web-test-runner.config.mjs` @ `ba39cb43`](https://github.com/AlaskaAirlines/auro-formkit/blob/ba39cb433/packages/config/src/web-test-runner.config.mjs) resolves relative to CWD. Running from repo root 404s design-token CSS, mobile fullscreen never activates, ~41 mobile tests fail with `waitUntil` timeouts on `el.shadowRoot.activeElement === el.inputInBib`.
+
+**Mechanical assertion sweep used during the empty-input filter revert (10 sites) to dodge the chai hang:**
+```
+perl -i -pe 's/await expect\(([^)]+)\)\.to\.equal\((menuOptions\[\d+\]|enabledOptions\[\d+\]|el\.availableOptions\[\d+\]|options\[\d+\])\);/await expect(\1 === \2, ...).to.be.true;/g'
+```
+Run from the combobox `test/` directory. Strict-equality form fails with `expected false to be true` instead of deadlocking chai's diff inspector on the DOM-element compare.
+
+**Test count progression (combobox wtr):** 369 baseline + 56 failing → 425 → 427 → 453 → 459 → 461 → 463 → 465 → 467 final. Each step landed with a locking regression test.
+
+**Framework test results:** React 358/358, Svelte 354/2 passed + 2 pre-existing flakes (`combobox-remount:60`, `input-interaction:79` — outside this work).
+
+**Memories filed from this work (local; no remote URL):**
+- `project_wtr-rootdir-cwd` — WTR config gotcha
+- `project_combobox-filter-hang-is-chai` — the chai diff inspector deadlock
+- `project_combobox-validity-cascade` — symmetric sync rationale + `!==` guard
+- `project_select-setmenuvalue-bypass` — stringify contract
+- `project_menu-selectedoption-detail` — `{ source }`-only contract + dist-build gotcha
+- `project_menu-async-options-defer` — defer-failure + slotchange-rematch
+
+**Open items not addressed in this PR:**
+- `inputErrorMessage` property may still hold stale "Please enter a valid credit card number." after symmetric sync clears the visible error state — auro-input renders styling off `hasAttribute('error')`, not off the property, so visually clean. Cosmetic; deferred.
+- `web-components.d.ts` still declares `hasLoadingPlaceholder?` as optional — left alone since runtime is fine (the read-only getter satisfies "optional property of boolean").

--- a/turbo.json
+++ b/turbo.json
@@ -126,6 +126,13 @@
         "@aurodesignsystem/auro-menu#build"
       ]
     },
+    "@aurodesignsystem/auro-counter#build": {
+      "dependsOn": [
+        "@aurodesignsystem/auro-bibtemplate#build",
+        "@aurodesignsystem/auro-dropdown#build",
+        "@aurodesignsystem/auro-helptext#build"
+      ]
+    },
     "test:framework": {
       "dependsOn": ["^build"],
       "cache": false,


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request makes significant improvements and bug fixes to the `auro-combobox` component, particularly around option filtering, input synchronization, and menu interaction. It also cleans up framework demo and test files by removing the deprecated `allowDeselect` functionality. The changes enhance the reliability and user experience of the combobox, especially in edge cases involving filtering, option selection, and fullscreen transitions.

**Key changes include:**

### Combobox filtering, option management, and input synchronization

* Improved the filtering logic in `auro-combobox` to properly handle `nomatch` and `static` options, ensuring that only relevant options are shown based on user input, and that "No matching option" rows do not appear alongside real results. [[1]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L582-R622) [[2]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L605-R663)
* Added a utility function `getOptionLabel` to normalize option labels for display, and updated input synchronization logic to use this function, preventing stale or incorrect values from appearing in the input. [[1]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895R47-R65) [[2]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L640-R686)
* Enhanced the synchronization between the trigger input and the bib input (fullscreen dropdown), ensuring that values are updated synchronously and keystrokes always operate on the correct content, especially during fullscreen transitions. [[1]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L659-R733) [[2]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L831-R922) [[3]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895R1003-L916)

### Demo and test cleanup

* Removed the deprecated `allowDeselect` property and related demo sections from both React and Svelte framework demo files, aligning documentation and demos with current component behavior. [[1]](diffhunk://#diff-572ba2db478b3d158439cafaba063230dca4899407e61fcb76178287b9d47579L7-R7) [[2]](diffhunk://#diff-572ba2db478b3d158439cafaba063230dca4899407e61fcb76178287b9d47579L64-L72) [[3]](diffhunk://#diff-034746dc3376b6f7569ae0639d618db5239a11c360e3e7ee27b67169bc8c43c8L44-L52)
* Updated the shared menu interaction test suite to remove tests for `allowDeselect` and clarify the expected behavior for single-select menus (selection is persistent when clicking the same option twice).

### Minor improvements and fixes

* Improved the logic for re-activating available options in the combobox when the active option is no longer visible or the internal index is reset, making option navigation more robust.
* Added a missing `<auro-menu>` wrapper in the combobox CSS parts demo example for better structure.
* Minor code style and documentation improvements, including ESLint config updates and clarifying comments.

### Test stability improvements

* Updated nested menu interaction tests to more reliably wait for menu options to be connected and interactive, reducing test flakiness. [[1]](diffhunk://#diff-657cf55685387825ee9df0abbe88ac4eed95a35f3af5a255b2f0598fbc60ce58L391-R371) [[2]](diffhunk://#diff-657cf55685387825ee9df0abbe88ac4eed95a35f3af5a255b2f0598fbc60ce58L404-R384)

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
