### PR TITLE
fix(datepicker): properly disable out-of-range cells

### DIFF
--- a/components/datepicker/src/auro-calendar-cell.js
+++ b/components/datepicker/src/auro-calendar-cell.js
@@ -270,8 +270,7 @@ export class AuroCalendarCell extends LitElement {
     const date = new Date(this.day.date * 1000);
 
     // Generate localized full date string using the configured locale
-    const localeCode = this.locale?.code || undefined;
-    const dateFormatter = new Intl.DateTimeFormat(localeCode, {
+    const dateFormatter = new Intl.DateTimeFormat(this.locale, {
       weekday: 'long',
       year: 'numeric',
       month: 'long',

--- a/components/datepicker/src/auro-calendar.js
+++ b/components/datepicker/src/auro-calendar.js
@@ -329,8 +329,7 @@ export class AuroCalendar extends RangeDatepicker {
     }
 
     const date = this.centralDateObject;
-    const localeCode = this.locale?.code || undefined;
-    const formatter = new Intl.DateTimeFormat(localeCode, { month: 'long',
+    const formatter = new Intl.DateTimeFormat(this.localeCode, { month: 'long',
       year: 'numeric' });
     this.announceSelection(formatter.format(date));
   }
@@ -1451,8 +1450,7 @@ export class AuroCalendar extends RangeDatepicker {
    */
   formatAnnouncementDate(timestamp) {
     const date = new Date(parseInt(timestamp, 10) * 1000);
-    const localeCode = this.locale?.code || undefined;
-    const formatter = new Intl.DateTimeFormat(localeCode, {
+    const formatter = new Intl.DateTimeFormat(this.localeCode, {
       weekday: 'long',
       year: 'numeric',
       month: 'long',

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -852,7 +852,7 @@ export class AuroDatePicker extends AuroElement {
    * @returns {Number} Simplified number.
    */
   convertToWcValidTime(date) {
-    return new Date(date).getTime() / 1000;
+    return date?.getTime() / 1000;
   }
 
   /**
@@ -1899,7 +1899,7 @@ export class AuroDatePicker extends AuroElement {
           <div class="${classMap(this.commonDisplayValueWrapperClasses)}">
             <slot name="displayValue" @slotchange=${this.checkDisplayValueSlotChange}>
               <span>
-                ${this.formatShortDate(this.value)}${this.range ? html`–${this.formatShortDate(this.valueEnd)}` : undefined}
+                ${this.formatShortDate(this.valueObject)}${this.range ? html`–${this.formatShortDate(this.valueEndObject)}` : undefined}
               </span>
             </slot>
           </div>
@@ -1973,7 +1973,7 @@ export class AuroDatePicker extends AuroElement {
    * Simple formatter that ONLY WORKS FOR US DATES.
    * Returns formatted date like Apr 21 or Dec 25.
    * @private
-   * @param {string} date - Date format should be in a format Date constructor accepts, like '2023-04-21' or '2023/04/21'.
+   * @param {Date} date - Date format should be in a format Date constructor accepts, like '2023-04-21' or '2023/04/21'.
    * @returns {string}
    */
   formatShortDate(date) {
@@ -1983,16 +1983,16 @@ export class AuroDatePicker extends AuroElement {
       day: '2-digit'
     };
 
-    return new Date(date).toLocaleDateString('en-US', options).replace(',', '');
+    return date?.toLocaleDateString(this.locale, options).replace(',', '');
   }
 
   /**
    * Format and render the provided date value.
    * @private
-   * @param {string} dateValue - The date value to format and render.
+   * @param {Date} date - The date value to format and render.
    * @returns {import('lit').TemplateResult}
    */
-  renderDisplayTextDate(dateValue) {
+  renderDisplayTextDate(date) {
     const displayTextClasses = {
       'displayValueText': true,
       'body-lg': true
@@ -2001,8 +2001,8 @@ export class AuroDatePicker extends AuroElement {
     return html`
         <div>
           <div class="${classMap(displayTextClasses)}">
-            ${dateValue && dateFormatter.isValidDate(dateValue)
-        ? this.formatShortDate(dateValue)
+            ${date
+        ? this.formatShortDate(date)
         : undefined
       }
           </div>
@@ -2051,7 +2051,7 @@ export class AuroDatePicker extends AuroElement {
           ${this.layout !== "classic"
         ? html`
               <span slot="displayValue">
-                ${this.renderDisplayTextDate(this.value)}
+                ${this.renderDisplayTextDate(this.valueObject)}
               </span>
             `
         : undefined
@@ -2095,7 +2095,7 @@ export class AuroDatePicker extends AuroElement {
             ${this.layout !== "classic"
           ? html`
               <span slot="displayValue">
-                ${this.renderDisplayTextDate(this.valueEnd)}
+                ${this.renderDisplayTextDate(this.valueEndObject)}
               </span>
             `
           : undefined

--- a/components/datepicker/src/utilitiesCalendarRender.js
+++ b/components/datepicker/src/utilitiesCalendarRender.js
@@ -148,8 +148,8 @@ export class UtilitiesCalendarRender {
       <auro-formkit-calendar-month
         id="${`month-${month}-${year}`}"
         .disabledDays="${elem.disabledDays}"
-        .min="${elem.min}"
-        .max="${elem.max}"
+        .min="${elem.minDateObject?.getTime() / 1000}"
+        .max="${elem.maxDateObject?.getTime() / 1000}"
         ?noRange="${elem.noRange}"
         .monthFirst="${elem.monthFirst}"
         .dateTo="${elem.dateTo}"

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -8241,12 +8241,9 @@ function runFullTest(mobileView) {
     describe('Out-of-range cells', () => {
       // Verify out-of-range cells marks out-of-range cells as aria-hidden.
       it('should mark out-of-range cells as aria-hidden', async () => {
-        // Use a minDate to create out-of-range cells
-        const today = new Date();
-        const minDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-
+        // centralDate shows June 2024; minDate=June 15 makes June 1-14 unconditionally out-of-range
         const el = await fixture(html`
-          <auro-datepicker minDate="${minDate}"></auro-datepicker>
+          <auro-datepicker centralDate="2024-06-15" minDate="2024-06-15"></auro-datepicker>
         `);
 
         const input = getInput(el, 0);
@@ -8256,15 +8253,51 @@ function runFullTest(mobileView) {
 
         const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
         const month = calendar.shadowRoot.querySelector('auro-formkit-calendar-month');
-        const allCellElements = Array.from(month.shadowRoot.querySelectorAll('auro-formkit-calendar-cell'));
+        const allCells = Array.from(month.shadowRoot.querySelectorAll('auro-formkit-calendar-cell'));
 
-        // Find a cell that is out of range
-        const outOfRangeCell = allCellElements.find((cell) => cell.day && cell.isOutOfRange(cell.day, cell.min, cell.max));
+        // June 1-14 are before minDate — assert they exist so the test never silently passes
+        const minTs = new Date('2024-06-15').getTime() / 1000;
+        const outOfRangeCells = allCells.filter((cell) => cell.day && cell.day.date < minTs);
 
-        if (outOfRangeCell) {
-          await outOfRangeCell.updateComplete;
-          const button = outOfRangeCell.shadowRoot.querySelector('button');
+        expect(outOfRangeCells.length).to.be.greaterThan(0);
+
+        for (const cell of outOfRangeCells) {
+          await cell.updateComplete;
+          const button = cell.shadowRoot.querySelector('button');
           expect(button.hasAttribute('aria-hidden')).to.be.true;
+          expect(button.disabled).to.be.true;
+        }
+      });
+
+      // Verify cells become disabled when minDate is set after the calendar is already open.
+      it('should disable cells when minDate is set dynamically after open', async () => {
+        // Open with no minDate so all June 2024 cells are enabled
+        const el = await fixture(html`
+          <auro-datepicker centralDate="2024-06-15"></auro-datepicker>
+        `);
+
+        const input = getInput(el, 0);
+        input.click();
+        await elementUpdated(el);
+        await nextFrame();
+
+        // Now set minDate through the real datepicker API
+        el.minDate = '2024-06-15';
+        await elementUpdated(el);
+        await nextFrame();
+
+        const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
+        const month = calendar.shadowRoot.querySelector('auro-formkit-calendar-month');
+        const allCells = Array.from(month.shadowRoot.querySelectorAll('auro-formkit-calendar-cell'));
+
+        const minTs = new Date('2024-06-15').getTime() / 1000;
+        const cellsBeforeMin = allCells.filter((cell) => cell.day && cell.day.date < minTs);
+
+        expect(cellsBeforeMin.length).to.be.greaterThan(0);
+
+        for (const cell of cellsBeforeMin) {
+          await cell.updateComplete;
+          const button = cell.shadowRoot.querySelector('button');
           expect(button.disabled).to.be.true;
         }
       });
@@ -9347,28 +9380,6 @@ function runFullTest(mobileView) {
 
         await expect(cell.hasAttribute('role')).to.be.false;
         await expect(cell.hasAttribute('aria-label')).to.be.false;
-        cell.min = savedMin;
-      });
-
-      // Verify renderCellButton renders button as disabled and aria-hidden when cell is out of range.
-      it('should render button as disabled and aria-hidden when cell is out of range', async () => {
-        const el = await fixture(html`<auro-datepicker centralDate="2024-01-15" value="2024-01-15"></auro-datepicker>`);
-        const input = getInput(el, 0);
-        input.click();
-        await elementUpdated(el);
-        await nextFrame();
-
-        const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
-        const cell = calendar.getAllFocusableCells()[0];
-
-        const savedMin = cell.min;
-        cell.min = 9999999999;
-        await elementUpdated(cell);
-        await nextFrame();
-
-        const button = cell.shadowRoot.querySelector('button');
-        await expect(button.hasAttribute('aria-hidden')).to.be.true;
-        await expect(button.disabled).to.be.true;
         cell.min = savedMin;
       });
     });

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -375,10 +375,6 @@ export class AuroInput extends BaseInput {
       return i18n(this.lang, this.type);
     }
 
-    if (this.type === 'date') {
-      return i18n(this.lang, this.dateFormatMap[this.format] || 'dateMMDDYYYY');
-    }
-
     return '';
   }
 

--- a/components/input/src/utilities.js
+++ b/components/input/src/utilities.js
@@ -99,7 +99,11 @@ export class AuroInputUtilities {
             return part.value;
         }
       })
-      .join("");
+      .join("")
+      // Remove whitespace and leading/trailing special characters for IMask compatibility
+      // for example, ko-KR's format is `YYYY. MM. DD.` which causes issues with IMask if we don't remove the trailing period.
+      .replace(/\s/gu, '')
+      .replace(/^[^A-Z0-9]+|[^A-Z0-9]+$/gu, '');
   }
 
   /**

--- a/components/input/test/auro-input-util.test.js
+++ b/components/input/test/auro-input-util.test.js
@@ -186,6 +186,16 @@ describe('AuroInputUtil', () => {
         expect(mask).to.be.a('string').and.not.empty;
       });
 
+      it('getDateMaskFromLocale does not start or end with a special character', () => {
+        const locales = ['en-US', 'en-GB', 'de-DE', 'ja-JP', 'zh-CN', 'fr-FR', 'ko-KR'];
+        locales.forEach((locale) => {
+          const util = new AuroInputUtilities({ locale });
+          const mask = util.getDateMaskFromLocale(locale);
+          expect(mask).to.match(/^[A-Z0-9]/, `mask for ${locale} should not start with a special character`);
+          expect(mask).to.match(/[A-Z0-9]$/, `mask for ${locale} should not end with a special character`);
+        });
+      });
+
       it('getMaskOptions date falls back to mm/dd/yyyy when format, overrideFormat, and pattern are all falsy', () => {
         const util = new AuroInputUtilities({ locale: 'en-US' });
         util.overrideFormat = undefined;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure datepicker calendar cells correctly reflect out-of-range constraints based on min/max dates, including when constraints are applied dynamically after opening.

Bug Fixes:
- Fix out-of-range datepicker cells so they are consistently marked aria-hidden and disabled when before the configured minDate.
- Fix dynamic updates of minDate so already-rendered calendar cells become disabled when they fall outside the allowed date range.

Tests:
- Strengthen datepicker out-of-range cell tests with deterministic dates and explicit checks for pre-minDate cells, including dynamic minDate updates.