### PR TITLE
Formkit v6 - address skipped test

### DIFF
--- a/apps/shared/combobox-interaction.suite.ts
+++ b/apps/shared/combobox-interaction.suite.ts
@@ -310,49 +310,28 @@ export function comboboxInteractionSuite(framework: string, options?: SuiteOptio
       });
     });
 
-    // ── Screen reader live region ─────────────────────────────────────────
+    // ── Screen reader announcements ───────────────────────────────────────
 
     test.describe('Screen reader announcements', () => {
-      test.skip('populates live region when an option is activated', async ({ page }) => {
-        test.setTimeout(45_000);
+      // Desktop's screen reader hook is aria-activedescendant — expressed
+      // via the ariaActiveDescendantElement DOM property so the reference
+      // can cross the shadow-DOM boundary between the trigger input and the
+      // menu option in light DOM. The polite live region (#srAnnouncement)
+      // is populated only in fullscreen mode (see auro-combobox.js:1259 and
+      // the fullscreen-mobile suite below), so no desktop live-region test.
+      test('points the trigger input at the active option via ariaActiveDescendantElement', async ({ page }) => {
         await typeInCombobox(page, 'no-filter', 'a');
         await waitForBibOpen(page, 'no-filter');
         await waitForOptionsReady(page, 'no-filter');
 
         await page.keyboard.press('ArrowDown');
 
-        // The live region is inside the combobox's shadow root
-        await expect.poll(async () => {
-          return combobox(page, 'no-filter').evaluate((el: any) => {
-            const root = el.shadowRoot;
-            const liveRegion = root?.querySelector('#srAnnouncement');
-            return liveRegion?.textContent ?? '';
-          });
-        }, { timeout: 3_000 }).not.toBe('');
-      });
-
-      test.skip('clears live region after announcement duration', async ({ page }) => {
-        test.setTimeout(45_000);
-        await typeInCombobox(page, 'no-filter', 'a');
-        await waitForBibOpen(page, 'no-filter');
-
-        await page.keyboard.press('ArrowDown');
-
-        // Wait for the announcement to appear
-        await expect.poll(async () => {
-          return combobox(page, 'no-filter').evaluate((el: any) => {
-            const root = el.shadowRoot;
-            return root?.querySelector('#srAnnouncement')?.textContent ?? '';
-          });
-        }, { timeout: 3_000 }).not.toBe('');
-
-        // Wait for it to be cleared (component uses a ~1000ms timer)
-        await expect.poll(async () => {
-          return combobox(page, 'no-filter').evaluate((el: any) => {
-            const root = el.shadowRoot;
-            return root?.querySelector('#srAnnouncement')?.textContent ?? '';
-          });
-        }, { timeout: 5_000 }).toBe('');
+        await expect.poll(() =>
+          combobox(page, 'no-filter').evaluate((el: any) => {
+            const inputEl = el.input?.inputElement;
+            return inputEl?.ariaActiveDescendantElement?.value ?? null;
+          }),
+        { timeout: 3_000 }).not.toBeNull();
       });
     });
 
@@ -597,6 +576,32 @@ export function comboboxInteractionSuite(framework: string, options?: SuiteOptio
           return bibText || hostText;
         });
       }, { timeout: 3_000 }).not.toBe('');
+    });
+
+    test('live region clears after announcement duration in fullscreen', async ({ page }) => {
+      await typeInCombobox(page, 'no-filter', 'a');
+      await waitForBibOpen(page, 'no-filter');
+
+      // Wait for fullscreen to settle
+      await expect.poll(async () =>
+        combobox(page, 'no-filter').evaluate((el: any) => Boolean(el.dropdown?.isBibFullscreen)),
+      ).toBe(true);
+
+      await page.keyboard.press('ArrowDown');
+
+      const readLiveRegion = () =>
+        combobox(page, 'no-filter').evaluate((el: any) => {
+          const bibEl = el.dropdown?.bibElement?.value;
+          const bibText = bibEl?.shadowRoot?.querySelector('#srAnnouncement')?.textContent ?? '';
+          const hostText = el.shadowRoot?.querySelector('#srAnnouncement')?.textContent ?? '';
+          return bibText || hostText;
+        });
+
+      // Wait for the announcement to appear
+      await expect.poll(readLiveRegion, { timeout: 3_000 }).not.toBe('');
+
+      // Wait for it to be cleared (announceToScreenReader uses a ~1000ms timer)
+      await expect.poll(readLiveRegion, { timeout: 5_000 }).toBe('');
     });
   });
 }

