### PR TITLE
fix(select): typeahead/multiSelect interaction bugs

### DIFF
--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1093,6 +1093,13 @@ export class AuroSelect extends AuroElement {
         const cycleIndex = (this.typeaheadBuffer.length - 1) % matches.length;
         match = matches[cycleIndex];
       }
+    } else if (!match && this.typeaheadBuffer.length > 1) {
+      // Buffer has no prefix match and isn't a repeat-char cycle (e.g. "a" then
+      // "b" against [Apple, Banana]). Reset to just the new key and retry —
+      // mirrors native <select>, which falls back to a single-char search when
+      // accumulated input matches nothing, rather than swallowing the keystroke.
+      this.typeaheadBuffer = key;
+      match = options.find((option) => this._getOptionDisplayText(option).startsWith(key));
     }
 
     // Intentional: no-match leaves the bib closed (deviates from APG / some native <select>).

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -885,6 +885,14 @@ export class AuroSelect extends AuroElement {
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));
 
     this.menu.addEventListener("auroMenu-selectValueFailure", () => {
+      // Menu dispatches this from two paths: a programmatic value mismatch
+      // (menu pre-clears its own optionSelected to undefined before firing)
+      // and a click on an unselected valueless option (menu leaves state
+      // untouched). Only mirror the clear in the first case — otherwise a
+      // valueless click in multiSelect would wipe every prior pick.
+      if (this.menu.optionSelected !== undefined) {
+        return;
+      }
       this.value = undefined;
       this.optionSelected = this.multiSelect ? [] : undefined;
       // The trigger label is rendered imperatively into #value, so a property

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -4231,6 +4231,22 @@ function runTest(mobileView) {
           await expect(el.menu.optionActive).to.equal(beforeActive);
         });
 
+        it('should fall back to the latest key when the accumulated buffer prefix-matches nothing', async () => {
+          // Fast "a" then "b" against [Apples, Oranges, Bananas]
+          // built buffer "ab", which prefix-matched nothing and failed the
+          // repeat-char gate, so the keystroke was silently dropped. Native
+          // <select> falls back to the latest key — jump to Bananas.
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          el.updateActiveOptionBasedOnKey('a');
+          el.updateActiveOptionBasedOnKey('b');
+          await elementUpdated(el);
+
+          await expect(el.menu.optionActive.value).to.equal('Bananas');
+          expect(el.typeaheadBuffer).to.equal('b');
+        });
+
         it('should not open a closed dropdown when no match is found', async () => {
           const el = await defaultFixture();
           await elementUpdated(el);

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -558,6 +558,36 @@ function runTest(mobileView) {
           await expect(el.optionSelected.length).to.equal(0);
         });
 
+        it('should not wipe prior selections when a valueless option is clicked', async () => {
+          // Regression: menu fires auroMenu-selectValueFailure on a click of an
+          // unselected valueless option without mutating its own state. The
+          // select listener used to unconditionally clear value/optionSelected,
+          // dropping every prior multiSelect pick on a single bad click.
+          const el = await fixture(html`
+            <auro-select multiselect>
+              <span slot="label">Pick</span>
+              <auro-menu>
+                <auro-menuoption value="a">Alpha</auro-menuoption>
+                <auro-menuoption value="b">Beta</auro-menuoption>
+                <auro-menuoption>NoValue</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+          await elementUpdated(el);
+
+          const opts = el.querySelectorAll('auro-menuoption');
+          opts[0].click();
+          await elementUpdated(el);
+          opts[1].click();
+          await elementUpdated(el);
+          expect(el.optionSelected.length).to.equal(2);
+
+          opts[2].click(); // valueless -> selectValueFailure
+          await elementUpdated(el);
+
+          expect(el.optionSelected.length, 'valueless click must not clear prior selections').to.equal(2);
+        });
+
         it('should not leak external mutation of select.optionSelected back into menu state', async () => {
           // Regression: select.optionSelected must be a cloned array in multiselect
           // mode so consumers mutating it cannot reach back into menu.optionSelected

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -575,14 +575,18 @@ function runTest(mobileView) {
           `);
           await elementUpdated(el);
 
+          const menu = el.querySelector('auro-menu');
           const opts = el.querySelectorAll('auro-menuoption');
           opts[0].click();
+          await elementUpdated(menu);
           await elementUpdated(el);
           opts[1].click();
+          await elementUpdated(menu);
           await elementUpdated(el);
           expect(el.optionSelected.length).to.equal(2);
 
           opts[2].click(); // valueless -> selectValueFailure
+          await elementUpdated(menu);
           await elementUpdated(el);
 
           expect(el.optionSelected.length, 'valueless click must not clear prior selections').to.equal(2);


### PR DESCRIPTION
## Summary
  - **MultiSelect clear on valueless click (TI.2):** `auroMenu-selectValueFailure` unconditionally cleared `value`/`optionSelected`, so clicking a valueless option in multiSelect
  mode wiped every prior pick. Now early-returns when `menu.optionSelected` is still defined, so only the real programmatic-mismatch path clears state.

  - **Typeahead dead-end (T1.3):** Pressing two distinct non-prefix letters within `typeaheadTimeoutMs` (e.g. `a` + `b` on `[Apples, Oranges, Bananas]`) built buffer
  `"ab"`, prefix-matched nothing, failed the repeat-char gate, and silently swallowed the keystroke. Now falls back to the latest key — matches native `<select>`.

  ## Test plan
- [x] `npm test --workspace=components/select` — 486 passed
- [x] Manual typeahead: on `apiExamples/basic.html`, set `typeaheadTimeoutMs="2000"` in devtools, press `s` + `d` → focus lands on **Duration**
- [x] Manual multiSelect: on `apiExamples/multi-select.html`, pick two options, then click a valueless option → prior picks remain selected
- [x] Existing prefix matching (`ap` → Apples), repeat-cycle (`a`,`a`,`a`), and single-key non-match (`z`) unchanged

## Original Bug as Reported

````
### T1.2 — `selectValueFailure` wipes the entire multiSelect selection (select)
- **Where:** `components/select/src/auro-select.js:887-894`; menu dispatch at `components/menu/src/auro-menu.js:831-841`.
- **Why it breaks:** Old select listened to `auroMenu-deselectPrevented` → `hideBib()` only. New select listens to `auroMenu-selectValueFailure` and sets `value = undefined; optionSelected = multiSelect ? [] : undefined`. The menu fires `selectValueFailure` when an unselected option with empty/undefined `value` is toggled.
- **Symptom:** In multiSelect, clicking a valueless option clears **all** previously selected options (data loss).
- **Verdict:** CONFIRMED.
**Try it on the demo page** — `npm run dev --workspace=components/select`
```html
<auro-select multiselect>
  <span slot="label">Pick options (multiselect)</span>
  <auro-menu>
    <auro-menuoption value="a">Alpha</auro-menuoption>
    <auro-menuoption value="b">Beta</auro-menuoption>
    <auro-menuoption>No Value option</auro-menuoption>
  </auro-menu>
</auro-select>
```
- **Do:** open, check **Alpha** and **Beta** (the trigger shows both), then click **No Value option**.
- **Expected:** Alpha/Beta stay selected; the valueless option simply doesn't get added.
- **Bug:** every selection clears — the trigger empties.
- **Console confirm:** read `document.querySelector('auro-select').optionSelected` before vs. after clicking the valueless option.
**Automated check (WTR):**
```js
it('valueless multiselect option does not wipe existing selections', async () => {
  const el = await fixture(html`
    <auro-select multiselect><span slot="label">Pick</span>
      <auro-menu>
        <auro-menuoption value="a">Alpha</auro-menuoption>
        <auro-menuoption value="b">Beta</auro-menuoption>
        <auro-menuoption>NoValue</auro-menuoption>
      </auro-menu>
    </auro-select>`);
  await elementUpdated(el);
  const opts = el.querySelectorAll('auro-menuoption');
  opts[0].click(); await elementUpdated(el);
  expect(el.optionSelected.length).to.equal(1);
  opts[2].click(); await elementUpdated(el); // valueless → selectValueFailure
  expect(el.optionSelected.length).to.equal(1); // RED on rc/1484 (becomes 0)
});
```
### T1.3 — Typeahead dead-ends on two fast different letters (select)
- **Where:** `components/select/src/auro-select.js:1072-1088`.
- **Why it breaks:** Buffer accumulates every keystroke; pressing `a` then `b` within the timeout makes buffer `"ab"`. `find(startsWith("ab"))` matches nothing and the repeat-cycle gate `new Set("ab").size === 1` is false → no match, no jump. Old code matched the single current letter, so it always jumped.
- **Symptom:** Fast typing of two distinct non-prefix letters does nothing; native `<select>` jumps to the last letter.
- **Verdict:** CONFIRMED.
**Try it on the demo page** — `npm run dev --workspace=components/select`
```html
<auro-select>
  <span slot="label">Fruit</span>
  <auro-menu>
    <auro-menuoption value="apple">Apple</auro-menuoption>
    <auro-menuoption value="banana">Banana</auro-menuoption>
  </auro-menu>
</auro-select>
```
- **Do:** focus the trigger and press **a** then **b** quickly (<0.5s). Then redo it pressing **a**, waiting ~1s, then **b**.
- **Expected (native `<select>`):** the **b** keypress jumps to Banana.
- **Bug:** the fast `a`+`b` stays on Apple; the slow version jumps to Banana — proving it's the buffer timing, not key handling.
````

## Summary by Sourcery

Fix select typeahead and multiselect interaction regressions and add regression tests.

Bug Fixes:
- Prevent multiselect selections from being cleared when clicking a valueless option that triggers auroMenu-selectValueFailure.
- Ensure typeahead falls back to the latest key when the accumulated buffer has no prefix match, aligning behavior with native select elements.

Tests:
- Add regression tests covering valueless multiselect option clicks and typeahead fallback behavior when buffered input fails to match any option.

## Summary by Sourcery

Resolve regressions in select multiSelect behavior and typeahead navigation to align with expected user interactions.

Bug Fixes:
- Prevent multiselect selections from being cleared when clicking a valueless option that triggers a select value failure event.
- Ensure typeahead falls back to the latest key when buffered input fails to prefix-match any option, matching native select behavior.

Tests:
- Add regression tests covering valueless multiselect option clicks to verify existing selections are preserved.
- Add regression tests for typeahead fallback when an accumulated key buffer fails to match any options.