### PR TITLE
fix(datepicker): improve focus handling on grid to prevent activeCell…

### DIFF
--- a/components/datepicker/src/auro-calendar.js
+++ b/components/datepicker/src/auro-calendar.js
@@ -537,10 +537,23 @@ export class AuroCalendar extends RangeDatepicker {
   /**
    * Shows the activeCell ring when the grid gains focus.
    * @private
+   * @param {FocusEvent} [event] - The focusin event.
    * @returns {void}
    */
-  handleGridFocusIn() {
+  handleGridFocusIn(event) {
     this._gridHasFocus = true;
+
+    // Only apply the activeCell ring when the grid wrapper itself receives focus
+    // (Tab/programmatic). When focus moves into a cell button via mousedown,
+    // event.target is the cell descendant — skip the ring here. The subsequent
+    // click handler calls setActiveCell on the clicked cell, which applies the
+    // ring there. Without this guard, mousedown briefly flashes the ring on the
+    // previously-active cell (e.g. the 1st-of-month set by month navigation
+    // when the grid was not focused).
+    if (event && event.target !== event.currentTarget) {
+      return;
+    }
+
     const activeCell = this.getAllFocusableCells().find((cell) => cell.active);
     if (activeCell) {
       const btn = activeCell._cachedButton || activeCell.shadowRoot.querySelector('button.day');

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -7216,6 +7216,49 @@ function runFullTest(mobileView) {
       });
     });
 
+    describe('handleGridFocusIn descendant guard', () => {
+      // Regression: when focusin bubbles to the grid from a cell descendant
+      // (mousedown on a cell button), the previously-active cell must not
+      // receive the activeCell ring. Before the guard, this caused the ring
+      // to flash on the stale active cell (e.g. the 1st-of-month set by
+      // month navigation while the grid was unfocused) on mousedown, before
+      // the click handler moved it to the clicked cell.
+      it('should not add activeCell ring when focusin bubbles from a cell descendant', async () => {
+        const el = await fixture(html`<auro-datepicker centralDate="2024-01-15" value="2024-01-15"></auro-datepicker>`);
+
+        const input = getInput(el, 0);
+        input.click();
+        await elementUpdated(el);
+        await nextFrame();
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
+        const activeCell = calendar.getAllFocusableCells().find((cell) => cell.active);
+        expect(activeCell).to.exist;
+
+        const activeBtn = activeCell._cachedButton || activeCell.shadowRoot.querySelector('button.day');
+        expect(activeBtn).to.exist;
+
+        // Simulate the post-month-nav state: the active cell data is set, but
+        // the ring is not applied because the grid was not focused.
+        activeBtn.classList.remove('activeCell');
+        calendar._gridHasFocus = false;
+
+        // Dispatch focusin from a non-active cell host so the event bubbles
+        // to the grid div with event.target retargeted to a descendant — the
+        // shape of focusin produced by a mousedown on a cell button.
+        const otherCell = calendar.getAllFocusableCells().find((cell) => cell !== activeCell);
+        expect(otherCell).to.exist;
+        otherCell.dispatchEvent(new Event('focusin', { bubbles: true, composed: true }));
+        await nextFrame();
+
+        // Guard must prevent the ring from being applied to the stale active cell.
+        expect(activeBtn.classList.contains('activeCell')).to.be.false;
+        // _gridHasFocus still flips so a subsequent setActiveCell (from click) can apply the ring.
+        expect(calendar._gridHasFocus).to.be.true;
+      });
+    });
+
     describe('disconnectedCallback cleanup', () => {
       // Verify 'disconnectedCallback cleanup' cleans up timers and live region on disconnect.
       it('should clean up timers and live region on disconnect', async () => {


### PR DESCRIPTION
… ring flash

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Prevent the active cell focus ring from briefly flashing on the previously active date when clicking into the calendar grid.