--- a/apps/shared/combobox-preselected-navigation.suite.ts
+++ b/apps/shared/combobox-preselected-navigation.suite.ts
@@ -34,7 +34,7 @@ async function waitForPreselectedPath(page: Page) {
 
 export function comboboxPreselectedNavigationSuite(framework: string) {
   test.describe(`auro-combobox preselected value after SPA navigation in ${framework}`, () => {
-    test.skip('value equals preselected value after SPA navigation from homepage', async ({ page }) => {
+    test('value equals preselected value after SPA navigation from homepage', async ({ page }) => {
       await page.goto('/combobox-city-search-preselected-navigate');
 
       await waitForPreselectedPath(page);
@@ -46,7 +46,7 @@ export function comboboxPreselectedNavigationSuite(framework: string) {
       expect(result.dropdownOpen, 'menu should not open on its own after navigation').toBe(false);
     });
 
-    test.skip('selected-value display reflects preselected value after SPA navigation', async ({ page }) => {
+    test('selected-value display reflects preselected value after SPA navigation', async ({ page }) => {
       await page.goto('/combobox-city-search-preselected-navigate');
 
       await waitForPreselectedPath(page);

--- a/apps/shared/combobox-remount.suite.ts
+++ b/apps/shared/combobox-remount.suite.ts
@@ -57,53 +57,70 @@ export function comboboxRemountSuite(framework: string, options?: SuiteOptions) 
       expect(value).toBe(initialValue);
     });
 
-    test.skip('setting an invalid value clears the selection', async ({ page }) => {
+    // Preserve contract: setting an unmatched programmatic value keeps the
+    // freeform value on the combobox while clearing menu.value/optionSelected.
+    // Matches the WTR "should clear menu.optionSelected when value is set to
+    // an unmatched string" regression test.
+    test('setting an invalid value clears menu selection but preserves the value', async ({ page }) => {
       await waitForComboboxValue(page, initialValue);
 
       await page.locator('#set-invalid').click();
 
-      // Wait for value to be cleared
+      // Wait for the menu selection to clear.
       await page.waitForFunction(
-        () => (document.querySelector('auro-combobox') as any)?.value === undefined,
+        () => {
+          const el = document.querySelector('auro-combobox') as any;
+          return el?.menu?.value === undefined && el?.menu?.optionSelected === undefined;
+        },
         { timeout: 3000 },
       );
 
       const result = await page.locator('auro-combobox').evaluate((el: any) => ({
         value: el.value,
-        optionSelected: el.optionSelected,
+        menuValue: el.menu?.value,
+        menuOptionSelected: el.menu?.optionSelected,
       }));
 
-      expect(result.value).toBeUndefined();
-      expect(result.optionSelected).toBeUndefined();
+      expect(result.value).toBe('invalid-option');
+      expect(result.menuValue).toBeUndefined();
+      expect(result.menuOptionSelected).toBeUndefined();
     });
 
-    test.skip('double-clicking set-invalid keeps value cleared', async ({ page }) => {
+    test('double-clicking set-invalid keeps the freeform value pinned', async ({ page }) => {
       await waitForComboboxValue(page, initialValue);
 
-      // First click - confirm the invalid value is cleared
+      // First click - confirm the menu state clears to the unmatched value.
       await page.locator('#set-invalid').click();
       await page.waitForFunction(
-        () => (document.querySelector('auro-combobox') as any)?.value === undefined,
+        () => {
+          const el = document.querySelector('auro-combobox') as any;
+          return el?.value === 'invalid-option' && el?.menu?.optionSelected === undefined;
+        },
         { timeout: 3000 },
       );
 
-      // Second click - ensure the assignment takes effect before polling for cleared state
+      // Second click - re-assert the same value; state must remain identical.
       await page.locator('#set-invalid').click();
       await page.locator('auro-combobox').evaluate(async (el: any) => {
         await el.updateComplete;
       });
       await page.waitForFunction(
-        () => (document.querySelector('auro-combobox') as any)?.value === undefined,
+        () => {
+          const el = document.querySelector('auro-combobox') as any;
+          return el?.value === 'invalid-option' && el?.menu?.optionSelected === undefined;
+        },
         { timeout: 3000 },
       );
 
       const result = await page.locator('auro-combobox').evaluate((el: any) => ({
         value: el.value,
-        optionSelected: el.optionSelected,
+        menuValue: el.menu?.value,
+        menuOptionSelected: el.menu?.optionSelected,
       }));
 
-      expect(result.value).toBeUndefined();
-      expect(result.optionSelected).toBeUndefined();
+      expect(result.value).toBe('invalid-option');
+      expect(result.menuValue).toBeUndefined();
+      expect(result.menuOptionSelected).toBeUndefined();
     });
   });
 }

--- a/apps/shared/counter-interaction.suite.ts
+++ b/apps/shared/counter-interaction.suite.ts
@@ -156,7 +156,7 @@ export function counterInteractionSuite(framework: string) {
     });
 
     test.describe('Mouse interaction', () => {
-      test.skip('clicking the plus button increments the value', async ({ page }) => {
+      test('clicking the plus button increments the value', async ({ page }) => {
         const before = await counterValue(page, 'default');
         await clickPlus(page, 'default');
         await expect.poll(() => counterValue(page, 'default')).toBe(before + 1);

--- a/apps/shared/menu-interaction.suite.ts
+++ b/apps/shared/menu-interaction.suite.ts
@@ -312,7 +312,7 @@ export function menuInteractionSuite(framework: string) {
     // ── Reset ─────────────────────────────────────────────────────────────
 
     test.describe('Reset', () => {
-      test.skip('reset() clears selection', async ({ page }) => {
+      test('reset() clears selection', async ({ page }) => {
         await clickOption(page, 'default', 'Bananas');
         await expect.poll(() => menuValue(page, 'default')).toBe('Bananas');
 

--- a/apps/svelte-framework/src/routes/combobox-city-search-preselected/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-city-search-preselected/+page.svelte
@@ -95,7 +95,10 @@
 	}
 
 	function handleOptionSelected(event: Event) {
-		const el = event.target as any;
+		// Ignore `input` events that bubble up from inner trigger/bib inputs —
+		// only react when auro-combobox itself dispatches the event.
+		if (event.target !== event.currentTarget) return;
+		const el = event.currentTarget as any;
 		selectedValue = el?.value ?? '';
 	}
 

--- a/apps/svelte-framework/src/routes/combobox-city-search-preselected/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-city-search-preselected/+page.svelte
@@ -95,11 +95,13 @@
 	}
 
 	function handleOptionSelected(event: Event) {
-		// Ignore `input` events that bubble up from inner trigger/bib inputs —
-		// only react when auro-combobox itself dispatches the event.
-		if (event.target !== event.currentTarget) return;
-		const el = event.currentTarget as any;
-		selectedValue = el?.value ?? '';
+		// auro-combobox dispatches a CustomEvent with a detail payload;
+		// inner trigger/bib input events bubble up as plain Events.
+		// event.target/currentTarget are unreliable here because native
+		// input events cross shadow DOM with retargeting.
+		const detail = (event as CustomEvent).detail;
+		if (!detail) return;
+		selectedValue = (detail.value ?? '') as string;
 	}
 
 	function triggerValidation() {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -786,8 +786,16 @@ export class AuroCombobox extends AuroElement {
   /**
    * Processes hidden state of all menu options and determines if there are any available options not hidden.
    * @private
-   * @param {object} [root0={}] - Optional flag bag.
-   * @param {boolean} [root0.preferComboboxValue=false] - When true, a match on `this.value` wins the tie-break over `this.input.value` (used by handleSlotChange on mount / re-mount).
+   * @param {object} [options={}] - Optional flag bag.
+   * @param {boolean} [options.preferComboboxValue=false] - When true,
+   *   handleMenuOptions matches the selected option against `this.value`
+   *   first instead of `this.input.value`. Needed on mount and re-mount
+   *   because under `persistInput` the consumer's typedValue prop can drift
+   *   from the framework value (Svelte `{#key}` re-mount after a swap, or
+   *   SPA preselect after route change) and the old input-first match would
+   *   then pick the stale text. Only handleSlotChange passes this; typing
+   *   and clearing paths keep the input-first match so user clears aren't
+   *   undone.
    * @returns {void}
    */
   handleMenuOptions({ preferComboboxValue = false } = {}) {
@@ -815,16 +823,17 @@ export class AuroCombobox extends AuroElement {
     // `this.value` when it matches a menu option. Covers SPA preselect and
     // consumer swap patterns (e.g. Svelte `{#key}` re-mount) where
     // `this.value` is authoritative but `this.input.value` may be empty or
-    // carry stale typed text from another field. Do NOT enable this in the
-    // event-driven path — user clears would be undone by re-syncing to the
-    // previous combobox.value.
-    const valueMatches = preferComboboxValue &&
-      this.value &&
-      this.menu.options &&
-      this.menu.options.some((opt) => opt.value === this.value);
-    const matchValue = valueMatches ? this.value : this.input.value;
-    if (matchValue && this.menu.options && this.menu.options.some((opt) => opt.value === matchValue)) {
-      this.setMenuValue(matchValue);
+    // carry stale typed text from another field. Event-driven callers do
+    // not pass the flag, otherwise user clears would be undone by
+    // re-syncing to the previous combobox.value.
+    if (preferComboboxValue &&
+        this.value &&
+        this.menu.options?.some((opt) => opt.value === this.value)) {
+      this.setMenuValue(this.value);
+      this.syncValuesAndStates();
+    } else if (this.input.value &&
+        this.menu.options?.some((opt) => opt.value === this.input.value)) {
+      this.setMenuValue(this.input.value);
       this.syncValuesAndStates();
     }
 
@@ -1260,15 +1269,19 @@ export class AuroCombobox extends AuroElement {
       this.optionActive = evt.detail;
 
       if (this.input) {
-        // Defer to after this optionActive assignment flushes through Lit:
-        // the template binds `.a11yActivedescendant` on the trigger input,
-        // which propagates to auro-input.updated() → setAttribute(
-        // 'aria-activedescendant', id) on the internal <input>. That
-        // setAttribute call clears the reflected ariaActiveDescendantElement
-        // property, so setting the ref first (synchronously here) gets
-        // clobbered. Awaiting updateComplete lets the attribute write finish
-        // first; the element reference then sticks and screen readers can
-        // cross the shadow-DOM boundary to the auro-menuoption in light DOM.
+        // setActiveDescendant runs after Lit's update finishes because the
+        // template's `.a11yActivedescendant` binding calls setAttribute on
+        // the internal <input> in auro-input.updated(), which clears the
+        // reflected ariaActiveDescendantElement property. Setting the ref
+        // synchronously here would get overwritten by that attribute write.
+        // Awaiting updateComplete lets the attribute write finish first,
+        // then the ref sticks and screen readers can cross the shadow-DOM
+        // boundary to the auro-menuoption in light DOM.
+        //
+        // The equality check covers the async gap: this.optionActive can
+        // change before the callback runs (user arrowed elsewhere, or the
+        // menu closed and cleared it to null), so we bail if the target
+        // no longer matches to avoid reinstating a stale ref.
         const targetOption = this.optionActive;
         this.updateComplete.then(() => {
           if (this.input && this.optionActive === targetOption) {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1246,7 +1246,21 @@ export class AuroCombobox extends AuroElement {
       this.optionActive = evt.detail;
 
       if (this.input) {
-        this.input.setActiveDescendant(this.optionActive);
+        // Defer to after this optionActive assignment flushes through Lit:
+        // the template binds `.a11yActivedescendant` on the trigger input,
+        // which propagates to auro-input.updated() → setAttribute(
+        // 'aria-activedescendant', id) on the internal <input>. That
+        // setAttribute call clears the reflected ariaActiveDescendantElement
+        // property, so setting the ref first (synchronously here) gets
+        // clobbered. Awaiting updateComplete lets the attribute write finish
+        // first; the element reference then sticks and screen readers can
+        // cross the shadow-DOM boundary to the auro-menuoption in light DOM.
+        const targetOption = this.optionActive;
+        this.updateComplete.then(() => {
+          if (this.input && this.optionActive === targetOption) {
+            this.input.setActiveDescendant(targetOption);
+          }
+        });
       }
 
       // In fullscreen mode the menu sits inside a nested <dialog> shadow root,
@@ -1381,6 +1395,18 @@ export class AuroCombobox extends AuroElement {
         this.inputInBib.skipNextProgrammaticInputEvent = true;
         bibNativeInput.value = this.input.value || '';
       }
+    }
+
+    // SPA preselect guard: on init render, auro-input's notifyValueChanged
+    // echoes an empty value through as an isProgrammatic input event before
+    // the framework-set combobox.value has propagated down to the input.
+    // Without this bail, the `this.value = this.input.value` below clobbers
+    // the framework value with '' and clear() wipes optionSelected. Scoped
+    // to the exact shape of that echo (isProgrammatic + non-empty combobox
+    // value + empty input.value) so it doesn't affect the swap/typed paths
+    // where value/input already track each other through the sync helpers.
+    if (event && event.isProgrammatic && this.value && !this.input.value) {
+      return;
     }
 
     this.value = this.input.value;

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -786,9 +786,11 @@ export class AuroCombobox extends AuroElement {
   /**
    * Processes hidden state of all menu options and determines if there are any available options not hidden.
    * @private
+   * @param {object} [root0={}] - Optional flag bag.
+   * @param {boolean} [root0.preferComboboxValue=false] - When true, a match on `this.value` wins the tie-break over `this.input.value` (used by handleSlotChange on mount / re-mount).
    * @returns {void}
    */
-  handleMenuOptions() {
+  handleMenuOptions({ preferComboboxValue = false } = {}) {
     this.generateOptionsArray();
     this.availableOptions = [];
     // Single source of truth for the menu's filter/highlight token per call.
@@ -809,8 +811,20 @@ export class AuroCombobox extends AuroElement {
       option.setAttribute('aria-posinset', index + 1);
     });
 
-    if (this.input.value && this.menu.options && this.menu.options.some((opt) => opt.value === this.input.value)) {
-      this.setMenuValue(this.input.value);
+    // On mount/re-mount (via handleSlotChange), prefer the framework-set
+    // `this.value` when it matches a menu option. Covers SPA preselect and
+    // consumer swap patterns (e.g. Svelte `{#key}` re-mount) where
+    // `this.value` is authoritative but `this.input.value` may be empty or
+    // carry stale typed text from another field. Do NOT enable this in the
+    // event-driven path — user clears would be undone by re-syncing to the
+    // previous combobox.value.
+    const valueMatches = preferComboboxValue &&
+      this.value &&
+      this.menu.options &&
+      this.menu.options.some((opt) => opt.value === this.value);
+    const matchValue = valueMatches ? this.value : this.input.value;
+    if (matchValue && this.menu.options && this.menu.options.some((opt) => opt.value === matchValue)) {
+      this.setMenuValue(matchValue);
       this.syncValuesAndStates();
     }
 
@@ -1841,7 +1855,11 @@ export class AuroCombobox extends AuroElement {
           }
         });
 
-        this.handleMenuOptions();
+        // Slot change (mount/re-mount): pass `preferComboboxValue` so that a
+        // framework-set `this.value` wins over any stale `input.value` when
+        // matching against the newly-available options. Fixes the display
+        // for SPA preselect and Svelte `{#key}` re-mount swap patterns.
+        this.handleMenuOptions({ preferComboboxValue: true });
 
         break;
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -766,6 +766,64 @@ function runFullTest(mobileView) {
       await expect(right.input.value).to.equal('a');
     });
 
+    // Regression: with persistInput + framework re-mount (Svelte `{#key}`),
+    // a fresh combobox mounts with `value` set to a valid option but
+    // `input.value` still holding stale typed text from another field.
+    // handleSlotChange must reconcile by matching against `this.value` (not
+    // just `input.value`) so the option's displayValue clone lands in the
+    // trigger — otherwise the trigger shows the stale typed text (or nothing
+    // when hidden by the empty `<span slot="displayValue">` forwarder).
+    it('should sync menu.optionSelected to combobox.value on mount when input.value diverges under persistInput', async () => {
+      if (mobileView) {
+        await setViewport({ width: 500, height: 800 });
+      } else {
+        await setViewport({ width: 800, height: 800 });
+      }
+
+      // Framework-set combobox.value that DOESN'T match the trigger's typed
+      // value (mimics the swap-remount shape from consumer apps).
+      const el = await fixture(html`
+        <auro-combobox persistInput value="Oranges">
+          <span slot="label">Name</span>
+          <span slot="displayValue"></span>
+          <auro-menu>
+            <auro-menuoption value="Apples" id="opt-apples">
+              Apples
+              <span slot="displayValue">Apples</span>
+            </auro-menuoption>
+            <auro-menuoption value="Oranges" id="opt-oranges">
+              Oranges
+              <span slot="displayValue">Oranges</span>
+            </auro-menuoption>
+          </auro-menu>
+        </auro-combobox>
+      `);
+      await elementUpdated(el);
+      await el.menu.updateComplete;
+
+      // Simulate the pre-swap stale-typed-text state by directly writing to
+      // the trigger input (bypassing the Lit template's typedValue binding).
+      el.input.value = 'stale-typed';
+      await elementUpdated(el);
+
+      // Re-trigger the slotchange path (the one that fires on Svelte
+      // re-mount / SPA hydration) so the reconciliation runs against the
+      // now-diverged input.value + framework-set combobox.value.
+      el.handleSlotChange({ target: { name: '' } });
+      await elementUpdated(el);
+      await el.menu.updateComplete;
+
+      // Menu must reflect the framework-set value, not the stale typed text.
+      await expect(el.menu.value).to.equal('Oranges');
+      await expect(el.menu.optionSelected).to.not.be.undefined;
+      await expect(el.menu.optionSelected.value).to.equal('Oranges');
+      // The option's <span slot="displayValue"> must be cloned into the
+      // trigger so the visible display picks up the right label.
+      const clone = el.input.querySelector('[slot="displayValue"]:not(slot)');
+      await expect(clone).to.not.be.null;
+      await expect(clone.textContent.trim()).to.equal('Oranges');
+    });
+
     // Regression: programmatic value/input mutations in noFilter + persistInput
     // + suggestion mode (the dynamic-menu apiExample swap pattern) used to pump
     // a ~125-update cascade between handleInputValueChange and the

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -647,20 +647,37 @@ function runFullTest(mobileView) {
         await expect(el.getAttribute('validity')).to.not.equal('valueMissing');
       });
 
-      // TODO: revisit. Under behavior="suggestion" (the persistInputFixture
-      // default), typed text sets this.value via handleInputValueChange, so
-      // "zz" without a menu match is currently treated as valid. The
-      // "must select from menu" semantic only applies under behavior="filter".
-      // Decide whether persistInput should imply filter-style required-selection
-      // semantics, then either add a behavior="filter" fixture or remove this.
-      it.skip('reports valueMissing on blur when typed text has no matching selection under persistInput', async () => {
-        const el = await persistInputFixture(mobileView);
+      // filter behavior enforces "must select from menu": typed text without
+      // a matching option leaves optionSelected undefined and required's
+      // valueMissing fires on blur. persistInput here only pins the typed
+      // display value; the required-selection semantic comes from behavior.
+      it('reports valueMissing on blur when typed text has no matching selection under filter + persistInput', async () => {
+        if (mobileView) {
+          await setViewport({ width: 500, height: 800 });
+        } else {
+          await setViewport({ width: 800, height: 800 });
+        }
+        const el = await fixture(html`
+          <auro-combobox required persistInput behavior="filter">
+            <span slot="label">Name</span>
+            <auro-menu>
+              <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+            </auro-menu>
+          </auro-combobox>
+        `);
         await elementUpdated(el);
 
         el.focus();
         await elementUpdated(el);
         await sendKeys({ press: 'z' });
         await sendKeys({ press: 'z' });
+        await elementUpdated(el);
+
+        // Close the bib before blur so the combobox's focusout handler runs
+        // its validate() call (see auro-combobox.js line 1310 — validate is
+        // skipped while dropdownOpen to avoid flashing errors mid-selection).
+        await sendKeys({ press: 'Escape' });
 
         el.input.focus();
         el.input.blur();
@@ -2402,7 +2419,7 @@ function runFullTest(mobileView) {
         await expect(el.hasAttribute('validity')).to.be.false;
       });
 
-      it.skip('should re-run input validation when a fresh user selection lands', async () => {
+      it('should re-run input validation when a fresh user selection lands', async () => {
         const el = await fixture(html`
           <auro-combobox type="credit-card">
             <span slot="label">Card</span>
@@ -2420,9 +2437,12 @@ function runFullTest(mobileView) {
 
         await elementUpdated(el);
 
-        if (mobileView) {
-          await sendKeys({ press: 'Escape' });
-        }
+        // Close the bib before blur — the combobox's focusout handler skips
+        // `validate()` while `dropdownOpen` is true (see auro-combobox.js
+        // line 1310: prevents flashing pre-selection errors during a menu
+        // option mousedown). Real users tab/click-out which closes the bib
+        // first; typed-then-blur without closing is a test-only shape.
+        await sendKeys({ press: 'Escape' });
 
         el.input.focus();
         el.input.blur();
@@ -2438,6 +2458,8 @@ function runFullTest(mobileView) {
         await el.input.updateComplete;
         await new Promise((resolve) => setTimeout(resolve, 0));
 
+        // Enter selects the option and closes the bib in most paths, but
+        // mobile fullscreen may need an explicit Escape to return focus.
         if (mobileView) {
           await sendKeys({ press: 'Escape' });
         }

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -323,20 +323,15 @@ export class AuroInput extends BaseInput {
    * @returns {void}
    */
   checkDisplayValueSlotChange() {
-    let nodes = this.shadowRoot.querySelector('slot[name="displayValue"]').assignedNodes();
+    // flatten:true resolves through auro-combobox's forwarding slot
+    // (<slot name="displayValue" slot="displayValue">) so a clone appended
+    // directly to auro-input's light DOM alongside the forwarder still
+    // counts as content. The prior nodes[0].tagName === 'SLOT' recursion
+    // discarded any siblings past the forwarder.
+    const slot = this.shadowRoot.querySelector('slot[name="displayValue"]');
+    const nodes = slot.assignedNodes({ flatten: true });
 
-    // Handle when DisplayValue is multi-level slot content (e.g. combobox passing displayValue to input)
-    if (nodes && nodes[0] && nodes[0].tagName === 'SLOT') {
-      nodes = nodes[0].assignedNodes();
-    }
-
-    let hasContent = false;
-
-    if (nodes.length > 0) {
-      hasContent = true;
-    }
-
-    this.hasDisplayValueContent = hasContent;
+    this.hasDisplayValueContent = nodes.length > 0;
   }
 
   firstUpdated() {

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -959,14 +959,17 @@ export default class BaseInput extends AuroElement {
    * @returns {void}
    */
   notifyValueChanged() {
-    let inputEvent = null;
-
-    inputEvent = new Event('input', {
+    // This echoes Lit's reactive value update (and handleClickClear's
+    // programmatic clear) — it is NOT a fresh user-input event. Mark it
+    // `isProgrammatic` so consumers (e.g. auro-combobox) can distinguish
+    // it from genuine user typing and skip clobbering their own
+    // programmatic state during init-time renders.
+    const inputEvent = new Event('input', {
       bubbles: true,
       composed: true,
     });
+    inputEvent.isProgrammatic = true;
 
-    // Dispatched event to alert outside shadow DOM context of event firing.
     this.dispatchEvent(inputEvent);
   }
 

--- a/packages/config/src/web-test-runner.config-global.mjs
+++ b/packages/config/src/web-test-runner.config-global.mjs
@@ -8,6 +8,11 @@ export default {
   ],
   concurrency: 1,
   testsFinishTimeout: 300000,
+  // Filter out browser `console.debug()` output. We emit `console.debug` from
+  // component internals (e.g. deprecation notices, locale fallbacks) to help
+  // consumers troubleshoot integration issues at runtime — they shouldn't
+  // clutter our own test output. Warnings, errors, log, and info still print.
+  filterBrowserLogs: (log) => log.type !== 'debug',
   reporters: [defaultReporter(), jsonSummaryReporter()],
   nodeResolve: {
     moduleDirectories: [

--- a/packages/config/src/web-test-runner.config.mjs
+++ b/packages/config/src/web-test-runner.config.mjs
@@ -7,6 +7,11 @@ export default {
     'test/**/*.test.js',
     '!**/node_modules/**'
   ],
+  // Filter out browser `console.debug()` output. We emit `console.debug` from
+  // component internals (e.g. deprecation notices, locale fallbacks) to help
+  // consumers troubleshoot integration issues at runtime — they shouldn't
+  // clutter our own test output. Warnings, errors, log, and info still print.
+  filterBrowserLogs: (log) => log.type !== 'debug',
   reporters: [defaultReporter(), jsonSummaryReporter()],
   nodeResolve: {
     moduleDirectories: [


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request introduces several important improvements and bug fixes to the combobox component and its related test suites, focusing on enhanced SPA preselect behavior, more robust handling of programmatic value changes, and improved accessibility and validation. It also unskips and updates a number of tests to reflect the latest contract and regression scenarios.

**Combobox SPA Preselect and Remount Handling:**

- Improved `handleMenuOptions` and slot change logic in `auro-combobox.js` to prefer framework-set `value` over potentially stale `input.value` during mount/remount, ensuring correct option selection and display after SPA navigation or Svelte `{#key}` remounts. This prevents the trigger from showing outdated or empty values when a valid preselected value is present. [[1]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895R789-R793) [[2]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L812-R827) [[3]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L1818-R1862) [[4]](diffhunk://#diff-d17608b4b393bad997a94e8c279a4584fbdbc0a328878c95318d340d9aac2840R769-R826)

- Added a guard in the input event handler to prevent framework-set `value` from being clobbered by initial empty input values during SPA preselect, ensuring the correct value persists through initialization.

**Accessibility and Screen Reader Announcements:**

- Updated combobox interaction tests to reflect that desktop uses `ariaActiveDescendantElement` for screen reader focus, and moved live region assertion to fullscreen mode only. Added a new test to verify that the live region clears after the announcement duration in fullscreen mode. [[1]](diffhunk://#diff-7713ff4fe4005c840c72009bb5a75be916978e72c897afa827c2f35edeb026eeL313-R334) [[2]](diffhunk://#diff-7713ff4fe4005c840c72009bb5a75be916978e72c897afa827c2f35edeb026eeR580-R605)

- Improved the timing of setting `ariaActiveDescendantElement` to ensure correct propagation for screen readers, especially across shadow DOM boundaries.

**Validation and Selection Contract:**

- Updated and unskipped tests to reflect that with `behavior="filter"` and `persistInput`, required fields enforce "must select from menu" semantics: typed text without a matching option triggers `valueMissing` on blur.

- Added and updated regression tests to verify that programmatic value changes and re-mounts correctly clear or preserve freeform values and menu selections according to the contract, especially when setting invalid values.

**SPA Navigation and General Test Improvements:**

- Unskipped and updated SPA navigation tests to verify correct value and display after navigation, ensuring the preselected value is reflected in both the component and its visible display. [[1]](diffhunk://#diff-2aae02dcd37ec4018a0ce7f081a773f77be5988fe9466310e9cb9e6eb6c442e4L37-R37) [[2]](diffhunk://#diff-2aae02dcd37ec4018a0ce7f081a773f77be5988fe9466310e9cb9e6eb6c442e4L49-R49) [[3]](diffhunk://#diff-796aa85478f5202efd7ba79bf4fc9dbc1f6a824176551679729c66ba5c1ff7b1L98-R101)

- Unskipped and updated various other interaction and regression tests for menu and counter components to ensure they reflect the latest expected behaviors. [[1]](diffhunk://#diff-546a8d67343ed6df5448731af6323d7bb963a5dcde1daca10c17ec9d01c39188L159-R159) [[2]](diffhunk://#diff-657cf55685387825ee9df0abbe88ac4eed95a35f3af5a255b2f0598fbc60ce58L315-R315) [[3]](diffhunk://#diff-d17608b4b393bad997a94e8c279a4584fbdbc0a328878c95318d340d9aac2840L2405-R2480)

---

**Combobox SPA Preselect, Remount, and Value Handling:**
- Enhanced `handleMenuOptions` and slot change logic to prefer framework-set `value` over `input.value` during mount/remount, fixing display and selection for SPA preselect and Svelte remount patterns. [[1]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895R789-R793) [[2]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L812-R827) [[3]](diffhunk://#diff-01a201af0451a8bf263081160cec77b3ed61a3bfa8fe94b92c0298bc7288f895L1818-R1862) [[4]](diffhunk://#diff-d17608b4b393bad997a94e8c279a4584fbdbc0a328878c95318d340d9aac2840R769-R826)
- Added a guard to prevent framework-set `value` from being overwritten by empty input during SPA preselect initialization.

**Accessibility Improvements:**
- Updated screen reader announcement tests to use `ariaActiveDescendantElement` on desktop and moved live region checks to fullscreen only; added a test for live region clearing after announcement. [[1]](diffhunk://#diff-7713ff4fe4005c840c72009bb5a75be916978e72c897afa827c2f35edeb026eeL313-R334) [[2]](diffhunk://#diff-7713ff4fe4005c840c72009bb5a75be916978e72c897afa827c2f35edeb026eeR580-R605)
- Improved timing for setting `ariaActiveDescendantElement` to ensure screen readers can correctly follow focus across shadow DOM.

**Validation and Selection Contract:**
- Updated validation logic and tests to enforce "must select from menu" when `behavior="filter"` and `persistInput` are set, ensuring required fields behave as expected.
- Updated regression tests to verify correct contract for programmatic value changes, including clearing menu selection but preserving freeform values when setting invalid values.

**SPA Navigation and General Test Improvements:**
- Unskipped and updated SPA navigation and display tests to verify correct behavior after navigation and remount. [[1]](diffhunk://#diff-2aae02dcd37ec4018a0ce7f081a773f77be5988fe9466310e9cb9e6eb6c442e4L37-R37) [[2]](diffhunk://#diff-2aae02dcd37ec4018a0ce7f081a773f77be5988fe9466310e9cb9e6eb6c442e4L49-R49) [[3]](diffhunk://#diff-796aa85478f5202efd7ba79bf4fc9dbc1f6a824176551679729c66ba5c1ff7b1L98-R101)
- Unskipped and updated additional interaction and regression tests for menu, counter, and combobox components to ensure alignment with current contracts. [[1]](diffhunk://#diff-546a8d67343ed6df5448731af6323d7bb963a5dcde1daca10c17ec9d01c39188L159-R159) [[2]](diffhunk://#diff-657cf55685387825ee9df0abbe88ac4eed95a35f3af5a255b2f0598fbc60ce58L315-R315) [[3]](diffhunk://#diff-d17608b4b393bad997a94e8c279a4584fbdbc0a328878c95318d340d9aac2840L2405-R2480)

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
