### PR TITLE
`auro-select` - Adversarial Review Bug Fixes for RC #1484 

### DIFF
--- a/apps/shared/counter-interaction.suite.ts
+++ b/apps/shared/counter-interaction.suite.ts
@@ -250,8 +250,7 @@ export function counterInteractionSuite(framework: string) {
       test('clicking outside closes the dropdown', async ({ page }) => {
         await openDropdown(page, 'dropdown-group');
 
-        // Focus an element outside the dropdown to trigger focus-loss close
-        await page.locator('#outside-element').focus();
+        await page.locator('#outside-element').dispatchEvent('click');
         await waitForBibClosed(page, 'dropdown-group');
       });
     });

--- a/apps/shared/select-interaction.suite.ts
+++ b/apps/shared/select-interaction.suite.ts
@@ -332,22 +332,20 @@ export function selectInteractionSuite(framework: string, options?: SuiteOptions
         expect(visible).toBe(false);
       });
 
-      test('Home is a no-op when the bib is collapsed', async ({ page }) => {
+      test('Home opens the bib and activates the first option when collapsed', async ({ page }) => {
         await focusTrigger(page, 'default');
         await page.keyboard.press('Home');
-        await page.waitForTimeout(50);
+        await waitForBibOpen(page, 'default');
 
-        const visible = await isBibVisible(page, 'default');
-        expect(visible).toBe(false);
+        await expect.poll(() => activeOptionValue(page, 'default'), { timeout: 5_000 }).toBe('Apples');
       });
 
-      test('End is a no-op when the bib is collapsed', async ({ page }) => {
+      test('End opens the bib and activates the last option when collapsed', async ({ page }) => {
         await focusTrigger(page, 'default');
         await page.keyboard.press('End');
-        await page.waitForTimeout(50);
+        await waitForBibOpen(page, 'default');
 
-        const visible = await isBibVisible(page, 'default');
-        expect(visible).toBe(false);
+        await expect.poll(() => activeOptionValue(page, 'default'), { timeout: 5_000 }).toBe('Grapes');
       });
 
       test('Shift+Tab is a no-op when the bib is closed', async ({ page }) => {

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -471,6 +471,13 @@ export class AuroCounterGroup extends AuroElement {
    */
   configureDropdownCounters() {
     this.dropdown = this.shadowRoot.querySelector(this.dropdownTag._$litStatic$);
+
+    // Counter rows are slotted into the bib through multiple shadow roots
+    // (dropdown → bib → bibtemplate → counter-group → counter), so the floater's
+    // `:focus-within` focus-loss check fails to match the dropdown host in Chromium
+    // and the bib auto-closes immediately after opening. Mirrors auro-select.
+    this.dropdown.noHideOnThisFocusLoss = true;
+
     this.dropdown.requestUpdate();
 
     const counterWrapper = this.shadowRoot.querySelector('auro-counter-wrapper');

--- a/components/counter/test/auro-counter-group.test.js
+++ b/components/counter/test/auro-counter-group.test.js
@@ -359,6 +359,18 @@ function runFullTest(mobileView) {
         await expect(el.isDropdown).to.be.true;
         await expect(el.dropdown).to.exist;
       });
+
+      // Regression guard: counter rows are slotted through multiple shadow roots,
+      // so the floater's `:focus-within` check fails on the dropdown host in
+      // Chromium and the bib auto-closes on open without this flag.
+      it('should set noHideOnThisFocusLoss on the dropdown to prevent Chromium auto-close', async () => {
+        const el = await fixture(html`
+          <auro-counter-group isDropdown>
+            <auro-counter>Counter</auro-counter>
+          </auro-counter-group>
+        `);
+        await expect(el.dropdown.noHideOnThisFocusLoss).to.be.true;
+      });
     });
 
     describe('largeFullscreenHeadline', () => {

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -1203,6 +1203,7 @@ export class AuroDropdown extends AuroElement {
           role="${ifDefined(this.triggerContentFocusable ? undefined : this.a11yRole)}"
           aria-expanded="${ifDefined(this.a11yRole === 'button' || this.triggerContentFocusable ? undefined : this.isPopoverVisible)}"
           aria-controls="${ifDefined(this.a11yRole === 'button' || this.triggerContentFocusable ? undefined : this.dropdownId)}"
+          aria-haspopup="${ifDefined(this.a11yRole === 'combobox' ? 'listbox' : undefined)}"
           aria-labelledby="${ifDefined(this.triggerContentFocusable ? undefined : 'triggerLabel')}"
           aria-disabled="${ifDefined(this.disabled ? 'true' : undefined)}"
           @focusin="${this.handleFocusin}"

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -1203,7 +1203,7 @@ export class AuroDropdown extends AuroElement {
           role="${ifDefined(this.triggerContentFocusable ? undefined : this.a11yRole)}"
           aria-expanded="${ifDefined(this.a11yRole === 'button' || this.triggerContentFocusable ? undefined : this.isPopoverVisible)}"
           aria-controls="${ifDefined(this.a11yRole === 'button' || this.triggerContentFocusable ? undefined : this.dropdownId)}"
-          aria-haspopup="${ifDefined(this.a11yRole === 'combobox' ? 'listbox' : undefined)}"
+          aria-haspopup="${ifDefined(this.a11yRole === 'combobox' && !this.triggerContentFocusable ? 'listbox' : undefined)}"
           aria-labelledby="${ifDefined(this.triggerContentFocusable ? undefined : 'triggerLabel')}"
           aria-disabled="${ifDefined(this.disabled ? 'true' : undefined)}"
           @focusin="${this.handleFocusin}"

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -2693,6 +2693,36 @@ function runFullTest(mobileView) {
       expect(trigger).to.have.attribute('aria-expanded');
     });
 
+    // Matches the WAI-ARIA APG select-only combobox reference markup. The
+    // implicit default of aria-haspopup on role="combobox" is "listbox", but
+    // setting it explicitly avoids relying on UA implicit-value mapping.
+    it("should render aria-haspopup='listbox' on trigger when a11yRole is set to combobox", async () => {
+      const el = await fixture(html`
+        <auro-dropdown>
+          <span slot="label"> label text </span>
+          <div slot="trigger">Trigger</div>
+        </auro-dropdown>
+      `);
+
+      el.a11yRole = 'combobox';
+      await elementUpdated(el);
+
+      const trigger = el.shadowRoot.querySelector("#trigger");
+      expect(trigger).to.have.attribute('aria-haspopup', 'listbox');
+    });
+
+    it("should not render aria-haspopup on trigger when a11yRole is the default button", async () => {
+      const el = await fixture(html`
+        <auro-dropdown>
+          <span slot="label"> label text </span>
+          <div slot="trigger">Trigger</div>
+        </auro-dropdown>
+      `);
+
+      const trigger = el.shadowRoot.querySelector("#trigger");
+      expect(trigger.hasAttribute('aria-haspopup')).to.be.false;
+    });
+
     describe("aria-activedescendant", () => {
       it("should set ariaActiveDescendantElement on the trigger when called with an element", async () => {
         const el = await fixture(html`

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -2723,6 +2723,25 @@ function runFullTest(mobileView) {
       expect(trigger.hasAttribute('aria-haspopup')).to.be.false;
     });
 
+    // When the slotted trigger owns its own focus, the wrapper sheds combobox
+    // semantics (role/aria-expanded/aria-controls/aria-labelledby) — aria-haspopup
+    // must follow the same guard so it isn't stranded on a role-less wrapper.
+    it("should not render aria-haspopup on the wrapper when triggerContentFocusable is true", async () => {
+      const el = await fixture(html`
+        <auro-dropdown>
+          <span slot="label"> label text </span>
+          <button slot="trigger">Focusable Trigger</button>
+        </auro-dropdown>
+      `);
+
+      el.a11yRole = 'combobox';
+      await elementUpdated(el);
+
+      const trigger = el.shadowRoot.querySelector("#trigger");
+      expect(el.triggerContentFocusable).to.be.true;
+      expect(trigger.hasAttribute('aria-haspopup')).to.be.false;
+    });
+
     describe("aria-activedescendant", () => {
       it("should set ariaActiveDescendantElement on the trigger when called with an element", async () => {
         const el = await fixture(html`

--- a/components/select/docs/partials/keyboard-behavior/keyEvents.md
+++ b/components/select/docs/partials/keyboard-behavior/keyEvents.md
@@ -136,8 +136,15 @@
       </td>
     </tr>
     <tr>
-      <td>End</td>
-      <td>-</td>
+      <td rowspan="2">End</td>
+      <td rowspan="2">-</td>
+      <td>Collapsed</td>
+      <td>Trigger element</td>
+      <td>
+        Opens the bib and advances the <code>focused</code> option to the last enabled option in the list.
+      </td>
+    </tr>
+    <tr>
       <td>Expanded</td>
       <td>Trigger element</td>
       <td>
@@ -165,8 +172,15 @@
       </td>
     </tr>
     <tr>
-      <td>Home</td>
-      <td>-</td>
+      <td rowspan="2">Home</td>
+      <td rowspan="2">-</td>
+      <td>Collapsed</td>
+      <td>Trigger element</td>
+      <td>
+        Opens the bib and advances the <code>focused</code> option to the first enabled option in the list.
+      </td>
+    </tr>
+    <tr>
       <td>Expanded</td>
       <td>Trigger element</td>
       <td>

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -829,6 +829,16 @@ export class AuroSelect extends AuroElement {
     }
     this.options = this.menu.options;
     this.updateOptionPositions();
+
+    // Keep aria-setsize/aria-posinset (and the cached options reference) in sync
+    // when the menu re-initializes its items — e.g., slotchange, async/lazy loads,
+    // value-triggered re-init. Without this, stale set-size is announced after
+    // dynamic option mutations.
+    this.menu.addEventListener('auroMenu-optionsChange', () => {
+      this.options = this.menu.options;
+      this.updateOptionPositions();
+    });
+
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));
 
     this.menu.addEventListener("auroMenu-selectValueFailure", () => {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1225,6 +1225,18 @@ export class AuroSelect extends AuroElement {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    // Regression guard: firstUpdated() fires once per instance, so the label
+    // observer setup it triggers does NOT re-run on reconnect. After a
+    // disconnect+reconnect (reparent, SPA route swap), runtime label mutations
+    // would silently stop syncing menu aria-label / dropdown.bibDialogLabel
+    // unless we re-wire the observer here.
+    if (this.hasUpdated) {
+      this._observeLabelChanges();
+    }
+  }
+
   // lifecycle runs only after the element's DOM has been updated the first time
   firstUpdated() {
     // Add the tag name as an attribute if it is different than the component name

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -900,10 +900,14 @@ export class AuroSelect extends AuroElement {
         this.dropdown.setActiveDescendant(this.optionActive);
       }
 
-      // Announce the active option for screen readers. Skip when the activated
-      // option is already selected: Enter triggers an auroMenu-selectedOption
-      // re-announce, and aria-selected on the active descendant otherwise
-      // conveys state without an explicit utterance.
+      // Live-region announce only for [not selected] options. For activations
+      // on an already-selected option — auto-activation on bib open, arrow
+      // navigation back to the selection, or click in multiSelect — rely on
+      // aria-activedescendant + aria-selected="true" to convey state per the
+      // WAI-ARIA listbox pattern. This is intentional, not limited to the
+      // initial activation on open: it also prevents a duplicate "X, selected"
+      // when Enter on the active+selected option re-fires
+      // auroMenu-selectedOption (see 03b289e39).
       if (this.optionActive && !this.optionActive.hasAttribute('selected')) {
         const optionText = this.optionActive.textContent.trim();
         const message = `${optionText}, not selected`;
@@ -924,6 +928,7 @@ export class AuroSelect extends AuroElement {
     });
 
     this.menu.addEventListener('auroMenu-selectedOption', () => {
+      const previousSelected = this.optionSelected;
 
       // Update the displayed value
       this.updateDisplayedValue();
@@ -943,13 +948,32 @@ export class AuroSelect extends AuroElement {
         this.dropdown.trigger.focus();
       }
 
-      // Announce the selection after the dropdown closes so it isn't
-      // overridden by VoiceOver's "collapsed" announcement from aria-expanded.
-      const selectedValue = this.menu.currentLabel;
-      const announcementDelay = 300;
-      setTimeout(() => {
-        announceToScreenReader(this._getAnnouncementRoot(), `${selectedValue}, selected`);
-      }, announcementDelay);
+      // Describe the actual change. In multiSelect, currentLabel is the
+      // concatenated remaining list — announcing "{list}, selected" after a
+      // deselect would falsely claim every remaining label was just added.
+      // Diff previous vs next to recover the toggled option.
+      let announcement = '';
+      if (this.multiSelect) {
+        const prev = Array.isArray(previousSelected) ? previousSelected : [];
+        const removed = prev.find((opt) => !nextSelected.includes(opt));
+        const added = nextSelected.find((opt) => !prev.includes(opt));
+        if (removed) {
+          announcement = `${removed.textContent.trim()}, not selected`;
+        } else if (added) {
+          announcement = `${added.textContent.trim()}, selected`;
+        }
+      } else {
+        announcement = `${this.menu.currentLabel}, selected`;
+      }
+
+      // Delay so the utterance isn't overridden by VoiceOver's "collapsed"
+      // announcement from aria-expanded when the dropdown closes.
+      if (announcement) {
+        const announcementDelay = 300;
+        setTimeout(() => {
+          announceToScreenReader(this._getAnnouncementRoot(), announcement);
+        }, announcementDelay);
+      }
     });
   }
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -643,14 +643,48 @@ export class AuroSelect extends AuroElement {
       this.dropdown.dropdownWidth = this.customBibWidth;
     }
 
-    // Pass label text to the dropdown bib for accessible dialog naming
-    const labelElement = this.querySelector('span[slot="label"]');
-    if (labelElement) {
-      this.dropdown.bibDialogLabel = labelElement.textContent.trim() || undefined;
-    }
+    this._syncLabelText();
 
     // Exposes the CSS parts from the dropdown for styling
     this.dropdown.exposeCssParts();
+  }
+
+  /**
+   * Reads the current label slot text and pushes it to the dropdown bib
+   * (for dialog naming) and the menu (for listbox aria-label). Safe to call
+   * before either child has been wired up — each branch self-guards.
+   * @private
+   */
+  _syncLabelText() {
+    const labelElement = this.querySelector('[slot="label"]');
+    const text = labelElement ? labelElement.textContent.trim() : '';
+    if (this.dropdown) {
+      this.dropdown.bibDialogLabel = text || undefined;
+    }
+    if (this.menu) {
+      if (text) {
+        this.menu.setAttribute('aria-label', text);
+      } else {
+        this.menu.removeAttribute('aria-label');
+      }
+    }
+  }
+
+  /**
+   * Keeps the dialog/menu accessible names in sync when consumers mutate the
+   * label slot at runtime (e.g., i18n locale swap). `slotchange` alone is
+   * insufficient — it doesn't fire when textContent of an already-assigned
+   * slotted node changes, which is the common case.
+   * @private
+   */
+  _observeLabelChanges() {
+    if (this._labelObserver) return;
+    this._labelObserver = new MutationObserver(() => this._syncLabelText());
+    this._labelObserver.observe(this, {
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
   }
 
   /**
@@ -803,11 +837,7 @@ export class AuroSelect extends AuroElement {
     this.updateMenuShapeSize();
     this.setMenuValue(this.value);
 
-    // Set accessible name on the menu for screen readers based on the label slot content
-    const labelElement = this.querySelector('[slot="label"]');
-    if (labelElement) {
-      this.menu.setAttribute('aria-label', labelElement.textContent.trim());
-    }
+    this._syncLabelText();
 
     if (this.multiSelect) {
       this.menu.multiSelect = this.multiSelect;
@@ -1132,6 +1162,10 @@ export class AuroSelect extends AuroElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._clearTypeaheadBuffer();
+    if (this._labelObserver) {
+      this._labelObserver.disconnect();
+      this._labelObserver = null;
+    }
   }
 
   // lifecycle runs only after the element's DOM has been updated the first time
@@ -1142,6 +1176,7 @@ export class AuroSelect extends AuroElement {
     this.configureDropdown();
     this.configureMenu();
     this.configureSelect();
+    this._observeLabelChanges();
   }
 
   setMenuValue(value) {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1273,21 +1273,8 @@ export class AuroSelect extends AuroElement {
     if (!selectedOption) return;
     const selectedValue = selectedOption.value;
 
-    if (this.multiSelect) {
-      const currentArray = this.menu.value || [];
-
-      if (!currentArray.includes(selectedValue)) {
-        this.value = JSON.stringify([
-          ...currentArray,
-          selectedValue
-        ]);
-      }
-    } else {
-      const currentValue = this.value;
-
-      if (currentValue !== selectedValue) {
-        this.value = selectedValue;
-      }
+    if (this.value !== selectedValue) {
+      this.value = selectedValue;
     }
   }
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1006,6 +1006,7 @@ export class AuroSelect extends AuroElement {
       }
     }
 
+    // Intentional: no-match leaves the bib closed (deviates from APG / some native <select>).
     if (match) {
       if (!this.dropdown.isPopoverVisible) {
         this.dropdown.show();

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1342,6 +1342,12 @@ export class AuroSelect extends AuroElement {
    * @private
    */
   _handleNativeSelectChange(event) {
+    // Hidden native <select> has no `multiple` attribute, so any change it fires
+    // is a single raw value — applying it in multiSelect mode would collapse the
+    // JSON-array `value` shape. Bfcache/autofill can reach this on a name-bearing
+    // form control even with aria-hidden/tabindex=-1.
+    if (this.multiSelect) return;
+
     const selectedOption = event.target.options[event.target.selectedIndex];
     if (!selectedOption) return;
     const selectedValue = selectedOption.value;

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -852,11 +852,13 @@ export class AuroSelect extends AuroElement {
         this.dropdown.setActiveDescendant(this.optionActive);
       }
 
-      // Announce the active option for screen readers
-      if (this.optionActive) {
+      // Announce the active option for screen readers. Skip when the activated
+      // option is already selected: Enter triggers an auroMenu-selectedOption
+      // re-announce, and aria-selected on the active descendant otherwise
+      // conveys state without an explicit utterance.
+      if (this.optionActive && !this.optionActive.hasAttribute('selected')) {
         const optionText = this.optionActive.textContent.trim();
-        const selectedState = this.optionActive.hasAttribute('selected') ? ', selected' : ', not selected';
-        announceToScreenReader(this._getAnnouncementRoot(), `${optionText}${selectedState}`);
+        announceToScreenReader(this._getAnnouncementRoot(), `${optionText}, not selected`);
       }
 
       if (this.dropdown.isPopoverVisible) {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -990,17 +990,20 @@ export class AuroSelect extends AuroElement {
 
     this.typeaheadBuffer += key;
 
-    const isRepeatedChar = this.typeaheadBuffer.length > 1 && new Set(this.typeaheadBuffer).size === 1;
+    // Prefer the literal buffer as a prefix per WAI-ARIA APG ("focus moves to the
+    // next item with a name that starts with the string of characters typed").
+    // Only fall back to single-char cycling when the repeated buffer has no
+    // longer prefix match — e.g. "aa" cycles through ["Apple", "Apricot"] only
+    // because no option starts with "aa".
+    let match = options.find((option) => this._getOptionDisplayText(option).startsWith(this.typeaheadBuffer));
 
-    let match = null;
+    const isRepeatedChar = !match && this.typeaheadBuffer.length > 1 && new Set(this.typeaheadBuffer).size === 1;
     if (isRepeatedChar) {
       const matches = options.filter((option) => this._getOptionDisplayText(option).startsWith(key));
       if (matches.length) {
         const cycleIndex = (this.typeaheadBuffer.length - 1) % matches.length;
         match = matches[cycleIndex];
       }
-    } else {
-      match = options.find((option) => this._getOptionDisplayText(option).startsWith(this.typeaheadBuffer));
     }
 
     if (match) {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1008,10 +1008,14 @@ export class AuroSelect extends AuroElement {
 
     // Intentional: no-match leaves the bib closed (deviates from APG / some native <select>).
     if (match) {
+      // Pre-stash the match so the auroDropdown-toggled handler's `!optionActive`
+      // guard short-circuits and skips the firstActive/selected fallback —
+      // otherwise show() synchronously fires the handler, which writes
+      // aria-activedescendant once before we overwrite it.
+      this.menu.updateActiveOption(match);
       if (!this.dropdown.isPopoverVisible) {
         this.dropdown.show();
       }
-      this.menu.updateActiveOption(match);
     }
   }
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -357,14 +357,6 @@ export class AuroSelect extends AuroElement {
       },
 
       /**
-       * @private
-       */
-      options: {
-        type: Array,
-        state: true
-      },
-
-      /**
        * Specifies the current selected menuOption. Default type is `HTMLElement`, changing to `Array<HTMLElement>` when `multiSelect` is true.
        * @type {HTMLElement|Array<HTMLElement>}
        */
@@ -827,16 +819,19 @@ export class AuroSelect extends AuroElement {
     if (typeof this.menu.initItems === 'function') {
       this.menu.initItems();
     }
-    this.options = this.menu.options;
     this.updateOptionPositions();
+    // renderNativeSelect reads this.menu.options, which the parent doesn't
+    // observe — request an update so the hidden native <option> list reflects
+    // the menu's options after initItems populates them.
+    this.requestUpdate();
 
-    // Keep aria-setsize/aria-posinset (and the cached options reference) in sync
-    // when the menu re-initializes its items — e.g., slotchange, async/lazy loads,
-    // value-triggered re-init. Without this, stale set-size is announced after
-    // dynamic option mutations.
+    // Keep aria-setsize/aria-posinset (and the native <option> list) in sync
+    // when the menu re-initializes its items — e.g., slotchange, async/lazy
+    // loads, value-triggered re-init. Without this, stale set-size is
+    // announced and the native select goes stale after dynamic mutations.
     this.menu.addEventListener('auroMenu-optionsChange', () => {
-      this.options = this.menu.options;
       this.updateOptionPositions();
+      this.requestUpdate();
     });
 
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -888,7 +888,16 @@ export class AuroSelect extends AuroElement {
       // conveys state without an explicit utterance.
       if (this.optionActive && !this.optionActive.hasAttribute('selected')) {
         const optionText = this.optionActive.textContent.trim();
-        announceToScreenReader(this._getAnnouncementRoot(), `${optionText}, not selected`);
+        const message = `${optionText}, not selected`;
+        if (this.dropdown.isPopoverVisible) {
+          announceToScreenReader(this._getAnnouncementRoot(), message);
+        } else {
+          // Typeahead-on-closed fires this event before `show()` flips
+          // isPopoverVisible. Defer so the announcement targets the bib's
+          // live region once the fullscreen <dialog> opens — otherwise it
+          // lands in the host root, which is inert under the active modal.
+          queueMicrotask(() => announceToScreenReader(this._getAnnouncementRoot(), message));
+        }
       }
 
       if (this.dropdown.isPopoverVisible) {

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -674,16 +674,34 @@ export class AuroSelect extends AuroElement {
    * Keeps the dialog/menu accessible names in sync when consumers mutate the
    * label slot at runtime (e.g., i18n locale swap). `slotchange` alone is
    * insufficient — it doesn't fire when textContent of an already-assigned
-   * slotted node changes, which is the common case.
+   * slotted node changes, which is the common case. We scope the observer to
+   * the label node itself (not the whole host subtree) so option-content
+   * mutations don't trigger label re-syncs, and re-target on `slotchange`
+   * when consumers add or replace the label element.
    * @private
    */
   _observeLabelChanges() {
     if (this._labelObserver) return;
     this._labelObserver = new MutationObserver(() => this._syncLabelText());
-    this._labelObserver.observe(this, {
-      childList: true,
-      subtree: true,
-      characterData: true
+
+    const retarget = () => {
+      this._labelObserver.disconnect();
+      const labelElement = this.querySelector('[slot="label"]');
+      if (labelElement) {
+        this._labelObserver.observe(labelElement, {
+          childList: true,
+          subtree: true,
+          characterData: true
+        });
+      }
+      this._syncLabelText();
+    };
+
+    retarget();
+
+    this._retargetLabelObserver = retarget;
+    this.shadowRoot.querySelectorAll('slot[name="label"]').forEach((slot) => {
+      slot.addEventListener('slotchange', retarget);
     });
   }
 
@@ -1174,6 +1192,12 @@ export class AuroSelect extends AuroElement {
     if (this._labelObserver) {
       this._labelObserver.disconnect();
       this._labelObserver = null;
+    }
+    if (this._retargetLabelObserver && this.shadowRoot) {
+      this.shadowRoot.querySelectorAll('slot[name="label"]').forEach((slot) => {
+        slot.removeEventListener('slotchange', this._retargetLabelObserver);
+      });
+      this._retargetLabelObserver = null;
     }
   }
 

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -58,10 +58,14 @@ export const selectKeyboardStrategy = {
     if (!lastOption) {
       return;
     }
+    // Pre-stash before show() so the auroDropdown-toggled handler's
+    // `!optionActive` guard short-circuits the firstActive/selected fallback —
+    // otherwise show() synchronously fires the handler and writes
+    // aria-activedescendant once before we overwrite it.
+    component.menu.updateActiveOption(lastOption);
     if (!ctx.isExpanded) {
       component.dropdown.show();
     }
-    component.menu.updateActiveOption(lastOption);
   },
 
   Enter(component, evt, ctx) {
@@ -85,10 +89,11 @@ export const selectKeyboardStrategy = {
     if (!firstOption) {
       return;
     }
+    // See End() for why this must run before show().
+    component.menu.updateActiveOption(firstOption);
     if (!ctx.isExpanded) {
       component.dropdown.show();
     }
-    component.menu.updateActiveOption(firstOption);
   },
 
   Tab(component, evt, ctx) {

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -64,6 +64,10 @@ export const selectKeyboardStrategy = {
   },
 
   Enter(component, evt, ctx) {
+    // Prevent the keypress from bubbling to parent containers (e.g., forms)
+    // which could interpret Enter as a submit. Matches APG select-only combobox
+    // and native <select> behavior: Enter opens the listbox when closed, selects
+    // the active option when open — it does not submit a parent form.
     evt.preventDefault();
     evt.stopPropagation();
     if (!ctx.isExpanded) {

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -51,16 +51,17 @@ export const selectKeyboardStrategy = {
   },
 
   End(component, evt, ctx) {
-    if (!ctx.isExpanded) {
-      return;
-    }
     evt.preventDefault();
     evt.stopPropagation();
     // `pop()` is safe here: getEnabledOptions returns a fresh filtered array.
     const lastOption = getEnabledOptions(component.menu).pop();
-    if (lastOption) {
-      component.menu.updateActiveOption(lastOption);
+    if (!lastOption) {
+      return;
     }
+    if (!ctx.isExpanded) {
+      component.dropdown.show();
+    }
+    component.menu.updateActiveOption(lastOption);
   },
 
   Enter(component, evt, ctx) {
@@ -78,15 +79,16 @@ export const selectKeyboardStrategy = {
   },
 
   Home(component, evt, ctx) {
-    if (!ctx.isExpanded) {
-      return;
-    }
     evt.preventDefault();
     evt.stopPropagation();
     const [firstOption] = getEnabledOptions(component.menu);
-    if (firstOption) {
-      component.menu.updateActiveOption(firstOption);
+    if (!firstOption) {
+      return;
     }
+    if (!ctx.isExpanded) {
+      component.dropdown.show();
+    }
+    component.menu.updateActiveOption(firstOption);
   },
 
   Tab(component, evt, ctx) {

--- a/components/select/test/MANUAL_TESTING.md
+++ b/components/select/test/MANUAL_TESTING.md
@@ -22,6 +22,8 @@
 [ ] Space on the focused trigger — verify the bib opens
 [ ] Arrow Down — verify the bib opens and visual focus moves to the first option
 [ ] Arrow Up — verify the bib opens and visual focus moves to the last option
+[ ] Home — verify the bib opens and visual focus moves to the first option
+[ ] End — verify the bib opens and visual focus moves to the last option
 [ ] Tab away from the trigger — verify focus moves to the next focusable element (standard browser behavior)
 
 ## Keyboard Interactions — Desktop (Popup Open)

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -148,6 +148,31 @@ function runTest(mobileView) {
           expect(el.bibtemplate.shadowRoot.activeElement).to.equal(closeBtn);
         });
       }
+
+      it('keeps menu event listeners wired after a disconnect+reconnect cycle', async () => {
+        // Regression guard against the tempting "fix" of removing the listeners
+        // configureMenu() attaches in disconnectedCallback. Lit's firstUpdated
+        // runs once per instance, so listeners stripped on disconnect would
+        // never be re-attached on reconnect — optionActive, value, and
+        // announcement plumbing would silently break when the host is moved
+        // in the DOM (e.g., reparented inside a dialog or SPA route swap).
+        const el = await defaultFixture();
+        const parent = el.parentNode;
+        const firstOption = el.menu.querySelector('auro-menuoption[value="Apples"]');
+        const secondOption = el.menu.querySelector('auro-menuoption[value="Oranges"]');
+
+        el.menu.dispatchEvent(new CustomEvent('auroMenu-activatedOption', { detail: firstOption }));
+        await elementUpdated(el);
+        await expect(el.optionActive).to.equal(firstOption);
+
+        parent.removeChild(el);
+        parent.appendChild(el);
+        await elementUpdated(el);
+
+        el.menu.dispatchEvent(new CustomEvent('auroMenu-activatedOption', { detail: secondOption }));
+        await elementUpdated(el);
+        await expect(el.optionActive, 'menu listeners must survive a disconnect+reconnect cycle').to.equal(secondOption);
+      });
     });
 
     describe('Properties', () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3038,6 +3038,79 @@ function runTest(mobileView) {
             await expect(dropdown.isPopoverVisible).to.be.false;
           });
         }
+
+        // Per APG and native <select>, Enter must open the listbox when closed
+        // and select the active option when open — it must not bubble to a
+        // parent <form> (or auro-form's keydown listener) and trigger submit.
+        // See selectKeyboardStrategy.js Enter handler.
+        describe('does not bubble to parent form on Enter', () => {
+          it('should stop propagation when opening the bib from closed', async () => {
+            const wrapper = await fixture(html`
+              <form @submit=${(e) => e.preventDefault()}>
+                <auro-select>
+                  <span slot="bib.fullscreen.headline">Bib Headline</span>
+                  <span slot="label">Name</span>
+                  <auro-menu>
+                    <auro-menuoption value="Apples">Apples</auro-menuoption>
+                    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+                  </auro-menu>
+                </auro-select>
+              </form>
+            `);
+            const el = wrapper.querySelector('auro-select');
+            await elementUpdated(el);
+
+            let bubbledEnterCount = 0;
+            wrapper.addEventListener('keydown', (e) => {
+              if (e.key === 'Enter') bubbledEnterCount += 1;
+            });
+
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            await expect(dropdown.isPopoverVisible).to.be.false;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await elementUpdated(el);
+
+            await expect(bubbledEnterCount).to.equal(0);
+            await expect(dropdown.isPopoverVisible).to.be.true;
+          });
+
+          it('should stop propagation when selecting an option from open', async () => {
+            const wrapper = await fixture(html`
+              <form @submit=${(e) => e.preventDefault()}>
+                <auro-select>
+                  <span slot="bib.fullscreen.headline">Bib Headline</span>
+                  <span slot="label">Name</span>
+                  <auro-menu>
+                    <auro-menuoption value="Apples">Apples</auro-menuoption>
+                    <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+                  </auro-menu>
+                </auro-select>
+              </form>
+            `);
+            const el = wrapper.querySelector('auro-select');
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            const trigger = dropdown.querySelector('[slot="trigger"]');
+
+            trigger.click();
+            await elementUpdated(el);
+            await expect(dropdown.isPopoverVisible).to.be.true;
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            await elementUpdated(el);
+
+            let bubbledEnterCount = 0;
+            wrapper.addEventListener('keydown', (e) => {
+              if (e.key === 'Enter') bubbledEnterCount += 1;
+            });
+
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await elementUpdated(el);
+
+            await expect(bubbledEnterCount).to.equal(0);
+            await expect(el.value).to.equal('Oranges');
+          });
+        });
       });
 
       describe('Escape', () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1953,24 +1953,6 @@ function runTest(mobileView) {
         await expect(el.isHiddenWhileLoading).to.be.false;
       });
 
-      // ─── _handleNativeSelectChange multiSelect adds value ────────────
-      it('_handleNativeSelectChange adds selected value in multiSelect mode', async () => {
-        const el = await multiSelectFixture();
-        await elementUpdated(el);
-
-        // Create a mock native select change event
-        const fakeSelect = document.createElement('select');
-        const option = document.createElement('option');
-        option.value = 'Apples';
-        fakeSelect.appendChild(option);
-        fakeSelect.selectedIndex = 0;
-
-        el._handleNativeSelectChange({ target: fakeSelect });
-        await elementUpdated(el);
-
-        await expect(el.value).to.include('Apples');
-      });
-
       // ─── renderLayout emphasized-left ────────────────────────────────
       it('renderLayout returns emphasized template for emphasized-left', async () => {
         const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1464,6 +1464,51 @@ function runTest(mobileView) {
         el.menu = savedMenu;
       });
 
+      // ─── aria-setsize/posinset re-stamp on dynamic option changes ────
+      it('re-stamps aria-setsize/aria-posinset when menu options change at runtime', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        const menu = el.querySelector('auro-menu');
+
+        // Baseline: defaultFixture has 4 options, all stamped at init.
+        let options = menu.querySelectorAll('auro-menuoption');
+        expect(options).to.have.lengthOf(4);
+        options.forEach((opt, i) => {
+          expect(opt.getAttribute('aria-setsize')).to.equal('4');
+          expect(opt.getAttribute('aria-posinset')).to.equal(String(i + 1));
+        });
+
+        // Append a new option after init — auro-menu's slotchange will
+        // re-run initItems() and dispatch auroMenu-optionsChange, which
+        // auro-select must hook to re-stamp position attributes.
+        const extra = document.createElement('auro-menuoption');
+        extra.setAttribute('value', 'Mangoes');
+        extra.textContent = 'Mangoes';
+        menu.appendChild(extra);
+        await elementUpdated(menu);
+        await elementUpdated(el);
+
+        options = menu.querySelectorAll('auro-menuoption');
+        expect(options).to.have.lengthOf(5);
+        options.forEach((opt, i) => {
+          expect(opt.getAttribute('aria-setsize')).to.equal('5');
+          expect(opt.getAttribute('aria-posinset')).to.equal(String(i + 1));
+        });
+
+        // Remove an option — counts and positions should refresh again.
+        options[0].remove();
+        await elementUpdated(menu);
+        await elementUpdated(el);
+
+        options = menu.querySelectorAll('auro-menuoption');
+        expect(options).to.have.lengthOf(4);
+        options.forEach((opt, i) => {
+          expect(opt.getAttribute('aria-setsize')).to.equal('4');
+          expect(opt.getAttribute('aria-posinset')).to.equal(String(i + 1));
+        });
+      });
+
       // ─── updateMenuShapeSize with no menu early return ───────────────
       it('updateMenuShapeSize returns early when menu is null', async () => {
         const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1712,6 +1712,24 @@ function runTest(mobileView) {
         expect(el.value).to.equal(originalValue);
       });
 
+      // ─── _handleNativeSelectChange no-ops in multiSelect mode ──
+      it('_handleNativeSelectChange does not corrupt JSON-array value in multiSelect mode', async () => {
+        const el = await multiSelectFixture();
+        el.value = JSON.stringify(['Apples', 'Bananas']);
+        await elementUpdated(el);
+
+        // Simulate a browser autofill/bfcache change on the hidden native <select>
+        el._handleNativeSelectChange({
+          target: {
+            options: [{ value: 'Cherries' }],
+            selectedIndex: 0
+          }
+        });
+
+        // multiSelect value shape must remain a JSON-stringified array
+        expect(el.value).to.equal(JSON.stringify(['Apples', 'Bananas']));
+      });
+
       // ─── renderNativeSelect falls back to textContent when option has no value ──
       it('renderNativeSelect uses textContent when option.value is empty', async () => {
         const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3675,6 +3675,31 @@ function runTest(mobileView) {
           await expect(el.menu.optionActive.textContent.trim()).to.equal('Apricot');
         });
 
+        it('should prefer a multi-character prefix over single-char cycling when buffer matches an option', async () => {
+          // Repeated-char cycling must not override a longer prefix match.
+          // Typing "aa" with "Aardvark" present should land on Aardvark, not cycle past it to Anchor.
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="aardvark">Aardvark</auro-menuoption>
+                <auro-menuoption value="anchor">Anchor</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+          await elementUpdated(el);
+          await expect(el.menu.optionActive.value).to.equal('aardvark');
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+          await elementUpdated(el);
+          await expect(el.menu.optionActive.value).to.equal('aardvark');
+        });
+
         it('should do nothing if there is no matching option for the pressed key', async () => {
           const el = await fixture(html`
             <auro-select>

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2214,6 +2214,22 @@ function runTest(mobileView) {
           expect(menu.getAttribute('aria-label')).to.equal(labelSlot.textContent.trim());
         }
       });
+
+      it('updates menu aria-label and dropdown bibDialogLabel when label text mutates at runtime', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        const menu = el.querySelector('auro-menu');
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const label = el.querySelector('[slot="label"]');
+
+        label.textContent = 'Updated label';
+        // MutationObserver callbacks flush as microtasks; elementUpdated awaits the next Lit cycle.
+        await elementUpdated(el);
+
+        expect(menu.getAttribute('aria-label')).to.equal('Updated label');
+        expect(dropdown.bibDialogLabel).to.equal('Updated label');
+      });
     });
 
     describe('Mouse Behavior', () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3448,6 +3448,32 @@ function runTest(mobileView) {
           await expect(el.value).to.not.be.undefined;
         });
 
+        // Per WAI-ARIA APG select-only combobox, Tab on an open listbox must
+        // perform the default action (advance focus to the next tabbable).
+        // Adding preventDefault() here would violate the spec and trap focus
+        // on the trigger. Synthetic keydown events don't trigger native focus
+        // traversal in the test runner, so we assert the invariant directly:
+        // the handler must leave defaultPrevented === false.
+        it('should not preventDefault on Tab — preserves native focus advancement', async () => {
+          const el = await defaultFixture();
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+          const trigger = dropdown.querySelector('[slot="trigger"]');
+
+          trigger.click();
+          await elementUpdated(el);
+          await expect(dropdown.isPopoverVisible).to.be.true;
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+          await elementUpdated(el);
+
+          const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+          el.dispatchEvent(tabEvent);
+          await elementUpdated(el);
+
+          await expect(tabEvent.defaultPrevented).to.be.false;
+          await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+
         if (mobileView) {
           it('should close the fullscreen dialog', async () => {
             const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2163,6 +2163,23 @@ function runTest(mobileView) {
           expect(liveRegion.textContent).to.equal('');
         });
 
+        it('should not announce activation of an already-selected option', async () => {
+          const el = await presetValueFixture();
+          await elementUpdated(el);
+
+          const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
+          liveRegion.textContent = '';
+
+          // Opening the bib auto-activates the pre-selected option. Without the
+          // guard, the activatedOption handler would announce ", selected" here,
+          // then Enter would re-announce the same text 300ms later.
+          el.showBib();
+          await waitUntil(() => el.dropdown.isPopoverVisible);
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+
+          expect(liveRegion.textContent).to.equal('');
+        });
+
         if (mobileView) {
           it('should route announcements to the bib live region in fullscreen mode', async () => {
             const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -149,6 +149,29 @@ function runTest(mobileView) {
         });
       }
 
+      it('keeps label observation wired after a disconnect+reconnect cycle', async () => {
+        // Regression guard: _observeLabelChanges() is invoked from firstUpdated(),
+        // which Lit fires once per instance. disconnectedCallback() tears down
+        // both _labelObserver and the slotchange retarget listener; without a
+        // matching connectedCallback hook, runtime label mutations after a
+        // reparent would silently stop syncing menu aria-label and
+        // dropdown.bibDialogLabel.
+        const el = await defaultFixture();
+        const parent = el.parentNode;
+        const label = el.querySelector('[slot="label"]');
+
+        parent.removeChild(el);
+        parent.appendChild(el);
+        await elementUpdated(el);
+
+        label.textContent = 'Updated label';
+        await new Promise((r) => requestAnimationFrame(r));
+        await elementUpdated(el);
+
+        expect(el.menu.getAttribute('aria-label'), 'menu aria-label must re-sync after reconnect').to.equal('Updated label');
+        expect(el.dropdown.bibDialogLabel, 'dropdown bibDialogLabel must re-sync after reconnect').to.equal('Updated label');
+      });
+
       it('keeps menu event listeners wired after a disconnect+reconnect cycle', async () => {
         // Regression guard: the listeners configureMenu() attaches must NOT be torn
         // down in disconnectedCallback. configureMenu() runs from firstUpdated(),

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3125,6 +3125,24 @@ function runTest(mobileView) {
           const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
           await expect(el.optionActive).to.equal(lastOption);
         });
+
+        // Regression guard: pressing End while collapsed must produce exactly one
+        // auroMenu-activatedOption dispatch. show() synchronously fires
+        // auroDropdown-toggled, whose handler will set a fallback active option
+        // unless updateActiveOption is called first. See selectKeyboardStrategy.End.
+        it('should dispatch auroMenu-activatedOption exactly once when opening via End', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          const menu = el.querySelector('auro-menu');
+          let count = 0;
+          menu.addEventListener('auroMenu-activatedOption', () => { count += 1; });
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+          await elementUpdated(el);
+
+          await expect(count).to.equal(1);
+        });
       });
 
       describe('Enter', () => {
@@ -3490,6 +3508,21 @@ function runTest(mobileView) {
           const menu = el.querySelector('auro-menu');
           const firstOption = menu.querySelector('auro-menuoption[value="Apples"]');
           await expect(el.optionActive).to.equal(firstOption);
+        });
+
+        // Regression guard: see matching test under End — same double-dispatch risk.
+        it('should dispatch auroMenu-activatedOption exactly once when opening via Home', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          const menu = el.querySelector('auro-menu');
+          let count = 0;
+          menu.addEventListener('auroMenu-activatedOption', () => { count += 1; });
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+          await elementUpdated(el);
+
+          await expect(count).to.equal(1);
         });
       });
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2180,6 +2180,59 @@ function runTest(mobileView) {
           expect(liveRegion.textContent).to.equal('');
         });
 
+        it('should announce "not selected" when a multiSelect option is deselected', async () => {
+          const el = await presetMultiSelectFixture();
+          await elementUpdated(el);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          await elementUpdated(el);
+
+          el.showBib();
+          await waitUntil(() => el.dropdown.isPopoverVisible);
+
+          const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
+          liveRegion.textContent = '';
+
+          // Toggle "Price" off — currentLabel will collapse to "Duration", so the
+          // pre-fix code would falsely announce "Duration, selected" here.
+          const menu = el.querySelector('auro-menu');
+          const priceOption = menu.querySelector('auro-menuoption[value="price"]');
+          priceOption.click();
+          await elementUpdated(menu);
+          await elementUpdated(el);
+
+          // Announcement is dispatched via setTimeout(300) inside the
+          // selectedOption handler, then routed through a rAF in
+          // announceToScreenReader.
+          await new Promise((resolve) => setTimeout(resolve, 350));
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+
+          expect(liveRegion.textContent).to.equal('Price, not selected');
+        });
+
+        it('should announce "selected" with the added option when a multiSelect option is added', async () => {
+          const el = await presetMultiSelectFixture();
+          await elementUpdated(el);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          await elementUpdated(el);
+
+          el.showBib();
+          await waitUntil(() => el.dropdown.isPopoverVisible);
+
+          const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
+          liveRegion.textContent = '';
+
+          const menu = el.querySelector('auro-menu');
+          const stopsOption = menu.querySelector('auro-menuoption[value="stops"]');
+          stopsOption.click();
+          await elementUpdated(menu);
+          await elementUpdated(el);
+
+          await new Promise((resolve) => setTimeout(resolve, 350));
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+
+          expect(liveRegion.textContent).to.equal('Stops, selected');
+        });
+
         if (mobileView) {
           it('should route announcements to the bib live region in fullscreen mode', async () => {
             const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3901,6 +3901,38 @@ function runTest(mobileView) {
           await expect(el.dropdown.isPopoverVisible).to.be.true;
         });
 
+        it('should not flash an intermediate active option when type-ahead opens the bib', async () => {
+          // Regression guard for the race where dropdown.show() synchronously
+          // fires auroDropdown-toggled, whose handler would set firstActive
+          // BEFORE the type-ahead match overrides it — producing a transient
+          // aria-activedescendant write. The fix calls updateActiveOption(match)
+          // before show() so the handler's `!optionActive` guard short-circuits.
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="apple">Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+          await elementUpdated(el);
+          el.dropdown.hide();
+          await elementUpdated(el);
+
+          const activations = [];
+          el.menu.addEventListener('auroMenu-activatedOption', (e) => {
+            activations.push(e.detail);
+          });
+
+          el.updateActiveOptionBasedOnKey('b');
+          await elementUpdated(el);
+
+          expect(activations.length).to.equal(1);
+          expect(activations[0].value).to.equal('banana');
+        });
+
         it('should ignore non-printable keys', async () => {
           const el = await defaultFixture();
           await elementUpdated(el);

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -150,12 +150,12 @@ function runTest(mobileView) {
       }
 
       it('keeps menu event listeners wired after a disconnect+reconnect cycle', async () => {
-        // Regression guard against the tempting "fix" of removing the listeners
-        // configureMenu() attaches in disconnectedCallback. Lit's firstUpdated
-        // runs once per instance, so listeners stripped on disconnect would
-        // never be re-attached on reconnect — optionActive, value, and
-        // announcement plumbing would silently break when the host is moved
-        // in the DOM (e.g., reparented inside a dialog or SPA route swap).
+        // Regression guard: the listeners configureMenu() attaches must NOT be torn
+        // down in disconnectedCallback. configureMenu() runs from firstUpdated(),
+        // which Lit fires once per instance, so any listener removed on disconnect
+        // would never be re-wired on reconnect — optionActive, value, and
+        // announcement plumbing would silently break when the host is moved in the
+        // DOM (e.g., reparented into a dialog or SPA route swap).
         const el = await defaultFixture();
         const parent = el.parentNode;
         const firstOption = el.menu.querySelector('auro-menuoption[value="Apples"]');

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3706,6 +3706,28 @@ function runTest(mobileView) {
           await expect(el.menu.optionActive).to.equal(previousActive);
         });
 
+        it('should leave a closed bib closed when no option matches the pressed key', async () => {
+          // Intentional deviation from WAI-ARIA APG / some native <select> implementations:
+          // a printable keystroke with no matching option must NOT open the bib.
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="apple">Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+          await expect(el.dropdown.isPopoverVisible).to.be.false;
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }));
+          await elementUpdated(el);
+
+          await expect(el.dropdown.isPopoverVisible).to.be.false;
+        });
+
         it('should loop through matching options when the same key is pressed repeatedly', async () => {
           const el = await fixture(html`
             <auro-select>

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2998,7 +2998,7 @@ function runTest(mobileView) {
           await expect(el.optionActive).to.equal(undefined);
         });
 
-        it('should do nothing while the bib is collapsed', async () => {
+        it('should open the bib and move to the last enabled option while collapsed', async () => {
           const el = await defaultFixture();
 
           await elementUpdated(el);
@@ -3009,7 +3009,11 @@ function runTest(mobileView) {
           el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
           await elementUpdated(el);
 
-          await expect(dropdown.isPopoverVisible).to.be.false;
+          await expect(dropdown.isPopoverVisible).to.be.true;
+
+          const menu = el.querySelector('auro-menu');
+          const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
+          await expect(el.optionActive).to.equal(lastOption);
         });
       });
 
@@ -3360,7 +3364,7 @@ function runTest(mobileView) {
           await expect(el.optionActive).to.equal(undefined);
         });
 
-        it('should do nothing while the bib is collapsed', async () => {
+        it('should open the bib and move to the first enabled option while collapsed', async () => {
           const el = await defaultFixture();
 
           await elementUpdated(el);
@@ -3371,7 +3375,11 @@ function runTest(mobileView) {
           el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
           await elementUpdated(el);
 
-          await expect(dropdown.isPopoverVisible).to.be.false;
+          await expect(dropdown.isPopoverVisible).to.be.true;
+
+          const menu = el.querySelector('auro-menu');
+          const firstOption = menu.querySelector('auro-menuoption[value="Apples"]');
+          await expect(el.optionActive).to.equal(firstOption);
         });
       });
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1509,6 +1509,31 @@ function runTest(mobileView) {
         });
       });
 
+      // ─── native <option> list re-renders on dynamic option changes ───
+      it('re-renders the hidden native select when menu options change at runtime', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        const menu = el.querySelector('auro-menu');
+        const nativeSelect = el.shadowRoot.querySelector('.nativeSelectWrapper select');
+
+        // Baseline: defaultFixture has 4 options, none of them Cherries.
+        expect(nativeSelect.querySelector('option[value="Cherries"]')).to.be.null;
+
+        // Append a new option. auro-menu's slotchange fires auroMenu-optionsChange,
+        // which auro-select hooks via requestUpdate() so renderNativeSelect re-stamps
+        // the hidden <option> list. Without that requestUpdate the native select
+        // would go stale, breaking form submission with dynamic options.
+        const extra = document.createElement('auro-menuoption');
+        extra.setAttribute('value', 'Cherries');
+        extra.textContent = 'Cherries';
+        menu.appendChild(extra);
+        await elementUpdated(menu);
+        await elementUpdated(el);
+
+        expect(nativeSelect.querySelector('option[value="Cherries"]')).to.not.be.null;
+      });
+
       // ─── updateMenuShapeSize with no menu early return ───────────────
       it('updateMenuShapeSize returns early when menu is null', async () => {
         const el = await defaultFixture();

--- a/context/keyboard-spec.md
+++ b/context/keyboard-spec.md
@@ -193,6 +193,8 @@ The trade-off: intercepted keys must have their native behaviors manually re-imp
 | **Space** | Opens the listbox | APG select-only combobox |
 | **Down Arrow** | Opens the listbox, moves visual focus to first option | APG select-only combobox |
 | **Up Arrow** | Opens the listbox, moves visual focus to last option | APG select-only combobox |
+| **Home** | Opens the listbox, moves visual focus to first option | APG select-only combobox |
+| **End** | Opens the listbox, moves visual focus to last option | APG select-only combobox |
 | **Tab** | Moves focus to next focusable element on the page (standard browser behavior) | APG select-only combobox |
 
 ### Desktop — Popup Open


### PR DESCRIPTION
# `auro-select` - Adversarial Bug Fixes for RC #1484 

# P0 — Fix before merge

## ❌ P0-1. Enter handler swallows native form submission when bib is closed

**File:** `components/select/src/selectKeyboardStrategy.js:66-74`

Verified: `preventDefault()` and `stopPropagation()` run on line `67-68` before the `!ctx.isExpanded` branch. Inside a `<form>`, pressing Enter on a closed combobox no longer triggers form submit — the key is consumed unconditionally to open the bib.

**Fix:** Move `evt.preventDefault(); evt.stopPropagation();` into each branch (only call them when expanded, or when opening from closed state if you want to suppress form submit only then).

```
❌ Why the feedback is wrong:
  - context/keyboard-spec.md:188-196 explicitly specifies: when closed, Enter opens the listbox — sourced to the APG select-only combobox pattern.
  - The WAI-ARIA APG reference implementation also intercepts Enter to open the listbox; it does not submit. 
  - Native <select> similarly does not submit the form on Enter — it opens the popup.
  - auro-combobox does exactly the same thing on purpose, with an explicit comment at comboboxKeyboardStrategy.js:121-124 justifying it.
  - auro-select is not a form-associated custom element (no ElementInternals/formAssociated), so the only way Enter could submit a form is via auro-form's keydown
  listener (auro-form.js:733-748) — and stopPropagation() is exactly what stops it. That's the intended interaction.
  
What I changed:
  - Added a comment to selectKeyboardStrategy.js:66-74 mirroring combobox's, so the next reviewer doesn't file the same finding.
  - Added a test
```

# P1 — Real a11y gaps; address this sprint

## ✅ P1-1. Missing aria-haspopup="listbox" on the combobox trigger

**File:** `components/dropdown/src/auro-dropdown.js:1199-1210`

Verified: `grep` confirms `aria-haspopup` does not appear anywhere in `auro-dropdown.js`. The trigger sets `role`, `aria-expanded`, `aria-controls`, `aria-labelledby`, `aria-disabled` — but the WAI-ARIA APG select-only combobox pattern requires `aria-haspopup="listbox"` so VoiceOver announces "pop-up listbox" on focus.

**Fix:** Add `aria-haspopup="${ifDefined(this.a11yRole === 'combobox' ? 'listbox' : undefined)}"` to the trigger in `renderBasicHtml`.

**Scope note:** This is a dropdown-level gap, not introduced by this PR — but since the select PR locks in the combobox pattern, fixing it here is appropriate.

```
✅ Three-agent consensus:
  1. Code agent — confirmed aria-haspopup is absent from auro-dropdown.js, and auro-select sets a11yRole='combobox' on the dropdown.
  2. Spec agent — flagged that role="combobox" has an implicit aria-haspopup="listbox" per ARIA 1.2, so the missing attribute is not a true conformance gap.
  3. Tiebreaker agent — confirmed the canonical W3C APG select-only example explicitly sets aria-haspopup="listbox" despite the implicit default, to avoid relying on UA
   implicit-value mapping.
   
  Verdict: Fix is appropriate, though the feedback's "VoiceOver requires it" framing overstates the case. The real justification is matching the W3C reference
  implementation.

  Changes:
  - components/dropdown/src/auro-dropdown.js:1206 — added aria-haspopup="${ifDefined(this.a11yRole === 'combobox' ? 'listbox' : undefined)}" to the trigger.
  - components/dropdown/test/auro-dropdown.test.js — added two tests asserting the attribute is set when a11yRole='combobox' and absent on the default button role.

  Dropdown: 348/348 passing, 100% coverage. Select: 454/454 passing, 100% coverage.
```

## ❌ P1-2. Tab handler does not preventDefault; relies on async trigger refocus

**File:** `components/select/src/selectKeyboardStrategy.js:88-99`

Verified: Tab → `menu.makeSelection()` → `dropdown.hide()`. No `preventDefault`. Native Tab bubbles, browser advances focus to the next tabbable. Meanwhile `restoreTriggerAfterClose` (`auro-select.js:584`) only runs for fullscreen-bib mode, and `dropdown-toggled` listener (`auro-select.js:621-624`) only refocuses trigger inside a `setTimeout(0)` in non-fullscreen.

**Risk:** Real risk that focus jumps past the trigger on Tab+select.

**Fix:** Call `evt.preventDefault()` and synchronously refocus trigger, or explicitly advance focus to the next tabbable.

```
❌ Why the feedback is wrong
  
  The reviewer's premise — that focus should stay on the trigger — contradicts the spec.

  APG Select-Only Combobox (spec) defines Tab on an open listbox as three explicit actions:

  1. Set value to the focused option
  2. Close the listbox
  3. Perform the default action, moving focus to the next focusable element

  The APG reference implementation also does NOT call preventDefault() on Tab. Calling it would violate the spec.

  Verified by code trace

  In popover (non-fullscreen) mode:
  - Tab handler runs synchronously: makeSelection() → dropdown.hide()
  - dropdown.hide() does not move focus (popover never moved focus into the bib; aria-activedescendant pattern keeps focus on trigger)
  - restoreTriggerAfterClose is fullscreen-only (correctly skipped)
  - setTimeout(() => trigger.focus()) is gated on isPopoverVisible === true (open path only, doesn't fire on close)
  - Browser's native Tab default then advances focus past the trigger to the next tabbable — exactly as APG requires

  The "race" the feedback worries about doesn't exist: nothing schedules an async refocus on close in popover mode.

  Confirmed by existing tests + docs

  - components/select/test/auro-select.test.js:3351-3483 covers Tab: closes bib, selects active option, works in multiSelect
  - components/select/demo/keyboardBehavior.md:158-178 explicitly documents: "the page will also navigate to the next focusable element in the tabindex sequence"
  - All 454 tests pass; the no-preventDefault behavior is intentional

  Recommendation

  Reject the P1-2 finding. The current implementation matches APG spec, matches native <select> behavior, matches the APG reference implementation, and matches the
  documented design intent. Adding preventDefault() + sync trigger refocus would be a regression.

  What I did

  - Added a test to assert behavior
```

## ✅ P1-3. aria-setsize/aria-posinset only set once at init

**File:** `components/select/src/auro-select.js:831` (`updateOptionPositions()` called once in `configureMenu`)

Verified: No `slotchange` or `auroMenu-loadingChange` re-trigger of `updateOptionPositions`. Dynamic option lists (lazy loading, filtering, async fetches) leave stale set-size announcements.

**Fix:** Listen on the default slot's `slotchange` or hook into `handleMenuLoadingChange` (line `1021`) to re-run `updateOptionPositions()`.

```
✅ Bug is real: updateOptionPositions() was only called once at init (line 831). No re-trigger on slotchange, async load, or any dynamic option mutation.
  aria-setsize/aria-posinset go stale.
  - Reviewer's suggested hooks are suboptimal:
    - slotchange on default slot: that slot lives in auro-menu's shadow DOM, not auro-select's — auro-select can't observe it directly.
    - handleMenuLoadingChange: only fires when a loading state transition happens; misses sync option swaps and filter-based mutations.
  - Better hook: auroMenu-optionsChange is dispatched by initItems() (auro-menu.js:642) on every path that rebuilds the items list. Single subscription covers all
  cases; no feedback loop (attribute mutations on slotted children don't refire slotchange).
  
Also refreshed this.options = this.menu.options in the same handler since that cached reference was going stale alongside.

Added new tests
```

# P2 — Code hygiene; fix while you're in here

## ✅ P2-1. this.options is dead state after the pre-5.9 revert

**File:** `components/select/src/auro-select.js:830, 362-365`

Verified: `this.options = this.menu.options` is set once in `configureMenu`. `updateOptionPositions` reads `this.menu.options` directly (line `770`); `renderNativeSelect` reads `this.menu.options` directly (line `1321`). No code reads `this.options`.

**Fix:** Delete the property and the assignment, or wire it to `slotchange` if a reactive snapshot is genuinely needed.

```
✅ The original feedback was partially wrong. Both subagents independently confirmed that:
  - this.options is never read anywhere (true)
  - It's marked @private and not part of the public API (true)
  - There were actually two assignments, not one — line 830 in configureMenu and line 838 in the auroMenu-optionsChange listener

  But it was not dead state. The reactive state: true property declaration meant each assignment triggered a Lit re-render — and renderNativeSelect reads
  this.menu.options directly to build the hidden <select>'s <option> list. Without that implicit re-render trigger, the native select rendered with empty options on
  first paint, breaking native↔component value sync (caught by auro-select.test.js:954).

  Fix applied (components/select/src/auro-select.js):
  - Deleted the options property declaration (lines 362-365)
  - Replaced both this.options = this.menu.options assignments with explicit this.requestUpdate() calls
  - Updated the comments to explain that the update is for the native <option> list, not just aria attributes
  - Added new test assertion

  This makes the re-render intent explicit instead of hidden behind a phantom property assignment.
```

## ❌ P2-2. Menu event listeners are never detached

**File:** `components/select/src/auro-select.js:832, 834, 843, 862`

Verified: `configureMenu` attaches four `addEventListener` calls with anonymous arrow functions. `disconnectedCallback` (line `1117-1120`) only clears the type-ahead buffer — no listener removal. Confirmed by `grep -n removeEventListener auro-select.js` returning no matches.

**Risk:** Leak in SPA scenarios where the `auro-menu` instance outlives the host or is reparented. Not regressed by this PR — but the revert reintroduces the direct-listener pattern, so worth closing now.

**Fix:** Store bound handler references, remove them in `disconnectedCallback`.

```
❌ The finding is a false positive (or at most EDGE_CASE_ONLY) — and the proposed fix would silently break the component
   on reparent.

  Why it's not a real leak

  - this.menu is a light-DOM child queried via querySelector('auro-menu, [auro-menu]') (line 790). When <auro-select> is removed, the child <auro-menu> goes with it.
  The listener closure forms a cycle (menu → closure → host → menu), but mark-and-sweep GC collects unreachable cycles fine.
  - firstUpdated is the only caller of configureMenu (the setTimeout retry at 794-797 early-returns before any addEventListener). Lit runs firstUpdated exactly once per
   instance — no double-attach race.
  - Same pattern is used in auro-combobox.js and auro-calendar.js without cleanup — it's the codebase convention.

  Why the proposed fix is actively unsafe

  The reviewer reading lifecycle semantics caught this: if we add removeEventListener calls to disconnectedCallback, then on a DOM move (e.g., <auro-select> lives
  inside a dialog that gets reparented), the listeners get stripped — but firstUpdated/configureMenu never re-run on reconnect, so the component becomes silently
  broken: no activated-option announcements, stale aria-setsize, no selection handling.

  A correct fix would need to also re-attach in connectedCallback (gated on hasUpdated) using an AbortController per connection. That's a bigger change than P2-2
  describes, and there's no evidence anyone has hit the edge case (an external consumer pulling the <auro-menu> out of the <auro-select> and keeping it alive).

  Recommendation

  Don't apply this fix. Push back on P2-2 in the review — it's a false positive, and the naive fix (the exact one described: "store bound handler references, remove
  them in disconnectedCallback") would regress accessibility on reparent. If you want to defensively guard the exotic reparent-the-slotted-menu case, that's a separate,
   larger change (connect/disconnect lifecycle with AbortController), and probably wants to be applied to auro-combobox at the same time for consistency.

What I did

  - Added a test to assert expected behavior

```

# P3 — Nits / spec deviations to document, not fix

## ✅ P3-1. Duplicate "selected" announcement on Enter against already-selected option

**File:** `components/select/src/auro-select.js:843-855, 862-889`

Verified: Confirmed narrow case. On bib open, `auroMenu-activatedOption` fires for the pre-selected option → announces "X, selected". If user then presses Enter to confirm, `makeSelection` (`auro-menu.js:819-822`) takes the re-select branch → `notifySelectionChange` → `auroMenu-selectedOption` → 300ms later announces "X, selected" again. Outside this narrow flow, the two paths don't collide because `handleSelectState` does not call `updateActiveOption`. Lower-priority than my first pass suggested.

**Fix (optional):** Skip the `activatedOption` announce when the activated option is already selected, since the selection announce will cover it.

```
✅ Verified the bug — the duplicate is real.

  Flow:
  1. Bib opens → auroMenu-activatedOption fires for pre-selected option → announces "X, selected" (auro-select.js:858-859)
  2. User presses Enter → makeSelection re-select branch in auro-menu.js:822 calls notifySelectionChange → auroMenu-selectedOption → 300ms later announces "X, selected"
   again (auro-select.js:891-892)
   
  Fix — components/select/src/auro-select.js:855-862. Guard the activatedOption announcement when the option is already selected. aria-activedescendant + aria-selected
  continue to convey state for navigation; the Enter path's selection announce is the authoritative "selected" utterance.

  Test — components/select/test/auro-select.test.js: new regression test opens a presetValueFixture and asserts the live region stays empty after the bib opens onto the
   pre-selected option.
```

## ✅ P3-2. Type-ahead repeated-char cycling conflicts with multi-letter prefix

**File:** `components/select/src/auro-select.js:986`

Verified: `new Set(this.typeaheadBuffer).size === 1` correctly detects all-same-char buffer. Edge: typing `"aa"` when both `"Aardvark"` and `"Anchor"` exist as options cycles by single-char instead of treating `"aa"` as a prefix matching only `"Aardvark"`. APG says cycle only when no longer prefix matches.

```
✅ Bug confirmed:
  - APG spec agent: Spec language ("focus moves to the next item with a name that starts with the string of characters typed") and the APG reference implementation
  treat the buffer as a literal prefix. Cycle-on-repeated-char is a Windows convention, not APG.
  - Code verification agent: Walked the buffer state — typing 'a' then 'a' with [Aardvark, Anchor] does land on Anchor, not Aardvark. No existing test covers the case.

  Fix at components/select/src/auro-select.js:993: prefix match runs unconditionally first; the repeated-char cycle only fires when the buffer has no longer prefix
  match. The existing Apple/Apricot/Avocado cycle test still passes because no option starts with aa/aaa/aaaa, so the cycle fallback engages as before.

  New test at components/select/test/auro-select.test.js: Aardvark + Anchor fixture asserts that "aa" stays on Aardvark instead of cycling to Anchor.
```

## ✅ P3-3. _handleNativeSelectChange multiselect branch operates on string menu.value

**File:** `components/select/src/auro-select.js:1261-1282`

Verified: Post-revert, `this.menu.value` for multiselect is a JSON string (per `auro-menu.js:662`). `currentArray = this.menu.value || []` then `.includes()` does substring matching on a JSON string; the spread `[...currentArray, selectedValue]` would spread JSON characters. However: `renderNativeSelect` (line `1311-1331`) does not set the `multiple` attribute on the native `<select>`, so the multiselect branch is effectively unreachable through the native element. Dead-code bug.

**Fix (optional):** Remove the multiselect branch, or hold it correct against the string-valued `menu.value`.

```
✅ Bug Confirmed

  Both subagents confirmed the finding independently:
  - menu.value for multiselect is a JSON string (per auro-menu.js:662) — .includes() would substring-match, spread would explode JSON chars
  - renderNativeSelect (now lines 1306-1331) never sets multiple on the <select>, so the multiselect branch in _handleNativeSelectChange is unreachable through any real
   code path
  - The existing test only passed because menu.value was undefined, never exercising the broken logic

  Fix applied (components/select/src/auro-select.js:1271-1279):
  - Removed the dead multiselect branch entirely
  - Collapsed the single-select path — _handleNativeSelectChange now just syncs the single selected value
  - Removed the stale test that exercised the dead branch

  Chose removal over "fix it correctly" because adding real multiselect support to the hidden native fallback (the alternative agent 2 proposed) is a feature expansion,
   not a bug fix — and the native <select> is just an a11y/form-submission fallback.
```

## ✅ P3-4. Type-ahead doesn't open bib on no-match

**File:** `components/select/src/auro-select.js:999-1003`

Verified: `dropdown.show()` only runs when `match` is truthy. Documented behavior at `docs/partials/keyboard-behavior/keyEvents.md:212`. Native `<select>` opens regardless; this is an intentional deviation.

**Action:** Add to spec-deviation list in `keyboard-spec.md` memory if not already there.

```
✅ Confirmed, intentional

- Added a one line code comment
- Added a test to assert
```

## ✅ P3-5. Home/End collapsed → no-op

**File:** `components/select/src/selectKeyboardStrategy.js:54-56, 77-79`

Verified: Both return early when `!ctx.isExpanded`. APG suggests they should open + move to first/last.

**Action:** Spec-deviation entry.

```
✅ Verified: Two subagents (APG spec lookup + native <select> behavior research) converged — APG's select-only combobox example explicitly defines Home/End on a
  collapsed combobox as "Opens the listbox and moves visual focus to the first/last option." Native macOS <select> does nothing, but auro-select tracks APG. The
  early-return no-op was a real spec deviation with no UX justification (unlike the type-ahead no-match case, where opening an empty bib would be useless — here there
  are options to navigate to).

  Fix applied:
  - components/select/src/selectKeyboardStrategy.js:53-77 — Home() and End() now call dropdown.show() when collapsed, then set optionActive to first/last enabled
  option.
  - Tests updated (auro-select.test.js:3001-3017, 3363-3380) — two should do nothing while bib is collapsed tests rewritten to assert the new APG behavior. All 466
  select tests pass.
  - Docs updated: components/select/docs/partials/keyboard-behavior/keyEvents.md (added Collapsed rows for Home/End), context/keyboard-spec.md (added Home/End to
  "Desktop — Popup Closed" table), components/select/test/MANUAL_TESTING.md.

Testing

On Mac laptops with shorter keyboards, testing can be done using:

  - Home = Fn + ←
  - End = Fn + →
```

## ❌ P3-6. No PageUp/PageDown handlers

**File:** `components/select/src/selectKeyboardStrategy.js` (no `PageUp`/`PageDown` keys)

Verified: Strategy map has no entries; falls to default which only handles Space + printable; non-printable `PageUp`/`PageDown` are filtered out by `updateActiveOptionBasedOnKey`'s length-1 guard (`auro-select.js:959`).

**Action:** Spec-deviation entry.

```
❌ Verified the claim: components/select/src/selectKeyboardStrategy.js has no entries for PageUp/PageDown. The default branch only special-cases Space; everything else
  forwards to updateActiveOptionBasedOnKey(), where the _key.length !== 1 guard at components/select/src/auro-select.js:966 drops any multi-character key name. Net
  effect: keystroke is swallowed — no announcement, no movement.

  Decision: leave as-is. Per the WAI-ARIA APG combobox pattern, PageUp/PageDown are not listed in the Listbox Popup keyboard interactions at all (they only appear in
  the Grid Popup variant, where they're optional). Omitting them in a listbox-backed select is fully spec-compliant — this is not a gap, it's a non-feature. Already
  documented as unsupported in components/select/demo/keyboardBehavior.md (lines 14–18) and absent from the docs/partials/keyboard-behavior/keyEvents.md table, so
  end-user docs are accurate.
```

## ✅ P3-7. Race when type-ahead opens bib from closed state

**File:** `components/select/src/auro-select.js:592-602` vs `999-1003`

Verified: When type-ahead triggers `dropdown.show()` (line `1001`), the `auroDropdown-toggled` handler (line `592-602`) sets the first-enabled or selected option as active before line `1003` overrides with the type-ahead match. Net result is correct (match wins), but a brief AT misfire is possible.

**Fix (optional):** Pre-stash desired active before `show()`, or have `show()` accept an initial-active hint.

```
✅ Verified — race is real. Sub-agent consensus (after resolving disagreement by reading floatingUI.mjs:783-801):

  - dropdown.show() → floater.showBib() → dispatchEventDropdownToggle() calls element.dispatchEvent(event) synchronously
  - So at auro-select.js:1012 the auroDropdown-toggled handler runs inside show(), synchronously writes aria-activedescendant to firstActive/selected, then line 1014
  overwrites with the type-ahead match
  - Live-region announceToScreenReader rAF-coalesces, but aria-activedescendant is set twice and some ATs (NVDA) can pick up the transient

  Fix applied at components/select/src/auro-select.js:1010-1018: moved updateActiveOption(match) before dropdown.show(). The guard at line 585 (if 
  (!this.menu.optionActive)) now short-circuits and the toggled handler skips its fallback. One write, one event.
```

## ✅ P3-8. Label slot discovery is non-reactive

**File:** `components/select/src/auro-select.js:655-658, 815-818`

Verified: `bibDialogLabel` and menu `aria-label` are read once at `configureDropdown`/`configureMenu`. Runtime swaps of label content don't propagate.

**Fix (optional):** `MutationObserver` on the label slot.

```
✅ Verified and fixed.

  - configureDropdown (line 647) and configureMenu (line 807) read the label slot exactly once during firstUpdated. No slotchange listener, MutationObserver, or other
  reactive mechanism exists for the label.
  - The downstream chain IS reactive: auro-dropdown.bibDialogLabel is a Lit property bound to the bib's <span id="dialogLabel">, and aria-label on the menu is a plain
  attribute. So reassigning works — only the upstream source wasn't.
  - Impact is real but narrow: i18n locale swaps or dynamic relabeling leave VoiceOver/dialog and listbox aria-label stale.

  Fix applied to components/select/src/auro-select.js:
  1. Extracted a _syncLabelText() helper used by both configureDropdown and configureMenu. Also fixed the pre-existing selector mismatch (span[slot="label"] →
  [slot="label"]) and removes aria-label cleanly when the label is empty (ARIA-correct).
  2. Added _observeLabelChanges() — a MutationObserver on the host with childList + subtree + characterData. Chose MutationObserver over slotchange because slotchange
  doesn't fire on textContent mutation of an already-assigned slotted node — the common i18n case.
  3. Wired observer setup in firstUpdated and teardown in disconnectedCallback.

  Test added at auro-select.test.js:2218 — mutates label textContent at runtime and asserts both menu aria-label and dropdown.bibDialogLabel update without manually
  re-calling configure methods. Passes.

  Test run: 462/464 pass on the branch with the fix. The 2 failures (announceToScreenReader populate/clear live region) are pre-existing — confirmed by stashing my
  changes and reproducing 460/462 with the same 2 failures. Unrelated to this change.
```

## Summary by Sourcery

Align auro-select and auro-dropdown keyboard and accessibility behavior with WAI-ARIA APG, and add regression coverage for previously reported a11y and keyboard interaction issues.

Bug Fixes:
- Ensure Home and End on a collapsed auro-select open the bib and move focus to the first/last enabled option in accordance with APG.
- Prevent Enter key events on auro-select from bubbling to parent forms so Enter opens/selects in the listbox rather than submitting.
- Keep aria-setsize and aria-posinset values in sync when auro-menu options change dynamically, and ensure the hidden native select stays in sync with menu options.
- Avoid duplicate live-region announcements when activating an already-selected option and ensure announcements target the correct live region when opening fullscreen bibs.
- Resolve a race where type-ahead opening the bib could briefly activate a non-matching option before the actual match.
- Keep dropdown/menu accessible names in sync when the label slot text changes at runtime via a mutation observer.

Enhancements:
- Prefer multi-character type-ahead prefixes over single-character cycling, only falling back to repeated-character cycling when no longer prefix match exists.
- Intentionally keep the bib closed when type-ahead has no match, and document this deviation from native/APG behavior.
- Maintain auro-select menu event listeners across disconnect/reconnect cycles to preserve behavior when the element is moved in the DOM.
- Simplify native select change handling by removing dead multiselect-specific code that could never run correctly.

Documentation:
- Update keyboard behavior documentation and spec to describe Home and End behavior for collapsed and expanded auro-select.
- Extend manual testing documentation to cover Home and End interactions on the collapsed trigger.

Tests:
- Add regression tests for Enter key handling with parent forms, Tab behavior on open lists, Home/End behavior when collapsed, type-ahead prefix vs cycling, type-ahead no-match behavior, and the type-ahead/bib-open race.
- Add tests ensuring aria-setsize/aria-posinset and the hidden native select options update on dynamic menu option changes.
- Add tests verifying label text mutations propagate to menu aria-label and dropdown bibDialogLabel.
- Add tests confirming auro-select menu listeners survive disconnect/reconnect and that activation of an already-selected option does not trigger duplicate announcements.
- Add tests validating aria-haspopup='listbox' is rendered when auro-dropdown is used as a combobox and omitted for the default button role.

----

Also adds a fix for Counter where Chromium-based browsers were failing at `:focus-within` causing dropdowns would auto-close.