### PR TITLE
docs(select): add "Reset" option guidance AB#1589552

### DIFF
--- a/components/select/apiExamples/none-option.html
+++ b/components/select/apiExamples/none-option.html
@@ -1,0 +1,12 @@
+<auro-select>
+  <span slot="bib.fullscreen.headline">Suffix</span>
+  <span slot="label">Suffix</span>
+  <span slot="helpText">If shown on your government-issued travel ID.</span>
+  <auro-menu>
+    <auro-menuoption value="none">None</auro-menuoption>
+    <auro-menuoption value="Jr">Jr</auro-menuoption>
+    <auro-menuoption value="Sr">Sr</auro-menuoption>
+    <auro-menuoption value="II">II</auro-menuoption>
+    <auro-menuoption value="III">III</auro-menuoption>
+  </auro-menu>
+</auro-select>

--- a/components/select/docs/pages/customize.md
+++ b/components/select/docs/pages/customize.md
@@ -8,6 +8,7 @@
       <auro-anchorlink fluid href="#layout" class="level2 body-xs">Shape, Size & Layout</auro-anchorlink>
       <auro-anchorlink fluid href="#background" class="level2 body-xs">Light vs. Dark Background</auro-anchorlink>
       <auro-anchorlink fluid href="#displayValue" class="level2 body-xs">Custom Display Value</auro-anchorlink>
+      <auro-anchorlink fluid href="#resetOption" class="level2 body-xs">Reset Option</auro-anchorlink>
       <auro-anchorlink fluid href="#noCheckmark" class="level2 body-xs">No Checkmark</auro-anchorlink>
       <auro-anchorlink fluid href="#fluid" class="level2 body-xs">Fluid</auro-anchorlink>
       <auro-anchorlink fluid href="#flexMenuWidth" class="level2 body-xs">Flex Menu Width</auro-anchorlink>
@@ -70,6 +71,20 @@
         <auro-accordion alignRight>
         <span slot="trigger">See code</span>
         <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/display-value.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </auro-accordion>
+        <auro-header level="3" id="resetOption">Adding a reset option</auro-header>
+        <p><code>auro-select</code> has no built-in way to clear a selection from the trigger. If a user picks the wrong option on an optional field, they have no way to reset their selection.</p>
+        <p>Add a selectable entry at the top of the menu with whatever label fits the field ("None," "N/A," "No preference," etc.). <code>value=""</code> won't work — <code>auro-menu</code> treats an empty string as a clear-selection signal.</p>
+        <p>Use a non-empty sentinel like <code>value="none"</code> instead, choosing one that cannot collide with any real domain value. Either accept <code>"none"</code> on the backend, or coerce it in your submit handler:</p>
+        <pre><code>payload.suffix = payload.suffix === "none" ? "" : payload.suffix;</code></pre>
+        <div class="exampleWrapper">
+        <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/none-option.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </div>
+        <auro-accordion alignRight>
+        <span slot="trigger">See code</span>
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/none-option.html) -->
         <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
         <auro-header level="3" id="noCheckmark">Hide checkmark indicators</auro-header>


### PR DESCRIPTION
## Summary

Adds an official Auro recommendation for a common UI pattern: how to give customers a way back to "no selection" in `auro-select`, since the component has no built-in clear affordance on its trigger.

- Documents the recommended pattern for a selectable "None" option in `auro-select`, addressing the UX gap where an accidental selection cannot be cleared from the trigger.

- Explains why `value=""` is not usable (auro-menu intentionally treats empty string as "cleared selection") and shows the `value="none"` sentinel approach with submit-time coercion guidance.

- Adds a working apiExample and a matching sidebar nav entry under Customize.

<img width="831" height="588" alt="Screenshot 2026-07-01 at 2 02 40 PM" src="https://github.com/user-attachments/assets/ee5d8406-7355-4569-b100-4bb88c77d472" />

## Summary by Sourcery

Document the recommended pattern for providing a selectable "None" option in auro-select to allow users to return to a no-selection state.

Documentation:
- Add guidance explaining why an empty-string value cannot be used for a "None" option and recommend a sentinel value such as "none" with submit-time coercion.
- Add a new "None" option section to the customize page navigation and content for auro-select.
- Include a working API example demonstrating a "None" option configuration in auro-select.

## Summary by Sourcery

Document guidance for providing a selectable "None" option in auro-select and illustrate it with an API example.

Enhancements:
- Add a concrete API example demonstrating an auro-select configured with a selectable "None" menu option.

Documentation:
- Add a new "None" option customization section to the auro-select docs explaining how to let users clear an optional selection without a built-in clear control.
- Clarify that an empty-string value cannot be used for a "None" option and recommend using a non-empty sentinel value such as "none" with submit-time coercion guidance.