### PR TITLE
refactor: correctly set range classes when changing months

### DIFF
--- a/components/datepicker/src/auro-calendar-cell.js
+++ b/components/datepicker/src/auro-calendar-cell.js
@@ -762,6 +762,41 @@ export class AuroCalendarCell extends LitElement {
     btn.classList.remove('inRange', 'lastHoveredDate', 'rangeDepartDate');
   }
 
+  /**
+   * Re-applies the committed-range classes (inRange / rangeDepartDate /
+   * rangeReturnDate) imperatively from the cell's current `day`,
+   * `dateFrom`, and `dateTo`. Used after month navigation flushes:
+   * classMap in `renderCellButton` tracks its own previous state, so a
+   * preceding imperative `classList.remove` (from
+   * `clearRangePreviewClasses`) leaves classMap thinking the class is
+   * still applied. On re-render with the same class-value, classMap emits
+   * no delta and the class stays missing in the DOM. Re-toggling
+   * imperatively resyncs the DOM with the committed range.
+   *
+   * Delegates to the same `isInRange` / `isDepartDate` / `isReturnDate`
+   * helpers `renderCellButton` uses, so the two code paths cannot drift
+   * (including whatever timestamp normalization those helpers apply).
+   * @returns {void}
+   */
+  applyCommittedRangeClasses() {
+    if (!this.day) return;
+    // Fall back to a shadowRoot query when `_cachedButton` hasn't
+    // populated yet — this method's whole job is recovering from stale
+    // DOM after a month re-render, so no-oping on a cache miss defeats
+    // the fix (mirrors the fallback in `clearActive()`).
+    const btn = this._cachedButton || this.shadowRoot?.querySelector('button.day');
+    if (!btn) return;
+
+    const hasRange = this.datepicker?.hasAttribute('range');
+    const inRange = hasRange && this.dateTo && this.isInRange(this.day, this.dateFrom, this.dateTo);
+    const isDepart = hasRange && this.isDepartDate(this.day, this.dateFrom) && this.dateTo;
+    const isReturn = hasRange && this.isReturnDate(this.day, this.dateFrom, this.dateTo);
+
+    btn.classList.toggle('inRange', Boolean(inRange));
+    btn.classList.toggle('rangeDepartDate', Boolean(isDepart));
+    btn.classList.toggle('rangeReturnDate', Boolean(isReturn));
+  }
+
   renderCellButton() {
     const outOfRange = this.isOutOfRange(this.day, this.min, this.max);
     const blackout = this.isBlackout();

--- a/components/datepicker/src/auro-calendar.js
+++ b/components/datepicker/src/auro-calendar.js
@@ -307,6 +307,11 @@ export class AuroCalendar extends RangeDatepicker {
     if (!opts.skipActiveUpdate) {
       this.updateActiveCellForVisibleMonth();
     }
+    // clearRangePreview above strips classMap-managed range classes from
+    // the DOM; classMap's private state still thinks they're applied, so
+    // it won't re-add them on the post-nav re-render. Re-apply imperatively
+    // after both months and their cell button caches have settled.
+    this.scheduleCommittedRangeClassRefresh();
     this.announceMonthChange();
   }
 
@@ -325,6 +330,11 @@ export class AuroCalendar extends RangeDatepicker {
     if (!opts.skipActiveUpdate) {
       this.updateActiveCellForVisibleMonth();
     }
+    // clearRangePreview above strips classMap-managed range classes from
+    // the DOM; classMap's private state still thinks they're applied, so
+    // it won't re-add them on the post-nav re-render. Re-apply imperatively
+    // after both months and their cell button caches have settled.
+    this.scheduleCommittedRangeClassRefresh();
     this.announceMonthChange();
   }
 
@@ -1403,9 +1413,14 @@ export class AuroCalendar extends RangeDatepicker {
    * @private
    * @param {Object} [options] - Optional settings.
    * @param {boolean} [options.force=false] - When true, clears classes even
-   *   when both dateFrom and dateTo are set. Used by month nav handlers
-   *   since the subsequent re-render re-applies classMap-managed classes,
-   *   while `lastHoveredDate` (not in classMap) would otherwise persist.
+   *   when both dateFrom and dateTo are set. Used by month nav handlers to
+   *   strip the imperative-only `lastHoveredDate` before the re-render.
+   *   The other two classes (`inRange`, `rangeDepartDate`) are classMap-
+   *   managed and get stripped as a side effect here; because classMap
+   *   remembers what it last emitted and does not diff against the actual
+   *   DOM, the following month re-render will NOT re-add them on its own.
+   *   Nav handlers must schedule `refreshCommittedRangeClasses` (via
+   *   `scheduleCommittedRangeClassRefresh`) to resync them.
    * @returns {void}
    */
   clearRangePreview(options) {
@@ -1418,6 +1433,57 @@ export class AuroCalendar extends RangeDatepicker {
     allCells.forEach((cell) => {
       cell.clearRangePreviewClasses();
     });
+  }
+
+  /**
+   * Re-applies the committed-range classes across every focusable cell
+   * after a month navigation. classMap in the cell tracks its own
+   * previous state: once `clearRangePreview({ force: true })` strips
+   * `inRange`/`rangeDepartDate` imperatively before the re-render,
+   * classMap's next diff sees the same class-value it emitted before and
+   * produces no delta, leaving the DOM without the classes even though a
+   * full range is committed. Re-applying imperatively resyncs the two
+   * months' cells with `dateFrom`/`dateTo`.
+   *
+   * Iterates `getAllFocusableCells()` — out-of-range cells (blocked by
+   * `min`/`max`) can never carry range classes anyway, so skipping them
+   * is correct and cheaper than a whole-grid walk.
+   *
+   * The cell's `applyCommittedRangeClasses` reuses the same
+   * `isInRange`/`isDepartDate`/`isReturnDate` helpers `renderCellButton`
+   * uses, so we don't parse dateFrom/dateTo here — the helpers already
+   * normalize their inputs (midnight-truncation, string→int) internally.
+   * @private
+   * @returns {void}
+   */
+  refreshCommittedRangeClasses() {
+    if (this.noRange || !this.dateFrom || !this.dateTo) {
+      return;
+    }
+
+    const allCells = this.getAllFocusableCells();
+    allCells.forEach((cell) => {
+      cell.applyCommittedRangeClasses();
+    });
+  }
+
+  /**
+   * Schedules `refreshCommittedRangeClasses` to run after the month
+   * re-render has flushed and the cells' button caches have refreshed.
+   * Both `handlePrevMonth` and `handleNextMonth` need this exact call
+   * shape; keeping it in one place prevents them from drifting apart.
+   *
+   * Bails synchronously when a full committed range isn't set — otherwise
+   * every prev/next click in single-date mode (or before the user picks
+   * both dates in range mode) pays for an unused double-rAF hop.
+   * @private
+   * @returns {void}
+   */
+  scheduleCommittedRangeClassRefresh() {
+    if (this.noRange || !this.dateFrom || !this.dateTo) {
+      return;
+    }
+    this._afterMonthRender(() => this.refreshCommittedRangeClasses());
   }
 
   /**

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -4211,6 +4211,107 @@ function runFullTest(mobileView) {
       expect(btn.classList.contains('lastHoveredDate')).to.be.false;
     });
 
+    // ─── committed inRange classes persist across next/prev month nav ──
+    // Regression: `clearRangePreview({ force: true })` in the month-nav
+    // handlers strips `inRange`/`rangeDepartDate` imperatively before the
+    // re-render. classMap in the cell remembers what it last emitted and
+    // does not diff against the actual DOM, so on the post-nav render its
+    // class-value stays the same and no delta is emitted — leaving the
+    // committed range dates without the `inRange` class in the DOM.
+    // `scheduleCommittedRangeClassRefresh` re-applies them imperatively
+    // once the re-render + cell-button caches have settled.
+    it('re-applies committed inRange classes on visible cells after next/prev month nav', async () => {
+      // Wide viewport so range mode renders two months (matches the
+      // established pattern in the existing "should render two calendars"
+      // test at ~line 1886, which also widens to 1200 without restoring
+      // afterward). An explicit restore here empirically causes ~7
+      // unrelated tests further down in the mobile-view pass to fail
+      // (centralDate-driven fixtures start rendering the current month
+      // instead of the fixture's centralDate) — likely a resize-driven
+      // state race in the datepicker. The file's convention is that
+      // later tests either don't depend on viewport or re-set it
+      // themselves; keep that.
+      await setViewport({
+        width: 1200,
+        height: 800
+      });
+
+      // Whole-year range so every day well inside 2024 is strictly
+      // between depart (Jan 1) and return (Dec 31). centralDate can't be
+      // passed as a static attribute here — the datepicker's dropdown
+      // open handler resets it to `this.value` when a value is set (see
+      // auro-datepicker.js line ~1172). We navigate forward with the
+      // Next button after opening so the depart cell is safely out of
+      // view, which lets us assert count === total-focusable (the strong
+      // form of the regression; `> 0` can pass while most cells stay
+      // broken).
+      const el = await fixture(html`
+        <auro-datepicker
+          range
+          value="2024-01-01"
+          valueEnd="2024-12-31"
+        ></auro-datepicker>
+      `);
+      await elementUpdated(el);
+
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+      const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
+
+      await dropdown.querySelector('[auro-input]').click();
+      await elementUpdated(calendar.shadowRoot);
+      await nextFrame();
+
+      // Fall back to a shadow-root query when `_cachedButton` hasn't
+      // populated yet — otherwise a stale cache can undercount even when
+      // the button is in the DOM and carries the class.
+      const cellHasInRange = (cell) => {
+        const btn = cell._cachedButton || cell.shadowRoot.querySelector('button.day');
+        return btn?.classList.contains('inRange');
+      };
+      const focusableCount = () => calendar.getAllFocusableCells().length;
+      const inRangeCount = () => calendar.getAllFocusableCells().filter(cellHasInRange).length;
+
+      const nextMonthBtn = calendar.shadowRoot.querySelector('.nextMonth');
+      const prevMonthBtn = calendar.shadowRoot.querySelector('.prevMonth');
+      // Two rAF because scheduleCommittedRangeClassRefresh uses
+      // `_afterMonthRender` (double-rAF for Lit render + cell cache flush).
+      const settleAfterNav = async () => {
+        await elementUpdated(calendar);
+        await nextFrame();
+        await nextFrame();
+      };
+
+      // Navigate three months forward from Jan+Feb so both visible
+      // months (Apr+May) are strictly interior to the Jan 1 → Dec 31
+      // range — no depart/return cell in view.
+      nextMonthBtn.click();
+      await settleAfterNav();
+      nextMonthBtn.click();
+      await settleAfterNav();
+      nextMonthBtn.click();
+      await settleAfterNav();
+
+      // Baseline: every focusable cell carries `inRange` before the
+      // regression's test move.
+      expect(focusableCount()).to.be.greaterThan(0);
+      expect(inRangeCount()).to.equal(focusableCount());
+
+      // Next-month nav: shifts view forward. Still entirely inside the
+      // Jan 1 → Dec 31 range, so every focusable cell must still carry
+      // `inRange` after the re-render + refresh flush. Equality here is
+      // what makes this test catch the regression: with the old code,
+      // classMap's memory leaves most cells without the class.
+      nextMonthBtn.click();
+      await settleAfterNav();
+      expect(inRangeCount()).to.equal(focusableCount());
+
+      // Prev-month nav: symmetric path — verify the same fix restores
+      // classes when navigating backwards.
+      prevMonthBtn.click();
+      await settleAfterNav();
+      expect(inRangeCount()).to.equal(focusableCount());
+    });
+
     // ─── clearRangePreview respects guard unless forced ────────────────
     it('clearRangePreview retains classes when both dates are set unless forced', async () => {
       const el = await fixture(html`


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure date range styling is correctly restored after navigating between months in the datepicker calendar.

Bug Fixes:
- Fix loss of committed date range classes when changing months in the datepicker view.

Enhancements:
- Add calendar-level helper to reapply committed range classes to all visible cells after month navigation.
- Add cell-level API to recompute and toggle range-related CSS classes based on the committed date range.