### PR TITLE
fix(input): remove _rawMaskValue dead code and document yy century se…

### DIFF
--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -92,14 +92,16 @@ export default class BaseInput extends AuroElement {
     this.label = 'Input label is undefined';
     this.layout = 'classic';
     this.locale = 'en-US';
+    this._format = undefined;
+
+    /** @private */
+    this._userSetFormat = false;
     this.max = undefined;
     this.maxLength = undefined;
     this.min = undefined;
     this.minLength = undefined;
     this.noValidate = false;
     this.onDark = false;
-    // Raw values returned from the input mask before model normalization.
-    this._rawMaskValue = undefined;
     this.required = false;
     this.setCustomValidityForType = undefined;
     // Credit Card is intentionally excluded — its mask manages the cursor
@@ -257,7 +259,8 @@ export default class BaseInput extends AuroElement {
        */
       format: {
         type: String,
-        reflect: true
+        reflect: true,
+        noAccessor: true
       },
 
       /**
@@ -595,6 +598,34 @@ export default class BaseInput extends AuroElement {
     return this.max && dateFormatter.isValidDate(this.max) ? dateFormatter.stringToDateInstance(this.max) : undefined;
   }
 
+  get format() {
+    return this._format;
+  }
+
+  /**
+   * Overrides LitElement's generated accessor so we can track whether the
+   * consumer explicitly set `format`. Locale-derived updates use
+   * `_setFormatFromLocale` instead, which skips this flag.
+   */
+  set format(value) {
+    const oldValue = this._format;
+    this._format = value ? value.toLowerCase() : value;
+    this._userSetFormat = Boolean(value);
+    this.requestUpdate('format', oldValue);
+  }
+
+  /**
+   * Sets format without marking it as user-set. Used by locale auto-derive
+   * so that a subsequent locale change can still update the format.
+   * @private
+   * @param {string} value
+   */
+  _setFormatFromLocale(value) {
+    const oldValue = this._format;
+    this._format = value ? value.toLowerCase() : value;
+    this.requestUpdate('format', oldValue);
+  }
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -641,15 +672,6 @@ export default class BaseInput extends AuroElement {
     }
 
     this.inputId = this.id ? `${this.id}-input` : window.crypto.randomUUID();
-
-    // Normalize the format token to lowercase so case-mixed values supplied
-    // via attribute (e.g. `format="MM/DD/YYYY"`) hit the `dateFormatMap`
-    // lookup inside `setCustomHelpTextMessage`. Without this, an uppercase
-    // format silently misses the map and leaves `setCustomValidityForType`
-    // unset.
-    if (this.format) {
-      this.format = this.format.toLowerCase();
-    }
 
     // use validity message override if declared when initializing the component
     if (this.hasAttribute('setCustomValidity')) {
@@ -757,12 +779,10 @@ export default class BaseInput extends AuroElement {
   updated(changedProperties) {
     super.updated(changedProperties);
 
-    // When locale changes without an explicit format override, derive format from the new locale.
-    // Only runs if the current format is still the previous locale's default (not user-overridden).
+    // When locale changes, auto-derive format unless the consumer explicitly set one.
     if (changedProperties.has('locale') && !changedProperties.has('format') && this.type === 'date') {
-      const previousLocaleFormat = getDateFormatFromLocale(changedProperties.get('locale'));
-      if (!this.format || this.format.toLowerCase() === previousLocaleFormat) {
-        this.format = getDateFormatFromLocale(this.locale);
+      if (!this._userSetFormat) {
+        this._setFormatFromLocale(getDateFormatFromLocale(this.locale));
       }
     }
 
@@ -933,9 +953,6 @@ export default class BaseInput extends AuroElement {
         this.maskInstance.on('accept', () => {
           if (this._configuringMask) return;
           this.value = this.util.toModelValue(this.maskInstance.value, this.format);
-          if (this.type === "date") {
-            this._rawMaskValue = this.maskInstance.value;
-          }
         });
 
         // Mask fires 'complete' on the restore step below for any value that
@@ -943,9 +960,6 @@ export default class BaseInput extends AuroElement {
         this.maskInstance.on('complete', () => {
           if (this._configuringMask) return;
           this.value = this.util.toModelValue(this.maskInstance.value, this.format);
-          if (this.type === "date") {
-            this._rawMaskValue = this.maskInstance.value;
-          }
         });
 
         // Write existingValue through the mask (not the input directly) so
@@ -1182,8 +1196,7 @@ export default class BaseInput extends AuroElement {
 
     // Set default date format if type=date and no format is defined
     if (this.type === "date" && !this.format) {
-      // Use locale to determine default date format
-      this.format = this.util.getDateMaskFromLocale().toLowerCase();
+      this._setFormatFromLocale(this.util.getDateMaskFromLocale().toLowerCase());
       this.util.updateFormat(this.format);
     }
   }
@@ -1212,7 +1225,7 @@ export default class BaseInput extends AuroElement {
     const creditCard = this.matchInputValueToCreditCard();
     const previousFormat = this.format;
 
-    this.format = creditCard.maskFormat;
+    this._setFormatFromLocale(creditCard.maskFormat);
 
     this.maxLength = creditCard.formatLength;
     this.minLength = creditCard.formatMinLength;

--- a/components/input/test/auro-input-util.test.js
+++ b/components/input/test/auro-input-util.test.js
@@ -253,6 +253,21 @@ describe('AuroInputUtil', () => {
         expect(result).to.equal('xx/xx/xxxx');
       });
 
+      it('toModelValue with mm/dd/yy maps 2-digit years using date-fns rolling window', () => {
+        // date-fns `yy` token uses a rolling window: [currentYear-49, currentYear+50].
+        // Compute expected years dynamically so assertions stay correct as the window slides.
+        const util = new AuroInputUtilities({ locale: 'en-US' });
+        const refYear = new Date().getFullYear();
+        const resolve2digit = (yy) => {
+          const base = (Math.floor(refYear / 100) * 100) + yy;
+          if (base > refYear + 50) return base - 100;
+          if (base < refYear - 49) return base + 100;
+          return base;
+        };
+        expect(util.toModelValue('01/15/25', 'mm/dd/yy')).to.equal(`${resolve2digit(25)}-01-15`);
+        expect(util.toModelValue('12/31/99', 'mm/dd/yy')).to.equal(`${resolve2digit(99)}-12-31`);
+      });
+
       it('getDateMaskFromLocale uses locale parameter when this.locale is falsy', () => {
         const util = new AuroInputUtilities({ locale: 'en-US' });
         util.locale = '';

--- a/components/input/test/auro-input.test.js
+++ b/components/input/test/auro-input.test.js
@@ -1801,6 +1801,45 @@ function runFullTest(mobileView) {
         expect(el.valueObject).to.be.undefined;
       });
 
+      it('valueObject round-trips correctly on US DST spring-forward day (2025-03-09)', async () => {
+        const el = await fixture(html`<auro-input type="date"></auro-input>`);
+
+        el.value = '2025-03-09';
+        await elementUpdated(el);
+
+        expect(el.valueObject).to.be.instanceOf(Date);
+        expect(toISOFormatString(el.valueObject)).to.equal('2025-03-09');
+      });
+
+      it('valueObject round-trips correctly on US DST fall-back day (2024-11-03)', async () => {
+        const el = await fixture(html`<auro-input type="date"></auro-input>`);
+
+        el.value = '2024-11-03';
+        await elementUpdated(el);
+
+        expect(el.valueObject).to.be.instanceOf(Date);
+        expect(toISOFormatString(el.valueObject)).to.equal('2024-11-03');
+      });
+
+      it('valueObject round-trips correctly on a leap day (2024-02-29)', async () => {
+        const el = await fixture(html`<auro-input type="date"></auro-input>`);
+
+        el.value = '2024-02-29';
+        await elementUpdated(el);
+
+        expect(el.valueObject).to.be.instanceOf(Date);
+        expect(toISOFormatString(el.valueObject)).to.equal('2024-02-29');
+      });
+
+      it('valueObject is undefined for Feb 29 on a non-leap year (2023-02-29)', async () => {
+        const el = await fixture(html`<auro-input type="date"></auro-input>`);
+
+        el.value = '2023-02-29';
+        await elementUpdated(el);
+
+        expect(el.valueObject).to.be.undefined;
+      });
+
       it('keeps ISO model value and updates display when format changes', async () => {
         const el = await fixture(html`
           <auro-input type="date" format="mm/dd/yyyy"></auro-input>


### PR DESCRIPTION

# Alaska Airlines Pull Request
Addressing review https://github.com/AlaskaAirlines/auro-formkit/discussions/1526 

**Skipped by Jason / out of scope:**                                                                        
  - .1 Version bump — release process handles it                                                            
  - .3 Migration docs — release/migration guide handles it                                                  
  - .7 aria-pressed — works properly                                                      
  - .10 Silent en-US fallback — intentional logic
  - .6 AuroInputUtil in api.md — deferred (api.md is auto-generated, no clean path with WCA for a plain     
  object)    - Ticket created https://dev.azure.com/itsals/E_Retain_Content/_workitems/edit/1590521            
  - .2 AT date-format hint — helptext for date type input is intentionally left empty due to impossible localization support for every possible language                                                                                   
                                                           
  **Fixed this PR:**                                       
  - .9 _rawMaskValue dead code removed from base-input.js 
  - .5 yy century semantics test added
  - .8 DST/leap-year test coverage 
  - .4 Locale overwriting explicit format  - add setter/getter for noAccesor format

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update date input utilities and clean up unused masking state.

Bug Fixes:
- Align two-digit year parsing for mm/dd/yy date formats with date-fns rolling window semantics to ensure correct century resolution.

Enhancements:
- Remove unused _rawMaskValue field and related date-mask assignments from BaseInput to simplify input state management.

Tests:
- Add unit coverage verifying two-digit year mm/dd/yy inputs map to the expected full-year ISO dates based on date-fns behavior.