### PR TITLE
ci: add counter build deps for bibtemplate, dropdown, and helptext

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -96,6 +96,13 @@
         "@aurodesignsystem/auro-dropdown#build"
       ]
     },
+    "@aurodesignsystem/auro-counter#build": {
+      "dependsOn": [
+        "@aurodesignsystem/auro-bibtemplate#build",
+        "@aurodesignsystem/auro-dropdown#build",
+        "@aurodesignsystem/auro-helptext#build"
+      ]
+    },
     "@aurodesignsystem/auro-datepicker#build": {
       "dependsOn": [
         "@aurodesignsystem/auro-bibtemplate#build",


### PR DESCRIPTION
## Summary

- Adds `@aurodesignsystem/auro-counter#build` to `turbo.json` with explicit `dependsOn` entries for `auro-bibtemplate`, `auro-dropdown`, and `auro-helptext` builds.
- Counter consumes these three components at build time, but the pipeline did not declare the dependency, so they were not guaranteed to be built before counter on a cold cache. This brings counter's build graph in line with sibling components like datepicker and select.

## Why

Without the explicit `dependsOn`, Turbo can schedule `auro-counter#build` before its sibling component builds finish, which has produced flaky CI failures and stale artifacts in `components/counter/dist`. Declaring the edge makes the build order deterministic and lets Turbo cache the upstream outputs correctly.

## Changes

- `turbo.json` — added a new task entry:
  ```json
  "@aurodesignsystem/auro-counter#build": {
    "dependsOn": [
      "@aurodesignsystem/auro-bibtemplate#build",
      "@aurodesignsystem/auro-dropdown#build",
      "@aurodesignsystem/auro-helptext#build"
    ]
  }
  ```

## Test plan

- [x] `npx turbo run build --filter=@aurodesignsystem/auro-counter` from a clean cache succeeds and pulls bibtemplate, dropdown, and helptext builds in first.
- [x] `npm run build` at the repo root still completes with no new task-graph warnings.
- [x] CI build on this branch is green.

## Summary by Sourcery

Build:
- Add @aurodesignsystem/auro-counter#build task to turbo.json with dependsOn entries for bibtemplate, dropdown, and helptext build tasks.