### PR TITLE
Select · Adversarial Review · 2026-07-02

### DIFF
--- a/components/input/src/utilities.js
+++ b/components/input/src/utilities.js
@@ -7,7 +7,7 @@ import { dateFormatter } from "@aurodesignsystem/auro-library/scripts/runtime/da
 
 // ---------------------------------------------------------------------
 
-/* eslint-disable no-magic-numbers, dot-location, no-extra-parens, object-property-newline, radix, no-nested-ternary */
+/* eslint-disable no-magic-numbers, dot-location, no-extra-parens, object-property-newline, no-nested-ternary, complexity, max-lines */
 
 import IMask from 'imask';
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -896,6 +896,15 @@ export class AuroSelect extends AuroElement {
       if (this.menu.optionSelected !== undefined) {
         return;
       }
+      // Skip when the select is already cleared (valueless click with no
+      // prior selection): value/optionSelected are already empty and there
+      // is no stale trigger text to refresh, so updateDisplayedValue would
+      // just churn the DOM and request a needless dropdown re-render.
+      const hasStaleState = this.value !== undefined ||
+        (this.multiSelect ? this.optionSelected?.length > 0 : this.optionSelected !== undefined);
+      if (!hasStaleState) {
+        return;
+      }
       this.value = undefined;
       this.optionSelected = this.multiSelect ? [] : undefined;
       // The trigger label is rendered imperatively into #value, so a property

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -925,10 +925,15 @@ export class AuroSelect extends AuroElement {
         if (this.dropdown.isPopoverVisible) {
           announceToScreenReader(this._getAnnouncementRoot(), message);
         } else {
-          // Typeahead-on-closed fires this event before `show()` flips
-          // isPopoverVisible. Defer so the announcement targets the bib's
-          // live region once the fullscreen <dialog> opens — otherwise it
-          // lands in the host root, which is inert under the active modal.
+          // Typeahead-on-closed calls updateActiveOption() before show(), so
+          // this handler runs with isPopoverVisible still false. queueMicrotask
+          // is safe because show() → showBib() flips isPopoverVisible and
+          // dialog.showModal() both run synchronously in the same task; the
+          // microtask queue only drains once _handleTypeahead unwinds, by
+          // which point _getAnnouncementRoot() resolves to the bib's shadow
+          // root inside the now-open modal. Do NOT switch to auroDropdown-toggled
+          // — it fires before showModal(), landing the announcement in the
+          // host root while the dialog is still not-yet-modal.
           queueMicrotask(() => announceToScreenReader(this._getAnnouncementRoot(), message));
         }
       }

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1429,8 +1429,13 @@ export class AuroSelect extends AuroElement {
     // Hidden native <select> has no `multiple` attribute, so any change it fires
     // is a single raw value — applying it in multiSelect mode would collapse the
     // JSON-array `value` shape. Bfcache/autofill can reach this on a name-bearing
-    // form control even with aria-hidden/tabindex=-1.
-    if (this.multiSelect) return;
+    // form control even with aria-hidden/tabindex=-1, so revert to the expected
+    // mirror (formattedValue[0]) rather than letting the native select drift and
+    // silently submit the autofilled scalar under `name`.
+    if (this.multiSelect) {
+      this._updateNativeSelect();
+      return;
+    }
 
     const selectedOption = event.target.options[event.target.selectedIndex];
     if (!selectedOption) return;

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1327,6 +1327,13 @@ export class AuroSelect extends AuroElement {
     }
 
     if (changedProperties.has('value')) {
+      // A value change ends the current interaction — whether it came from a
+      // user commit, programmatic assignment, or reset(). Clear the buffer so
+      // a stale prefix does not concatenate onto the next keystroke while the
+      // host still has focus (the blur listener would otherwise be the only
+      // focus-retained clear point, and hideBib() below does not blur).
+      this._clearTypeaheadBuffer();
+
       this.setMenuValue(this.value);
 
       this._updateNativeSelect();
@@ -1382,6 +1389,9 @@ export class AuroSelect extends AuroElement {
    * @returns {void}
    */
   reset() {
+    // Defense-in-depth: updated()'s value-change branch also clears, but
+    // reset-to-same-value (e.g. undefined → undefined) skips that path.
+    this._clearTypeaheadBuffer();
     this.menu.reset();
     this.validation.reset(this);
   }

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -838,6 +838,12 @@ export class AuroSelect extends AuroElement {
 
   /**
    * Binds all behavior needed to the menu after rendering.
+   *
+   * The `<auro-menu>` reference is captured once and not re-targeted on
+   * `slotchange`. Runtime option mutations are covered via
+   * `auroMenu-optionsChange`, so swap options inside the menu freely; do not
+   * swap the `<auro-menu>` element itself under a live select — remount the
+   * parent `<auro-select>` instead.
    * @private
    * @returns {void}
    */

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -20,7 +20,7 @@ import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/util
 
 import { announceToScreenReader, doubleRaf, guardTouchPassthrough, restoreTriggerAfterClose, applyKeyboardStrategy } from '@aurodesignsystem/utils';
 import { selectKeyboardStrategy } from './selectKeyboardStrategy.js';
-import { getActiveOptions, getEnabledOptions } from './selectUtils.js';
+import { getActiveOptions } from './selectUtils.js';
 
 import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
 
@@ -588,8 +588,11 @@ export class AuroSelect extends AuroElement {
           } else if (this.multiSelect && Array.isArray(this.optionSelected) && this.optionSelected.length > 0) {
             this.menu.updateActiveOption(this.optionSelected[0]);
           } else {
-            // If no activeOption has yet to be set, then make the first enabled option active by default
-            const [firstActive] = getEnabledOptions(this.menu);
+            // If no activeOption has yet to be set, make the first active option
+            // (non-disabled, non-hidden, non-static) active by default. "Active" —
+            // not just "enabled" — so hidden rows and static placeholders never
+            // land in aria-activedescendant on open.
+            const [firstActive] = getActiveOptions(this.menu);
             this.menu.updateActiveOption(firstActive);
           }
         }

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -1,6 +1,6 @@
 /* eslint-disable new-cap */
 import { navigateArrow } from '@aurodesignsystem/utils';
-import { getEnabledOptions } from './selectUtils.js';
+import { getActiveOptions } from './selectUtils.js';
 
 export const selectKeyboardStrategy = {
   ArrowDown(component, evt, ctx) {
@@ -53,8 +53,10 @@ export const selectKeyboardStrategy = {
   End(component, evt, ctx) {
     evt.preventDefault();
     evt.stopPropagation();
-    // `pop()` is safe here: getEnabledOptions returns a fresh filtered array.
-    const lastOption = getEnabledOptions(component.menu).pop();
+    // `pop()` is safe here: getActiveOptions returns a fresh filtered array.
+    // Uses "active" (not "enabled") so hidden and static rows — which a screen
+    // reader must not announce as focused — are skipped.
+    const lastOption = getActiveOptions(component.menu).pop();
     if (!lastOption) {
       return;
     }
@@ -85,7 +87,7 @@ export const selectKeyboardStrategy = {
   Home(component, evt, ctx) {
     evt.preventDefault();
     evt.stopPropagation();
-    const [firstOption] = getEnabledOptions(component.menu);
+    const [firstOption] = getActiveOptions(component.menu);
     if (!firstOption) {
       return;
     }

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -112,6 +112,15 @@ export const selectKeyboardStrategy = {
   },
 
   default(component, evt, ctx) {
+    // Ignore keys chorded with Ctrl/Meta/Alt so browser/OS shortcuts
+    // (Cmd+C, Ctrl+V, Alt+X, Cmd+Space, …) don't leak into typeahead
+    // or toggle the bib. Native <select> ignores modified keys.
+    // ArrowUp/ArrowDown handle modifier+arrow explicitly above; this
+    // guard only affects the default (printable/Space) branch.
+    if (evt.ctrlKey || evt.metaKey || evt.altKey) {
+      return;
+    }
+
     // Space resolves to either typeahead-buffer extension or bib toggle
     // depending on whether a type-ahead buffer is active. Mirrors native
     // <select> and the WAI-ARIA APG Listbox guidance: mid-typeahead space

--- a/components/select/test/MANUAL_TESTING.md
+++ b/components/select/test/MANUAL_TESTING.md
@@ -47,9 +47,9 @@
 [ ] Enter on a highlighted option — verify it selects the option, closes the dialog, and returns focus to the trigger
 [ ] Escape — verify the dialog closes without selecting and focus returns to the trigger
 [ ] Space on a highlighted option — verify same behavior as Escape
-[ ] Tab (no option highlighted) — verify the dialog closes and focus returns to the trigger
-[ ] Tab (option highlighted) — verify the highlighted option is selected, the dialog closes, and focus returns to the trigger
-[ ] Shift+Tab — verify the highlighted option is selected, the dialog closes, and focus moves to the previous element
+[ ] Tab (no option highlighted) — verify the dialog closes and focus moves to the next focusable element after the select (same as desktop; native `<dialog>` focus restoration + browser Tab traversal)
+[ ] Tab (option highlighted) — verify the highlighted option is selected, the dialog closes, and focus moves to the next focusable element after the select
+[ ] Shift+Tab — verify the highlighted option is selected, the dialog closes, and focus moves to the previous focusable element before the select
 [ ] Home — verify visual focus moves to the first option
 [ ] End — verify visual focus moves to the last option
 

--- a/components/select/test/MANUAL_TESTING.md
+++ b/components/select/test/MANUAL_TESTING.md
@@ -53,6 +53,19 @@
 [ ] Home — verify visual focus moves to the first option
 [ ] End — verify visual focus moves to the last option
 
+## Type-ahead / Type-to-search
+
+[ ] With bib closed, type letters that match an option prefix (e.g., "ba") — verify the bib opens and the first matching option is highlighted
+[ ] With bib closed, type letters that match no option (e.g., "zzz") — verify the bib stays closed (intentional deviation from native select)
+[ ] With bib open, type same letter repeatedly (e.g., "a" then "a" again with no prefix match) — verify visual focus cycles through options starting with that letter
+[ ] With bib open, type a multi-letter prefix (e.g., "app") — verify the first option whose text starts with the buffer is highlighted (prefix match, not cycle)
+[ ] Type letters, then wait ~500ms without typing — verify the next keystroke starts a fresh buffer
+[ ] With bib open and typeahead buffer active, press Space — verify the space extends the buffer (does not toggle/close the bib)
+[ ] With bib open and buffer empty, press Space on a highlighted option — verify same behavior as Escape (closes without selecting)
+[ ] Type letters to build a buffer, then press Escape — verify the buffer clears (next keystroke starts fresh, not a continuation)
+[ ] Type letters to build a buffer, then blur the trigger (Tab away) — verify the buffer clears
+[ ] Set value programmatically or call `reset()` while a buffer is pending — verify the buffer clears
+
 ## Touch / Tap Interactions
 
 [ ] Tap the trigger — verify the bib opens (popover on desktop, fullscreen on mobile)
@@ -149,6 +162,21 @@
 [ ] Verify focus trapping in fullscreen dialog mode
 [ ] Verify color contrast meets WCAG 2.1 AA in both default and inverse appearances
 [ ] Verify focus indicators are clearly visible
+
+### Multi-Select Announcements
+[ ] In multi-select mode, select an option — verify screen reader announces `"<label>, selected"` (only the toggled option, not the full list)
+[ ] In multi-select mode, deselect a previously selected option — verify screen reader announces `"<label>, not selected"`
+[ ] Rapidly toggle multiple options — verify each add/remove is announced individually (announcements are debounced ~300ms so the `aria-expanded` collapse announcement does not override them)
+
+### aria-setsize / aria-posinset
+[ ] Inspect any option in the DOM — verify `aria-setsize` equals the total count of visible (non-hidden, non-static) options
+[ ] Inspect any option — verify `aria-posinset` equals its 1-based position among visible options
+[ ] Dynamically add or remove options via slot change (or via async/lazy load) — verify `aria-setsize` and `aria-posinset` re-stamp on all remaining options
+[ ] Change `value` programmatically to trigger a menu re-init — verify positional ARIA attributes remain correct
+
+### Mobile Announcement Routing
+[ ] At the fullscreen breakpoint, open the dialog and select/deselect an option in multi-select — verify the screen reader hears the announcement (the live region is routed into the bib's shadow root because everything outside the `<dialog>` is inert)
+[ ] At desktop (popover) sizes, verify the same announcements come from the host component's shadow root live region
 
 ## Slots
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3762,6 +3762,98 @@ function runTest(mobileView) {
         });
       });
 
+      // Regression: chorded shortcuts (Cmd+C, Ctrl+V, Alt+X, Cmd+Space, …)
+      // must not leak into the type-ahead buffer or toggle the bib. Native
+      // <select> ignores modified letter/Space keys; the default-branch
+      // guard in selectKeyboardStrategy enforces the same.
+      describe('Modifier-chorded printable keys', () => {
+        it('should ignore Ctrl+letter — no typeahead buffer, no bib open', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true }));
+          await elementUpdated(el);
+
+          expect(el.typeaheadBuffer).to.equal('');
+          expect(el.menu.optionActive).to.not.exist;
+          await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+
+        it('should ignore Meta+letter — no typeahead buffer, no bib open', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', metaKey: true }));
+          await elementUpdated(el);
+
+          expect(el.typeaheadBuffer).to.equal('');
+          expect(el.menu.optionActive).to.not.exist;
+          await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+
+        it('should ignore Alt+letter — no typeahead buffer, no bib open', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'x', altKey: true }));
+          await elementUpdated(el);
+
+          expect(el.typeaheadBuffer).to.equal('');
+          expect(el.menu.optionActive).to.not.exist;
+          await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+
+        it('should not toggle the bib on Ctrl+Space / Meta+Space / Alt+Space', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+          await expect(dropdown.isPopoverVisible).to.be.false;
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', ctrlKey: true }));
+          await elementUpdated(el);
+          await expect(dropdown.isPopoverVisible).to.be.false;
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', metaKey: true }));
+          await elementUpdated(el);
+          await expect(dropdown.isPopoverVisible).to.be.false;
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', altKey: true }));
+          await elementUpdated(el);
+          await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+
+        it('should not extend an active typeahead buffer with Ctrl+letter', async () => {
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="apple">Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+          await elementUpdated(el);
+
+          // Seed a buffer.
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+          await elementUpdated(el);
+          expect(el.typeaheadBuffer).to.equal('a');
+
+          // Ctrl+p must not append 'p' to the buffer.
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'p', ctrlKey: true }));
+          await elementUpdated(el);
+          expect(el.typeaheadBuffer).to.equal('a');
+        });
+      });
+
       describe('Tab', () => {
         it('should close the bib', async () => {
           const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2432,24 +2432,6 @@ function runTest(mobileView) {
             trigger.click();
             await expect(dropdown.isPopoverVisible).to.be.false;
           });
-
-          // // BUG: The select uses popover='manual' which does not support light dismiss,
-          // // and noHideOnThisFocusLoss is set to true, so clicking outside does not close the bib.
-          // it('should close the bib when clicking outside the select element', async () => {
-          //   const el = await defaultFixture();
-          //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-          //   const trigger = dropdown.querySelector('[slot="trigger"]');
-
-          //   trigger.click();
-          //   await elementUpdated(el);
-          //   await expect(dropdown.isPopoverVisible).to.be.true;
-
-          //   // Click outside the select element
-          //   document.body.click();
-          //   await elementUpdated(el);
-
-          //   await expect(dropdown.isPopoverVisible).to.be.false;
-          // });
         });
 
         describe('Menu Option', () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2383,9 +2383,8 @@ function runTest(mobileView) {
         const menu = el.querySelector('auro-menu');
         const labelSlot = el.querySelector('[slot="label"]');
 
-        if (labelSlot && menu.hasAttribute('aria-label')) {
-          expect(menu.getAttribute('aria-label')).to.equal(labelSlot.textContent.trim());
-        }
+        expect(labelSlot, 'label slot should be present').to.exist;
+        expect(menu.getAttribute('aria-label')).to.equal(labelSlot.textContent.trim());
       });
 
       it('updates menu aria-label and dropdown bibDialogLabel when label text mutates at runtime', async () => {
@@ -4483,7 +4482,7 @@ function runTest(mobileView) {
           el.updateActiveOptionBasedOnKey('n');
           await elementUpdated(el);
 
-          await expect(el.menu.optionActive === undefined || el.menu.optionActive === null).to.be.true;
+          await expect(el.menu.optionActive).to.not.exist;
         });
 
         it('should not mutate the buffer when all options are disabled', async () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -3,6 +3,7 @@ import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plu
 
 import { fixture, html, expect, elementUpdated, waitUntil } from '@open-wc/testing';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '@aurodesignsystem/auro-dropdown';
 import '../../menu/src/registered.js';
 import '../src/registered.js';
@@ -2251,18 +2252,30 @@ function runTest(mobileView) {
           const el = await defaultFixture();
           await elementUpdated(el);
 
-          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
-          await elementUpdated(el);
+          // Fake only setTimeout/clearTimeout — the announcement's cleanup timer
+          // is scheduled from inside a real rAF, so we need the fake in place
+          // before that rAF fires, but rAF/microtasks/Date must stay real so
+          // Lit's scheduler and @open-wc/testing helpers keep working.
+          const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
 
-          await new Promise((resolve) => requestAnimationFrame(resolve));
-          const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
-          expect(liveRegion.textContent).to.not.equal('');
+          try {
+            el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+            await elementUpdated(el);
 
-          // Multiple announcements can chain (e.g., active-option followed by selection),
-          // each resetting the 1000ms cleanup timer. Wait long enough for the final
-          // announcement's timer to expire.
-          await new Promise((resolve) => setTimeout(resolve, 2200));
-          expect(liveRegion.textContent).to.equal('');
+            // Real rAF frames: the first flushes announceToScreenReader's rAF
+            // callback (sets textContent, arms the fake 1000ms cleanup); the
+            // second absorbs any chained announcement (e.g., active-option
+            // followed by selection) that would rearm the timer.
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            const liveRegion = getAnnouncementRoot(el.dropdown, el.shadowRoot).querySelector('#srAnnouncement');
+            expect(liveRegion.textContent).to.not.equal('');
+
+            await clock.tickAsync(1000);
+            expect(liveRegion.textContent).to.equal('');
+          } finally {
+            clock.restore();
+          }
         });
 
         it('should not announce activation of an already-selected option', async () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -4551,6 +4551,45 @@ function runTest(mobileView) {
           expect(el.typeaheadBuffer).to.equal('');
         });
 
+        it('should clear the type-ahead buffer when value is set programmatically', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          // Seed the buffer while the host keeps focus.
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+          await elementUpdated(el);
+          expect(el.typeaheadBuffer).to.equal('a');
+          expect(el._typeaheadTimeout).to.not.equal(null);
+
+          // Programmatic value change (e.g. a parent controller or reset button)
+          // must reset the buffer so the next keystroke starts fresh.
+          el.value = 'Grapes';
+          await elementUpdated(el);
+          expect(el.typeaheadBuffer).to.equal('');
+          expect(el._typeaheadTimeout).to.equal(null);
+
+          // 'b' alone should now activate 'Bananas' — would fail if 'a' had
+          // survived, since 'ab' has no match.
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }));
+          await elementUpdated(el);
+          await expect(el.menu.optionActive.value).to.equal('Bananas');
+        });
+
+        it('should clear the type-ahead buffer on reset()', async () => {
+          const el = await defaultFixture();
+          await elementUpdated(el);
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+          await elementUpdated(el);
+          expect(el.typeaheadBuffer).to.equal('a');
+          expect(el._typeaheadTimeout).to.not.equal(null);
+
+          el.reset();
+          await elementUpdated(el);
+          expect(el.typeaheadBuffer).to.equal('');
+          expect(el._typeaheadTimeout).to.equal(null);
+        });
+
         it('cycles active option via type-ahead in multiselect mode without altering selection', async () => {
           const el = await multiSelectFixture();
           await elementUpdated(el);

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1812,6 +1812,26 @@ function runTest(mobileView) {
         expect(el.value).to.equal(JSON.stringify(['Apples', 'Bananas']));
       });
 
+      // ─── autofill/bfcache divergence on multiSelect is reverted ──
+      it('reverts hidden native <select> to formattedValue[0] on autofill in multiSelect', async () => {
+        const el = await multiSelectFixture();
+        el.value = JSON.stringify(['Apples', 'Bananas']);
+        await elementUpdated(el);
+
+        const { nativeSelect } = el;
+        expect(nativeSelect.value).to.equal('Apples');
+
+        // Simulate autofill/bfcache writing a divergent value + firing change,
+        // exactly what a password manager or restored form state would do.
+        nativeSelect.value = 'Cherries';
+        nativeSelect.dispatchEvent(new Event('change'));
+
+        // Component value stays authoritative and native select is snapped back
+        // to formattedValue[0] so form submissions under `name` stay consistent.
+        expect(el.value).to.equal(JSON.stringify(['Apples', 'Bananas']));
+        expect(nativeSelect.value).to.equal('Apples');
+      });
+
       // ─── renderNativeSelect falls back to textContent when option has no value ──
       it('renderNativeSelect uses textContent when option.value is empty', async () => {
         const el = await defaultFixture();

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1334,6 +1334,31 @@ function runTest(mobileView) {
           await elementUpdated(el);
           await expect(dropdown.isPopoverVisible).to.be.true;
         });
+
+        // Guards auro-select.js first-highlight fallback: on open with no
+        // selection, the first *active* option (not just non-disabled) must be
+        // highlighted so aria-activedescendant never points at a hidden row or
+        // static placeholder.
+        it('should highlight the first non-hidden, non-static option on open', async () => {
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption static>Header</auro-menuoption>
+                <auro-menuoption value="apple" hidden>Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+                <auro-menuoption value="cherry">Cherry</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+          el.showBib();
+          await elementUpdated(el);
+
+          await expect(el.menu.optionActive.value).to.equal('banana');
+        });
       });
 
       describe('setMenuValue', () => {
@@ -3160,6 +3185,54 @@ function runTest(mobileView) {
           await expect(el.optionActive).to.equal(lastOption);
         });
 
+        it('should skip options with the hidden attribute', async () => {
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="apple">Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+                <auro-menuoption value="cherry" hidden>Cherry</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+          el.showBib();
+          await elementUpdated(el);
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+          await elementUpdated(el);
+
+          // A hidden option must never land in aria-activedescendant.
+          await expect(el.optionActive.value).to.equal('banana');
+        });
+
+        it('should skip options with the static attribute', async () => {
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="apple">Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+                <auro-menuoption static>Footer</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+          el.showBib();
+          await elementUpdated(el);
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+          await elementUpdated(el);
+
+          await expect(el.optionActive.value).to.equal('banana');
+          await expect(el.optionActive.hasAttribute('static')).to.be.false;
+        });
+
         // Regression guard: pressing End while collapsed must produce exactly one
         // auroMenu-activatedOption dispatch. show() synchronously fires
         // auroDropdown-toggled, whose handler will set a fallback active option
@@ -3542,6 +3615,54 @@ function runTest(mobileView) {
           const menu = el.querySelector('auro-menu');
           const firstOption = menu.querySelector('auro-menuoption[value="Apples"]');
           await expect(el.optionActive).to.equal(firstOption);
+        });
+
+        it('should skip a leading hidden option', async () => {
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption value="apple" hidden>Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+                <auro-menuoption value="cherry">Cherry</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+          el.showBib();
+          await elementUpdated(el);
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+          await elementUpdated(el);
+
+          // A hidden option must never land in aria-activedescendant.
+          await expect(el.optionActive.value).to.equal('banana');
+        });
+
+        it('should skip a leading static placeholder', async () => {
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <span slot="label">Name</span>
+              <auro-menu>
+                <auro-menuoption static nomatch>No results</auro-menuoption>
+                <auro-menuoption value="apple">Apple</auro-menuoption>
+                <auro-menuoption value="banana">Banana</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+
+          await elementUpdated(el);
+          el.showBib();
+          await elementUpdated(el);
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+          await elementUpdated(el);
+
+          await expect(el.optionActive.value).to.equal('apple');
+          await expect(el.optionActive.hasAttribute('static')).to.be.false;
         });
 
         // Regression guard: see matching test under End — same double-dispatch risk.
@@ -4336,14 +4457,13 @@ function runTest(mobileView) {
           await elementUpdated(el);
 
           // 'n' is the first letter of the static "No results" placeholder
-          // (the only option whose displayed text starts with 'n').
-          // Type-ahead must NOT activate that row.
+          // (the only option whose displayed text starts with 'n'). Type-ahead
+          // must NOT activate that row — since no other option matches, the
+          // expected outcome is no active option at all.
           el.updateActiveOptionBasedOnKey('n');
           await elementUpdated(el);
 
-          if (el.menu.optionActive) {
-            await expect(el.menu.optionActive.hasAttribute('static')).to.be.false;
-          }
+          await expect(el.menu.optionActive === undefined || el.menu.optionActive === null).to.be.true;
         });
 
         it('should not mutate the buffer when all options are disabled', async () => {

--- a/docs/post-mortem/1511.md
+++ b/docs/post-mortem/1511.md
@@ -1,0 +1,186 @@
+# Post-Mortem: auro-select Adversarial Review Bug Fixes (PR #1511)
+
+**Branch:** `cfriedberg/advers-review` → `dev`
+**PR:** [#1511](https://github.com/AlaskaAirlines/auro-formkit/pull/1511)
+**Merge commit:** `1bf42261b`
+**Release:** `v6.0.0-rc-1484.6` (preview `@aurodesignsystem-dev/auro-formkit@0.0.0-pr1511.1`)
+**Scope:** Structured response to an adversarial review of `auro-select` against WAI-ARIA APG's select-only combobox pattern and native `<select>` behavior. Nine numbered findings across P0–P3; six fixes shipped, three findings rejected with justification tests that lock the deviation in. One unrelated Chromium fix on `auro-counter-group` was folded in when the same nested-shadow-root failure mode was found in adjacent code. 24 commits, 12 files, +726/−96.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| An adversarial review flags a select-only combobox for missing ARIA plumbing (aria-haspopup, aria-setsize/posinset, live labels) | Trust the audit for coverage but verify each finding against APG + native `<select>` before implementing. Three of nine findings here were APG-compliant "bugs" that were actually spec-conformant; fixing them would have broken form UX. Add tests that document the intentional deviation rather than "fixing" the deviation away. |
+| Announcing a typeahead match on a mobile fullscreen `<dialog>` and the live region goes silent | `showBib()` flips `isPopoverVisible` synchronously, but the fullscreen promotion inerts the host shadow root within the same task. Defer the announce one `queueMicrotask` so `_getAnnouncementRoot()` resolves to the dialog's shadow root instead of the inert host. |
+| A `MutationObserver` on the label slot works on first render then goes dead after the host is reparented | `firstUpdated` is a one-shot Lit lifecycle. Re-arm the observer from `connectedCallback` gated on `hasUpdated` — you own the reconnect path, Lit doesn't. |
+| Attempting to detach `this.menu` listeners for GC hygiene | `this.menu` is a light-DOM child of the host. When the host is unreachable, the menu is too; GC handles the cycle. The `firstUpdated`-only attach is deliberate — reattach-on-reconnect would need AbortController + `connectedCallback` re-arm, which is out of scope for this PR. Guard the current shape with a disconnect+reconnect regression test. |
+| Home/End on a *closed* combobox does nothing | APG lists Home/End under "Listbox Popup Keyboard Interactions" — the collapsed case is unspecified. Native `<select>` opens on Home/End and lands on first/last. Mirror native. Pre-stash the active option before `dropdown.show()` so the `auroDropdown-toggled` handler's `!optionActive` guard doesn't paint a transient "first option" activation on End. |
+| Nested `<auro-dropdown>` (counter inside select's bib) closes when focus lands on the inner control on Chromium only | Chromium's `:focus-within` fails to match a dropdown host across nested shadow roots (dropdown → bib → bibtemplate → counter-group → counter). Set `noHideOnThisFocusLoss = true` on the inner dropdown — same mitigation `auro-select` and `auro-combobox` already carry. |
+
+## What Landed vs What Was Reviewed
+
+| Adversarial finding | Priority | Verdict | Shipped as |
+|---|---|---|---|
+| 1. Enter swallows form submission | P0 | Rejected — intentional | Explanatory comment + regression test (`97ff085a8`) |
+| 2. Tab handler does not preventDefault | P1 | Rejected — spec-conformant | Assertion test (`511d3ac3b`) |
+| 3. Missing `aria-haspopup="listbox"` on trigger | P1 | Accepted | `73e3eeeb9` + `cf5dfba88` follow-up |
+| 4. `aria-setsize`/`aria-posinset` not re-stamped on options change | P1 | Accepted | `5dd78142c` |
+| 5. Menu event listeners never detached | P2 | Rejected — GC-clean; reattach-on-reconnect out of scope | Regression test (`672784b52`) + comment (`bdcc0d366`) |
+| 6. Dead reactive state (`options`) triggers unnecessary renders | P2 | Accepted | `aba3effaa` (explicit `requestUpdate()`) |
+| 7. Duplicate "selected" announce on bib open | P3 | Accepted | `ffa6bdaa8` |
+| 8. Label slot mutations don't re-sync accessible name | P3 | Accepted | `2f528858c` + `ee105cfae` + `a5588b0fe` |
+| 9. Typeahead prefers repeat-char cycle over prefix match | P3 | Accepted | `a014c996e` |
+
+Rejected findings each earned a *test that pins the deviation* — not just a comment. If a future contributor "cleans up" the intentional behavior, CI fails and the test comment points them at the rationale. This is what elevates a rejection from an opinion to a durable contract.
+
+## The Six Fixes
+
+### Fix 1 — `aria-haspopup="listbox"` on the combobox trigger (P1-3)
+
+**File:** `components/dropdown/src/auro-dropdown.js` (+1).
+`auro-dropdown` was rendering the trigger as `role="combobox"` with `aria-expanded` but omitting `aria-haspopup`. APG explicitly requires `aria-haspopup="listbox"` on a select-only combobox trigger so AT can announce "collapsed listbox" / "expanded listbox" correctly. Added the attribute unconditionally in the render, then follow-up commit `cf5dfba88` refined so it only applies when the trigger is focusable (bare visual `<auro-dropdown>` instances that aren't comboboxes stay clean). Test coverage in `components/dropdown/test/auro-dropdown.test.js` (+49).
+
+### Fix 2 — Re-stamp `aria-setsize`/`aria-posinset` on options change (P1-4)
+
+**File:** `components/select/src/auro-select.js`.
+Options set at first render were correctly annotated with `aria-setsize` and `aria-posinset`. When options were added or removed at runtime, `auro-menu` fires `auroMenu-optionsChange` but nothing re-annotated. AT reported stale "1 of 4" while a five-item listbox rendered. Fix wires an `auroMenu-optionsChange` listener that re-walks `menu.options` and re-stamps both attributes. Regression test asserts the counter updates after a dynamic append.
+
+### Fix 3 — Explicit `requestUpdate()` instead of dead reactive state (P2-6)
+
+**File:** `components/select/src/auro-select.js`.
+`static properties.options = { state: true }` existed but nothing ever assigned to it. The intent was to force re-render when options changed, but the reactive declaration was dead code — the render function reads `menu.options`, not `this.options`. Fix removes the property and adds `this.requestUpdate()` at the exact call site that needed to re-render the hidden native `<select>` reflecting current options. Less magic, one place to look.
+
+### Fix 4 — Silence duplicate "selected" announcement on bib open (P3-1)
+
+**File:** `components/select/src/auro-select.js`.
+When the bib opened with a pre-selected option, two announcements fired: the initial "selected" from the option-selection watcher and a second "selected" from the bib-open activation path. AT users heard the value twice. Fix short-circuits the redundant announce path when `menu.optionSelected` already reflects the active option at open time. Regression test asserts a single dispatch of the live-region push for the "open with pre-selection" flow.
+
+### Fix 5 — Live label slot resync (P3-8)
+
+**Files:** `components/select/src/auro-select.js` — `_observeLabelChanges()` + `_syncLabelText()`.
+Static label wiring worked; changing `<span slot="label">` textContent at runtime left `menu.aria-label` and `dropdown.bibDialogLabel` frozen. Fix runs a `MutationObserver` on the host's `[slot="label"]` subtree, feeds text updates into both consumers. Three commits refined:
+
+1. `2f528858c` — initial observer keyed off host with subtree.
+2. `ee105cfae` — Sourcery feedback: scope observer to the *slotted node* (not the host) to avoid observing unrelated mutations. Performance-only refactor.
+3. `a5588b0fe` — reconnect fix. `firstUpdated` runs once; if the host is disconnected and re-inserted, the observer must re-attach. Re-arm from `connectedCallback` gated on `hasUpdated` (skip on first connect so `firstUpdated` still owns the initial attach).
+
+### Fix 6 — Prefix-match precedence in typeahead (P3-9)
+
+**File:** `components/select/src/auro-select.js` — `_handleTypeahead()`.
+Prior implementation cycled through options whose first character matched the latest key — the classic native-`<select>` repeat-char behavior. But when the buffer accumulated multi-character input, prefix matches lost to the cycle: `"aa"` against `[Aardvark, Anchor]` landed on Anchor (second `a` cycled) instead of Aardvark (prefix match). Fix reorders: try prefix match on the full buffer first; only fall back to repeat-char cycle if the buffer is a single character. Companion commits:
+
+- `c5748c31a` — when typeahead opens the bib, call `updateActiveOption(match)` *before* `dropdown.show()` so the toggled event's guard sees the correct active option (avoids a transient "first option" paint).
+- `247ba291d` — regression test: a no-match keystroke against a closed bib leaves the bib closed. Intentional deviation from native `<select>`, which opens on any printable keystroke. APG doesn't specify; the team preferred quiet.
+- `962954c0f` — announcement routing. `queueMicrotask` around the announce call so `_getAnnouncementRoot()` resolves to the dialog's shadow root on mobile fullscreen (dialog promotion inerts the host root within the same task).
+
+## The Three Rejections
+
+### Rejection 1 — Enter must not `stopPropagation` (P0-1)
+
+**Finding:** `selectKeyboardStrategy.js:66-74` calls `stopPropagation()` on Enter, preventing enclosing `<form>` submission.
+
+**Verdict:** Intentional. `auro-select` follows APG's select-only combobox where Enter opens the listbox (collapsed) or selects the active option (expanded) — never submits. Native `<select>` behaves identically. `auro-select` is not form-associated; `auro-form`'s keydown listener would otherwise submit on Enter over a `<auro-select>`. Guard: commit `97ff085a8` added two tests inside the Enter describe block — closed→open path and open→select path — that both assert `bubbles: false` past the select's root. Source comment cites `keyboard-spec.md:188-196`.
+
+### Rejection 2 — Tab handler doesn't `preventDefault` (P1-2)
+
+**Finding:** `selectKeyboardStrategy.js:88-99` catches Tab to `dropdown.hide()` but doesn't `preventDefault`, so focus tabs to the next control while the bib is closing.
+
+**Verdict:** Spec-conformant. APG's Tab actions explicitly include "Perform the default action, moving focus to the next focusable element." `dropdown.hide()` in popover mode doesn't move focus; the `setTimeout` refocus branch is gated on `isPopoverVisible === true`, so it only runs when the bib was open. Closed-bib Tab is native. Guard: commit `511d3ac3b` — assertion tests at `auro-select.test.js:3351-3483` plus prose in `keyboardBehavior.md:158-178`.
+
+### Rejection 3 — Menu event listeners never detached (P2-5)
+
+**Finding:** `auro-select.js:832, 834, 843, 862` attach four listeners on `this.menu` in `firstUpdated` and never call `removeEventListener`. Suggested fix: track handlers, remove in `disconnectedCallback`.
+
+**Verdict:** Rejected on two grounds. First, `this.menu` is a light-DOM *child* of the host — when the host becomes unreachable, the menu becomes unreachable, and GC handles the reference cycle. There's no listener leak in practice. Second, the *proposed* fix (remove in `disconnectedCallback`) would silently break the reconnect case: `firstUpdated` is one-shot, so listeners removed on disconnect would never re-attach. Correct fix would be `AbortController` + reattach in `connectedCallback` — real work, out of scope for a review-response PR. Same pattern exists in `auro-combobox.js` and `auro-calendar.js` — a fleet-wide refactor if adopted. Guard: commit `672784b52` disconnects+reconnects and asserts `auroMenu-activatedOption` etc. still fire; `bdcc0d366` improved the source comment so a future contributor doesn't "clean up" the attach.
+
+## What Was Not Planned but Also Shipped
+
+Two counter-related changes rode in on the same branch:
+
+**`bbb1976bd` — Prevent Chromium dropdown auto-close on counter-group.** Investigating an unrelated bug surfaced during the review, we found `<auro-counter-group>`'s internal `<auro-dropdown>` was closing when focus crossed nested shadow roots on Chromium. Root cause: Chromium's `:focus-within` implementation doesn't traverse `dropdown → bib → bibtemplate → counter-group → counter`. `auro-select` and `auro-combobox` already carry `noHideOnThisFocusLoss = true` as the workaround; `auro-counter-group` was missing it. One-line fix, +7 with the test setup.
+
+**`1bf42261b` — Real `click` for outside-close test.** The previously merged counter test used `.focus()` on a hidden element to simulate outside interaction — passed in wtr's headless Chromium, misrepresented what a real user does. Swapped to a real `click` on a visible element outside the dropdown, catching the same regression path more honestly.
+
+These are folded in because the counter fixes came from the same investigation. In hindsight they should have been a separate PR — the diff would tell a cleaner story about which change fixed what.
+
+## Tests Added
+
+New assertions in `components/select/test/auro-select.test.js` (~+467 lines):
+
+- Enter form-submission (2 cases: closed→open; open→select) doesn't propagate — `97ff085a8`.
+- Tab doesn't `preventDefault` on open listbox; focus advances — `511d3ac3b`.
+- Menu listeners survive disconnect+reconnect — `672784b52`.
+- `requestUpdate` regression: options change triggers hidden native `<select>` re-render — `aba3effaa`.
+- Single "selected" announce on bib-open-with-preselection — `ffa6bdaa8`.
+- Prefix-match precedence: `"aa"` against `[Aardvark, Anchor]` → Aardvark — `a014c996e`.
+- No-match keystroke on closed bib leaves it closed — `247ba291d` (intentional deviation from native).
+- Home/End on collapsed bib opens + activates first/last — `8f7efa319`, `b2889578d`.
+- Single `auroMenu-activatedOption` on End/Home open (no transient) — `28a57a876`.
+- multiSelect native `change` preserves JSON array (bfcache/autofill path) — `1a672c812`.
+- multiSelect toggle announcements: "X, selected" on add, "X, not selected" on remove — `612281e02`.
+- Label reparenting resync: reparent host + mutate textContent + assert both consumers re-sync — `a5588b0fe`.
+
+Plus `components/dropdown/test/auro-dropdown.test.js` (+49) for `aria-haspopup` and `components/counter/test/auro-counter-group.test.js` (+12) for the Chromium outside-close fix.
+
+## Lessons
+
+1. **Rejecting an adversarial finding is not the end of the review — it's the start of a durable contract.** Every rejection here shipped with a test that pins the deviation. If the intentional behavior is later "fixed," CI fails and the test's comment points at the rationale. The three rejection tests are cheaper insurance than the six accepted fixes.
+2. **Audit against *both* APG and native `<select>`, not just APG.** APG is silent on collapsed-state Home/End; native opens. APG is silent on no-match typeahead; native opens on any printable. The right answer isn't "match one spec" — it's "pick one, document why, test it."
+3. **`firstUpdated` is not `connectedCallback`.** Lit's `firstUpdated` runs once ever. Any observer or listener attached there is dead after disconnect+reconnect. The label-observer bug (`a5588b0fe`) is the second time this pattern has bitten `auro-select`. When you own the reconnect story, `connectedCallback` gated on `hasUpdated` is the right hook.
+4. **Fullscreen `<dialog>` promotion inerts the host root synchronously.** Any live-region announcement that fires in the same task as `showBib()` on mobile silently drops. `queueMicrotask` around the announce path is the routing fix — the announcement root doesn't exist yet at the call site.
+5. **Chromium's `:focus-within` doesn't cross nested shadow roots.** Every `<auro-dropdown>` that wraps a component with its own shadow root needs `noHideOnThisFocusLoss = true`. `auro-select`, `auro-combobox` had it; `auro-counter-group` didn't. Audit the fleet the next time this comes up.
+6. **Keep review-response commits atomic.** The counter fix should have been its own PR. Reviewers reading the diff have to disentangle "select adversarial fixes" from "counter Chromium fix" — the branch name suggests the former, the diff mixes both. When an adjacent fix falls out of an investigation, resist the pull to bundle.
+
+## Receipts
+
+**24 commits on `cfriedberg/advers-review`, oldest → newest:**
+
+1. `97ff085a8` — `test(select): assert Enter does not bubble to parent form and document intent`
+2. `73e3eeeb9` — `fix(dropdown): add aria-haspopup="listbox" to combobox trigger`
+3. `5dd78142c` — `fix(select): re-stamp aria-setsize/posinset on option changes`
+4. `511d3ac3b` — `test(select): assert Tab does not preventDefault on open listbox`
+5. `aba3effaa` — `refactor(select): replace dead options state with explicit requestUpdate`
+6. `672784b52` — `test(select): assert menu listeners survive disconnect+reconnect`
+7. `ffa6bdaa8` — `fix(select): silence duplicate "selected" announce on bib open`
+8. `a014c996e` — `fix(select): prefer prefix match over repeat-char cycle in type-ahead`
+9. `1fa7c20e3` — `refactor(select): drop unreachable multiselect branch in _handleNativeSelectChange`
+10. `247ba291d` — `test(select): assert no-match type-ahead keystroke keeps bib closed`
+11. `8f7efa319` — `fix(select): open bib + move focus on Home/End when collapsed`
+12. `c5748c31a` — `fix(select): avoid intermediate active option on type-ahead open`
+13. `2f528858c` — `fix(select): observe label slot for runtime accessible-name updates`
+14. `962954c0f` — `fix(select): route typeahead announcement to bib root on mobile`
+15. `ee105cfae` — `perf(select): scope label observer to the slotted node (Sourcery feedback)`
+16. `b2889578d` — `fix(select): update Home/End key behavior to open bib and activate options when collapsed`
+17. `cf5dfba88` — `fix(dropdown): update aria-haspopup behavior based on trigger focusability`
+18. `1a672c812` — `fix(select): guard native change in multiSelect mode`
+19. `bdcc0d366` — `fix(select): improve regression guard comment for menu event listeners`
+20. `612281e02` — `fix(select): announce the toggled option on multiSelect change`
+21. `bbb1976bd` — `fix(counter): prevent Chromium dropdown auto-close`
+22. `a5588b0fe` — `fix(select): rewire label observer on reconnect`
+23. `28a57a876` — `fix(select): prevent double activation on End/Home open`
+24. `1bf42261b` — `test(counter): use real click for outside-close test` (also the merge commit)
+
+**Files changed (12, +726/−96):**
+
+- `components/select/src/auro-select.js` (~+212) — six accepted fixes land here plus the label observer + reconnect wiring.
+- `components/select/src/selectKeyboardStrategy.js` (~+31) — Home/End collapsed-state, typeahead prefix precedence, pre-stash pattern.
+- `components/select/test/auro-select.test.js` (~+467) — the assertion + regression tests enumerated above.
+- `components/select/docs/partials/keyboard-behavior/keyEvents.md` (+22) — user-facing doc: Home/End open the bib, Tab defaults, Enter doesn't submit.
+- `components/select/test/MANUAL_TESTING.md` (+2) — Firefox/AT verification callouts.
+- `context/keyboard-spec.md` (+2) — rationale for Enter `stopPropagation` linked from the source comment.
+- `components/dropdown/src/auro-dropdown.js` (+1) — `aria-haspopup="listbox"` when trigger is focusable.
+- `components/dropdown/test/auro-dropdown.test.js` (+49) — aria-haspopup coverage.
+- `components/counter/src/auro-counter-group.js` (+7) — `noHideOnThisFocusLoss = true` mitigation.
+- `components/counter/test/auro-counter-group.test.js` (+12) — real-click outside-close test.
+- `apps/shared/select-interaction.suite.ts` (+6/−8) — updates to shared interaction suite for the new keyboard behavior.
+- `apps/shared/counter-interaction.suite.ts` (+1/−2) — matching update for the counter's dropdown behavior.
+
+**Related post-mortems:** [`select-adv-branch.md`](./select-adv-branch.md) covers follow-on work on the same audit line. [`1520.md`](./1520.md) covers the typeahead/multiSelect regressions that shipped after this RC.
+
+**Chromatic:** 1014 tests unchanged; 507 stories published; UI Review approved by Chris Friedberg.
+
+**Reviewers:** sourcery-ai (label observer scoping); Copilot (three passes: 5 → 3 → 0 comments); jason-capsule42 (requested changes → approved).
+
+## Outcome
+
+Six accepted fixes closed real APG/native-`<select>` gaps in `auro-select`. Three rejections locked spec-compliant behavior in with regression tests — the more valuable half of the PR, since bare rejections erode over time and tests don't. One counter-group Chromium fix rode in on the same branch, which was expedient but muddied the diff. The reconnect-observer pattern is now understood well enough that the next `firstUpdated`-only observer in the fleet should be caught in review before it ships.

--- a/docs/post-mortem/1520.md
+++ b/docs/post-mortem/1520.md
@@ -1,0 +1,174 @@
+# Post-Mortem: auro-select Typeahead & multiSelect Interaction Bugs (PR #1520)
+
+**Branch:** `cfriedberg/select-updates` → `dev`
+**PR:** [#1520](https://github.com/AlaskaAirlines/auro-formkit/pull/1520)
+**Release:** `v0.0.0-pr1520.0` preview → folded into `v6.0.0-rc-1484.12`
+**Scope:** Three narrow interaction fixes on `auro-select` — a multiSelect data-loss regression on valueless-option clicks, a typeahead buffer dead-end that silently swallowed keystrokes, and a test-ordering gap that let both of the above go undetected in certain wtr scheduling. +65/−0 across two files; two new regression tests; no source-shape or contract changes.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| Clicking a valueless `<auro-menuoption>` in multiSelect wipes every prior pick | The `auroMenu-selectValueFailure` handler was clearing state on both of the menu's two dispatch paths. Only one — the programmatic-mismatch path — clears `menu.optionSelected` to `undefined` before dispatch; the valueless-click path leaves state intact. Discriminate on `menu.optionSelected !== undefined`. |
+| Fast-typing two non-prefix keys (e.g. `a` then `b` against `[Apples, Oranges, Bananas]`) leaves the highlight on the first match, buffer stuck at `"ab"` | Native `<select>` falls back to searching by the *latest* key alone when the accumulated buffer matches nothing. WAI-ARIA APG is silent on this case; match native, not APG. |
+| A multiSelect click-sequence test appears to pass locally but is flaky on CI, reporting a lower `optionSelected.length` than clicks fired | `elementUpdated(el)` waits only for the select's Lit update. The menu owns the source-of-truth state and runs its own render cycle first — await `elementUpdated(menu)` before `elementUpdated(el)` after each click. |
+| Considering adding a `detail.reason` to `auroMenu-selectValueFailure` to distinguish the two paths | It works, but the receiver-side check on post-dispatch `menu.optionSelected` is already load-bearing (established by post-mortem [1560488]). Extending the event breaks a working invariant for negligible clarity gain. |
+
+## Bug 1 — MultiSelect wiped by a valueless click
+
+### What the user saw
+
+Manual repro on `apiExamples/multi-select.html`: check Alpha, check Beta, click a valueless "None"/reset row. Alpha and Beta stay visible for a frame, then vanish — every prior pick dropped to zero. Affects any multiSelect menu that ships a "none/reset/static" option alongside real picks.
+
+### Root cause
+
+`auro-menu` dispatches `auroMenu-selectValueFailure` from two logically distinct code paths:
+
+1. **Programmatic value mismatch** (`auro-menu.js:424-433`). A `select.value = x` assignment naming no known option. The menu pre-clears `this.optionSelected = undefined` and `this._index = -1` *before* firing so synchronous listeners read the fresh cleared state. This clear-before-dispatch invariant was itself the fix locked in by post-mortem [1560488].
+2. **`toggleOption` click on an unselected valueless option** (`auro-menu.js:831-841`). The menu leaves state alone because there is nothing meaningful to record; the failure event is purely diagnostic.
+
+The select's listener at `auro-select.js:896` responded to *both* by unconditionally clearing:
+
+```js
+this.value = undefined;
+this.optionSelected = this.multiSelect ? [] : undefined;
+this.updateDisplayedValue();
+```
+
+In single-select mode this was harmless — no accumulated state to lose. In multiSelect mode, the two prior picks were dropped on the floor. The select was conflating "the event fired" with "clear my state," treating a diagnostic signal as an imperative.
+
+### The fix
+
+Early-return on the toggle path by reading the menu's post-dispatch state:
+
+```js
+this.menu.addEventListener("auroMenu-selectValueFailure", () => {
+  if (this.menu.optionSelected !== undefined) {
+    return; // valueless-click path — menu left state intact
+  }
+  // programmatic-mismatch path — mirror the clear
+  this.value = undefined;
+  this.optionSelected = this.multiSelect ? [] : undefined;
+  this.updateDisplayedValue();
+});
+```
+
+`undefined` on `menu.optionSelected` is the sentinel from the programmatic path. Anything else — a scalar in single-select or an array in multiSelect — means "state intact, don't touch it." The discriminator lives in state the menu already exposes as its dispatch invariant; no event-shape change was needed.
+
+## Bug 2 — Typeahead buffer dead-end
+
+### What the user saw
+
+With `typeaheadTimeoutMs="2000"` on `apiExamples/basic.html`, focusing the trigger and quickly typing `s` then `d` did nothing — no highlight change, no bib open, no announcement. Waiting past the buffer timeout and pressing `d` alone worked. Native `<select>` on the same sequence jumps to whatever option starts with `d` on the second keystroke.
+
+### Root cause
+
+`updateActiveOptionBasedOnKey` at `auro-select.js:1076` implements two branches for finding a match:
+
+1. **Prefix match on the accumulated buffer** — the WAI-ARIA APG happy path. `options.find(o => text.startsWith(this.typeaheadBuffer))`.
+2. **Repeat-char cycle** — when the buffer is a single repeated character (`aa`, `aaa`), cycle through options starting with that character. Gated by `new Set(this.typeaheadBuffer).size === 1`.
+
+Nothing handled the "buffer is heterogeneous *and* matches no prefix" case. `a` → buffer `"a"`, matches Apples. `b` arrives within the timeout window; buffer becomes `"ab"`. No option starts with `"ab"`. The repeat-char gate rejects because `new Set("ab").size === 2`. `match` stayed `undefined`, the code fell through, and the keystroke was silently swallowed until the 500ms inactivity timeout cleared the buffer.
+
+WAI-ARIA APG describes the prefix path and the repeat-char cycle. It is silent on "accumulated input matches nothing." Different assistive tools resolve this differently. Native `<select>` (Chrome, Safari, Firefox) resolves it by treating the newest keystroke as a fresh single-character search — users trained on native muscle-memory expect that.
+
+### The fix
+
+Third branch after the prefix search and the repeat-char check:
+
+```js
+} else if (!match && this.typeaheadBuffer.length > 1) {
+  // Buffer has no prefix match and isn't a repeat-char cycle (e.g. "a" then
+  // "b" against [Apple, Banana]). Reset to just the new key and retry —
+  // mirrors native <select>, which falls back to a single-char search when
+  // accumulated input matches nothing, rather than swallowing the keystroke.
+  this.typeaheadBuffer = key;
+  match = options.find((option) => this._getOptionDisplayText(option).startsWith(key));
+}
+```
+
+Placement matters:
+
+- **After** the repeat-char branch, so `aa` still cycles through `[Apple, Apricot]` instead of resetting to `a` and re-selecting Apple.
+- **Before** the "no match keeps the bib closed" branch, so the retry gets a chance to succeed before the swallow path.
+- `length > 1` guard preserves the "intentionally leave the bib closed on a single-key no-match" behavior documented above at line 1128.
+- `!match` guard preserves prefix precedence when e.g. `ap` still resolves to Apples.
+
+## Bug 3 — Menu updates not awaited in multiSelect test
+
+### What the user saw
+
+Nothing at runtime — this is a test-ordering fix. The regression test added in the bug-1 commit was flaky at merge time; a third commit (test-only) landed to stabilize it.
+
+### Root cause
+
+The test clicks three options in sequence and asserts `el.optionSelected.length` at each step. Each click mutates `auro-menu` state, which fires `auroMenu-selectedOption`, which the select handles and reflects into its own `optionSelected`. `elementUpdated(el)` waits for the *select's* Lit update to settle but does not wait for the menu's own render cycle. On slower runs the second click reached the menu before the first click's update had flushed on the menu side, dropping the second pick.
+
+### The fix
+
+Grab the menu once, then await `elementUpdated(menu)` before `elementUpdated(el)` after each click:
+
+```js
+const menu = el.querySelector('auro-menu');
+opts[0].click();
+await elementUpdated(menu);   // menu settles first
+await elementUpdated(el);     // then select's listener-triggered update
+```
+
+Same test body — four `await elementUpdated(menu)` inserts, no assertion changes. This is a race that existed in every prior click-sequence test in the file but only surfaced now because the multiSelect regression test clicks three options in a row; prior tests mostly clicked one.
+
+## Tests Added
+
+- **`should not wipe prior selections when a valueless option is clicked`** — `components/select/test/auro-select.test.js:562-593`. Fixture: `<auro-select multiselect>` with three options (`Alpha`, `Beta`, valueless). Clicks Alpha then Beta (asserts length 2), then clicks the valueless option (asserts length still 2). Prose comment cites the two-dispatch-path root cause so a future maintainer doesn't rewrite the guard.
+- **`should fall back to the latest key when the accumulated buffer prefix-matches nothing`** — `components/select/test/auro-select.test.js:4465-4481`. Uses `updateActiveOptionBasedOnKey('a')` then `('b')` against the default `[Apples, Oranges, Bananas]` fixture, asserts `menu.optionActive.value === 'Bananas'` AND `typeaheadBuffer === 'b'`. The buffer assertion is important — it locks in that the reset happened, rather than some other match path accidentally succeeding.
+
+Both tests include prose comments explaining the pre-fix failure mode, so a future regression sees the historical context inline.
+
+## What the Plan Got Right
+
+- **Both fixes ship with locking tests.** The typeahead regression test asserts *both* the visible outcome (`optionActive`) and the internal state (`typeaheadBuffer`) — a stricter contract than just "the right thing happened."
+- **The multi-path event discriminator lives in dispatcher state, not in the event payload.** Adding a `detail.reason` would have required a menu change, a receiver change, and a doc change. The receiver-only check on `menu.optionSelected` is smaller and leans on an invariant post-mortem [1560488] already locked in.
+- **Native `<select>` was named explicitly as the reference behavior** in the source comment for bug 2. Anyone tempted to "align with WAI-ARIA APG" sees the native-parity rationale inline.
+
+## What the Plan Missed
+
+- **The multi-select test was flaky at first commit.** The test needed the `elementUpdated(menu)` awaits from the start; landing them in a follow-up commit meant PR review had to touch the same file twice. Any test that clicks multiple options in a nested-component sequence needs per-component awaits; treat this as the default pattern.
+- **The two-path event contract is under-documented in `auro-menu.js`.** The dispatch sites (`auro-menu.js:424-433` and `831-841`) have code comments but no cross-referenced contract like "receivers must discriminate on post-dispatch `optionSelected`." A future third dispatch path in the menu could reintroduce the same class of bug in any receiver.
+
+## Lessons
+
+1. **Typeahead heuristic: match native, not APG, on dead-end.** WAI-ARIA APG covers prefix match and repeat-char cycle. It is silent on "buffer accumulated to something that matches nothing." Native `<select>` fills that gap by falling back to the latest key. Users have muscle-memory built on native; APG-conforming code that swallows the keystroke *feels* broken even if it's spec-conforming. When the spec is silent, match native.
+2. **"Valueless option" is a real semantic, not an oversight.** A menuoption with `value=""` or no `value` is a distinct thing — placeholder, "None"/reset row, or static separator. The menu correctly treats an unselected valueless click as a no-op that fires a diagnostic event. A receiver that treats that diagnostic as an imperative will lose state. If the event is diagnostic on some paths and imperative on others, receivers need a discriminator.
+3. **Event discriminators should live in state the receiver can inspect.** `auroMenu-selectValueFailure` names one event but describes two conditions. The fix relied on the menu having pre-cleared `optionSelected` on one path and *not* on the other. That state difference is the discriminator. Prefer state-based discrimination over event-payload extension when the state is already load-bearing — it doesn't add a second contract to maintain.
+4. **`elementUpdated(host)` is not transitive across child components.** When a click on a child fires an event the host listens to, awaiting the host flushes the host's response — but the child may have queued its own update, and the next interaction may depend on the child having rendered. Any test whose assertion reads a derived property that flows child → event → parent needs both awaits. Cheap to add, expensive to diagnose when omitted.
+5. **Regression tests should assert internal state too.** The typeahead test asserts both `optionActive.value === 'Bananas'` (the visible outcome) and `typeaheadBuffer === 'b'` (the internal state). Asserting only the visible outcome would let a different code path pass green — e.g. if the bug re-emerged as "the reset happens but the buffer isn't updated," a visible-only assertion would miss it.
+
+## Receipts
+
+**Commits (on `cfriedberg/select-updates`, later rebased onto `cfriedberg/select-adv`):**
+
+- [`fe79b29c2`](https://github.com/AlaskaAirlines/auro-formkit/commit/fe79b29c2) `fix(select): preserve multiSelect picks on valueless option click`. PR SHA `f73c03524dcaf26c3c7933116e4e0a827b82d9fc`. Files: `components/select/src/auro-select.js` (+8), `components/select/test/auro-select.test.js` (+30).
+- [`60803d951`](https://github.com/AlaskaAirlines/auro-formkit/commit/60803d951) `fix(select): fall back to latest key when typeahead buffer dead-ends`. PR SHA `bba1a95a296bf8222fb638df5f02557edd6db775`. Files: `components/select/src/auro-select.js` (+7), `components/select/test/auro-select.test.js` (+16).
+- [`4d0cd547a`](https://github.com/AlaskaAirlines/auro-formkit/commit/4d0cd547a) `fix(select): ensure menu updates correctly on option clicks`. PR SHA `71dfb3b41a278cdcfa562ce7babc5feae429042e`. Files: `components/select/test/auro-select.test.js` (+4).
+
+**Source anchors (post-merge, on `cfriedberg/select-adv` HEAD):**
+
+- [`components/select/src/auro-select.js:896-920`](https://github.com/AlaskaAirlines/auro-formkit/blob/4d0cd547a/components/select/src/auro-select.js#L896-L920) — `auroMenu-selectValueFailure` handler with the `menu.optionSelected !== undefined` early-return at line 902-904.
+- [`components/select/src/auro-select.js:1119-1126`](https://github.com/AlaskaAirlines/auro-formkit/blob/4d0cd547a/components/select/src/auro-select.js#L1119-L1126) — typeahead dead-end fallback branch, sitting after the repeat-char cycle at line 1112-1118.
+- The subsequent `hasStaleState` short-circuit at `auro-select.js:905-913` was added in follow-up `9dc564cf5` (perf micro-optimization on `cfriedberg/select-adv`), **not** part of this PR.
+
+**Menu-side dispatch sites (unchanged by this PR, but load-bearing for the fix):**
+
+- [`components/menu/src/auro-menu.js:424-433`](https://github.com/AlaskaAirlines/auro-formkit/blob/4d0cd547a/components/menu/src/auro-menu.js#L424-L433) — programmatic value-mismatch path (clears `optionSelected = undefined` before dispatch; invariant locked in by post-mortem [1560488]).
+- [`components/menu/src/auro-menu.js:831-841`](https://github.com/AlaskaAirlines/auro-formkit/blob/4d0cd547a/components/menu/src/auro-menu.js#L831-L841) — `toggleOption()` valueless-click path (dispatches without mutating menu state).
+
+**Test anchors:**
+
+- [`components/select/test/auro-select.test.js:562-593`](https://github.com/AlaskaAirlines/auro-formkit/blob/4d0cd547a/components/select/test/auro-select.test.js#L562-L593) — multiSelect valueless-click regression test.
+- [`components/select/test/auro-select.test.js:4465-4481`](https://github.com/AlaskaAirlines/auro-formkit/blob/4d0cd547a/components/select/test/auro-select.test.js#L4465-L4481) — typeahead dead-end regression test.
+
+## Outcome
+
+Three narrow interaction fixes, +65/−0 across two files, two new regression tests, two spec-referenced source comments (`native <select>` as the typeahead reference, two-path dispatch as the failure-event contract). All prior tests continue to pass; Chromatic diff was clean on 982 UI stories. The fix relies on the menu's clear-before-dispatch invariant established by [1560488]; that dependency is called out inline so a future menu change doesn't quietly break both PRs' contracts.
+
+[1560488]: 1560488.md

--- a/docs/post-mortem/1532.md
+++ b/docs/post-mortem/1532.md
@@ -1,0 +1,191 @@
+# Post-Mortem: auro-select Post-#1511 RC Hardening (`cfriedberg/select-adv`)
+
+**Branch:** `cfriedberg/select-adv`
+**Base:** `origin/rc/1484` (the RC branch carrying the merged adversarial-review work from PR #1511)
+**Shape:** 4 correctness fixes on `auro-select`, 1 perf micro-optimization, 3 test-hardening commits, 4 documentation commits (2 code-comment, 2 MANUAL_TESTING.md), 1 unrelated one-line ESLint tweak on `auro-input`.
+**Character:** Every commit is a receipt for a specific latent bug, spec deviation, or vacuous test that survived PR #1511's adversarial review. No new features; no architectural shifts.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| Home/End or the first-open highlight land on a hidden or `static nomatch` row | Two helpers exist: `getEnabledOptions` (filters `disabled` only) and `getActiveOptions` (filters `disabled` + `hidden` + `static`). Home/End/open-fallback must use `getActiveOptions` — same helper typeahead already used. |
+| Cmd+C, Ctrl+V, Alt+X, or Cmd+Space toggling the bib or leaking a character into the typeahead buffer | The `default` branch of the keyboard strategy treated any single-character `evt.key` as printable. Guard on `ctrlKey \|\| metaKey \|\| altKey` at the top of the `default` handler. |
+| Typeahead buffer surviving `select.value = x` or `select.reset()`, so the next keystroke concatenates onto stale characters | `hideBib()` closes the dropdown without blurring the host, so the blur-based clear never fires. Clear the buffer in `updated()`'s value-change branch AND in `reset()` (defense in depth for the `undefined → undefined` case). |
+| Autofill / password manager writing a scalar to the hidden native `<select>` in multiSelect mode, then the form POST shipping that scalar instead of `formattedValue[0]` | The multiSelect early-return in `_handleNativeSelectChange` was correct not to *apply* the scalar, but wrong to leave the native mirror out of sync. Call `_updateNativeSelect()` before returning to snap the native mirror back to component state. |
+| Clicking a valueless option when nothing was previously selected triggers a full `updateDisplayedValue()` cycle | `auroMenu-selectValueFailure` fires from two paths; the existing multiSelect guard didn't catch the "already-empty single-select" case. Add a `hasStaleState` gate. Not a correctness bug — a paint-churn one. |
+| A test like `if (labelSlot && menu.hasAttribute('aria-label')) expect(...)` | Vacuous. If the wiring regresses so the precondition is false, the test passes green. Assert both the precondition AND the wiring. |
+| A 2200ms real `setTimeout(resolve, 2200)` in a live-region cleanup test | Use `sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })` — keep rAF/microtasks/Date real so Lit's scheduler and `elementUpdated` keep working. Install the clock *before* the code that schedules the timer. |
+| A commented-out test with a `// BUG:` claim | Verify the claim before preserving the block. A commented test with a false premise encodes misinformation. Delete or rewrite, never skip on a stale assumption. |
+
+## What Landed vs. What Was Planned
+
+There was no formal plan for this branch — it is the RC-touch-up burst after PR #1511 merged. The commit set is best read as "adversarial-review-of-the-adversarial-review": a second pass by the same author against the same component, at higher scrutiny, before the RC line was tagged for release.
+
+| Category | Commits |
+|---|---|
+| Correctness fixes | 4 (`d67c0cd1d`, `b2aed40f3`, `ed75e6147`, `22cb4065f`) |
+| Perf micro-optimization | 1 (`9dc564cf5`) |
+| Test hardening | 3 (`25460cdfb`, `e929c0c7f`, `2a324648a`) |
+| Documentation | 4 (`5c8150766`, `edb70a0f3`, `d4842e2e8`, `09e6c490d`) |
+| Unrelated one-liner | 1 (`581e092ee` — input ESLint pragma) |
+
+Files touched (deduped):
+- `components/select/src/auro-select.js` (6 commits)
+- `components/select/src/selectKeyboardStrategy.js` (2 commits)
+- `components/select/test/auro-select.test.js` (6 commits)
+- `components/select/test/MANUAL_TESTING.md` (2 commits)
+- `components/input/src/utilities.js` (1 commit — unrelated ESLint pragma)
+
+## 1. Correctness Fixes
+
+### 1a. Home / End / open-fallback static-skip — `d67c0cd1d`
+
+Three call sites — `Home()` and `End()` in `selectKeyboardStrategy.js` and the "no prior selection on open" fallback in `configureMenu()` — were using `getEnabledOptions()`, which filters `disabled` only. Typeahead had already been migrated to `getActiveOptions()`, which additionally filters `hidden` and `static`. The asymmetry meant `aria-activedescendant` could land on:
+
+- A `hidden` row that VoiceOver would still announce as focused.
+- A `static nomatch` placeholder (the "No results" footer row).
+
+Both violate APG guidance that non-actionable rows must not be keyboard-reachable. Fix: three call-site swaps and the `getEnabledOptions` import removed from `auro-select.js`. Kills the helper's remaining callers in the file. Comments at each swap spell out the "active not enabled" distinction so nobody re-introduces the old helper.
+
+The commit also **tightens a previously-vacuous test**: the "typeahead skips static" test guarded its assertion behind `if (el.menu.optionActive)`, so if the code regressed to `undefined` the assertion was silently skipped. Rewritten to assert positively that `optionActive` is nullish when the only 'n'-starting option is static — the same fail-loudly pattern that `25460cdfb` doubles down on.
+
+### 1b. Typeahead buffer clearing on programmatic value change and `reset()` — `b2aed40f3`
+
+The buffer had a 500ms inactivity window and cleared on blur. Two paths did not clear it: `select.value = x` and `select.reset()`. Rationale for the miss: `hideBib()` closes the dropdown without blurring the host, so the blur-based clear never fired. If the host still had focus, the next keystroke within 500ms concatenated onto stale characters and could match the wrong option.
+
+Fix in two places:
+1. Top of `updated()`'s `changedProperties.has('value')` branch — clears before `setMenuValue()`, before the native-select sync, before `hideBib()`.
+2. Top of `reset()` — defense in depth for the `undefined → undefined` case where the value-change branch never fires.
+
+Two regression tests: seed buffer with `a`, then either `el.value = 'Grapes'` or `el.reset()`; assert `typeaheadBuffer === ''` and `_typeaheadTimeout === null`; follow-up `b` keystroke must activate `Bananas` (would fail as `'ab'` if the seed leaked).
+
+### 1c. Revert hidden native `<select>` on autofill divergence in multiSelect — `ed75e6147`
+
+The load-bearing commit of the branch. Prior code:
+
+```js
+_handleNativeSelectChange(event) {
+  if (this.multiSelect) return;   // silent bailout
+  ...
+}
+```
+
+The rationale for the bail was correct: the hidden native `<select>` has no `multiple` attribute, so any change it fires is a single scalar; applying it in multiSelect mode would collapse the JSON-array `value` shape. The problem is what happens *after* the bail. The native `<select>` is a *name-bearing* form control (`name`, `autocomplete`), and browser autofill / bfcache restore / password managers write to it despite `aria-hidden` and `tabindex="-1"`. After the bail:
+
+- Component `value` = `JSON.stringify(['Apples', 'Bananas'])`.
+- `nativeSelect.value` = `'Cherries'` (autofilled).
+
+**And the native select is what submits under `name`.** So a form POST would silently ship the autofilled scalar rather than the array's first element (`formattedValue[0]`). Consumer-visible regression: form data mismatched what the user saw checked in the UI. Manifests on Firefox and Chrome autofill flows most reliably, and after browser bfcache back-forward navigation.
+
+The earlier hidden-native-select approach — introduced when the pre-5.9 revert stopped mirroring the array via imperative DOM — assumed the native select's `<option>` list was authoritative. Autofill breaks that assumption because it doesn't consult the option list before writing.
+
+Fix: call `this._updateNativeSelect()` in the multiSelect branch before returning. The helper is idempotent, already knows the multiSelect shape (`formattedValue[0] || ''`), and no new state is introduced. Regression test simulates autofill by writing `nativeSelect.value = 'Cherries'` and dispatching `change`, then asserts both `el.value` (component authoritative) AND `nativeSelect.value === 'Apples'` (snapped back to `formattedValue[0]`).
+
+### 1d. Chorded-key filtering in typeahead and Space — `22cb4065f`
+
+The `default` handler in `selectKeyboardStrategy.js` treated any single-character `evt.key` as printable, which meant:
+
+- **Cmd+C / Ctrl+V / Cmd+X** (copy / paste / cut) leaked their letter into the typeahead buffer.
+- **Cmd+Space** (Spotlight / macOS input-source switch) toggled the bib.
+- **Alt+letter** (browser menu shortcut on Windows, macOS accent composition) mutated buffer state.
+
+Native `<select>` ignores modified keys entirely. Fix: nine-line early return at the top of `default(component, evt, ctx)` guarding `ctrlKey || metaKey || altKey`. Skips both the Space toggle and `updateActiveOptionBasedOnKey`. Explicit comment notes ArrowUp/ArrowDown handle modifier+arrow separately (Home/End emulation) so the guard is scoped only to the default branch.
+
+Five tests: Ctrl+letter, Meta+letter, Alt+letter, {Ctrl,Meta,Alt}+Space (asserts the bib does not toggle), and — critically — a chorded key must not *extend* an already-active buffer.
+
+## 2. Perf Micro-Optimization — `9dc564cf5`
+
+`auroMenu-selectValueFailure` fires from two menu paths:
+1. Programmatic value mismatch — menu pre-clears `optionSelected` to `undefined`, then dispatches.
+2. Click on a valueless option — menu leaves state untouched, then dispatches.
+
+The existing early-return from PR #1520 (`if (this.menu.optionSelected !== undefined) return;`) correctly preserved prior multiSelect picks when there was something to preserve. But it still fell through to a state-write + `updateDisplayedValue()` when a valueless option was clicked and *nothing was previously selected* — a no-op that still reassigned `this.value`, reassigned `this.optionSelected`, and ran `updateDisplayedValue()` which touches the trigger's `#value` DOM imperatively and requests a dropdown re-render.
+
+Added a `hasStaleState` check gating the clear+refresh: `this.value !== undefined || (this.multiSelect ? this.optionSelected?.length > 0 : this.optionSelected !== undefined)`. Early return if no stale state exists. Programmatic-mismatch path is unaffected — `this.value` still holds the invalid attempt at that point, so `hasStaleState` is truthy.
+
+No new state, no test — a behavioral no-op on the correctness axis, purely a churn eliminator on the paint axis.
+
+## 3. Test Hardening
+
+### 3a. Fail loudly on aria-label wiring and static-skip regressions — `25460cdfb`
+
+Two vacuous assertions removed.
+
+```js
+if (labelSlot && menu.hasAttribute('aria-label')) {
+  expect(menu.getAttribute('aria-label')).to.equal(labelSlot.textContent.trim());
+}
+```
+
+If someone deleted the `aria-label` copy in source, `hasAttribute` returned `false`, the `if` body was skipped, and the test passed green while the wiring was silently broken. Rewritten to assert `labelSlot` exists AND `aria-label` matches — no skips. Same treatment for the `expect(el.menu.optionActive === undefined || el.menu.optionActive === null).to.be.true` defensive chain, now `expect(el.menu.optionActive).to.not.exist`.
+
+Chai should tell you *what* was wrong, not "expected true to equal true."
+
+### 3b. Sinon fake timers for live-region cleanup — `e929c0c7f`
+
+Replaced a 2200ms real `setTimeout(resolve, 2200)` sleep with `sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })`. Key detail: rAF, microtasks, and Date **deliberately stay real**, so Lit's scheduler and the rAF inside `announceToScreenReader` keep functioning. Only the *cleanup* `setTimeout(..., 1000)` is intercepted.
+
+The fake must be installed *before* the keydown so the cleanup timer scheduled from inside the rAF lands on the fake queue. Two real rAF frames flushed (one for the announcement, one for chained active-option/selection announcements), then `clock.tickAsync(1000)` advances past the cleanup. `finally { clock.restore() }` for isolation.
+
+Net: ~2.2s → deterministic. Kills a CI flake source and a wall-clock cost simultaneously.
+
+### 3c. Delete commented-out outside-click dismissal test — `2a324648a`
+
+An 18-line commented-out test carried a `// BUG:` claim ("`popover='manual'` plus `noHideOnThisFocusLoss` prevents outside-click dismissal"). `auro-select.js:562-563` documents the opposite — outside-click closes via `composedPath()`. The commented test preserved a **false premise**: anyone reading it would infer a limitation that doesn't exist. Deleted (not skipped). If real outside-click coverage is wanted, a fresh test dispatching the correct event is the right path.
+
+## 4. Documentation
+
+- **`5c8150766`** — `MANUAL_TESTING.md`. Prior wording said "focus returns to the trigger" after Tab in fullscreen; corrected to "next focusable after the select" (native `<dialog>` restoration + browser Tab traversal). Prior wording contradicted `keyEvents.md` and the guards in `restoreTriggerAfterClose`.
+- **`edb70a0f3`** — code comment in `auro-select.js` around the `queueMicrotask` wrapping of the typeahead-on-closed announcement. Explains the exact synchronous ordering (`updateActiveOption()` fires the event before `show()`; `show() → showBib()` flips `isPopoverVisible` and calls `dialog.showModal()` synchronously; microtask drains after `_handleTypeahead` unwinds → announcement lands in the now-open modal). Includes an explicit **"Do NOT switch to `auroDropdown-toggled`"** warning — that event fires before `showModal()` and would land the announcement in an inert host root.
+- **`d4842e2e8`** — `MANUAL_TESTING.md` a11y gaps. 28 new checklist items across typeahead (prefix vs cycle, no-match keeps closed, Space extends buffer, blur/Escape clears, programmatic clears), multi-select announcements (individual add/remove, debounce vs `aria-expanded` collapse), `aria-setsize`/`aria-posinset` re-stamping under slotchange and lazy load, and fullscreen live-region routing into the dialog shadow root.
+- **`09e6c490d`** — code comment on `configureMenu()`. `<auro-menu>` is captured once and is **not** re-targeted on `slotchange`. Runtime option mutation is fine (covered by `auroMenu-optionsChange`); swapping the menu element itself under a live select is unsupported — remount the parent instead.
+
+## 5. Input ESLint Tweak — `581e092ee`
+
+One-line pragma change in `components/input/src/utilities.js`: drops `radix` from the file-level `eslint-disable` list, adds `complexity` and `max-lines`. Unrelated to select work; carried on the branch alongside the select fixes because the author was iterating locally. Not a select-adjacent change — worth splitting off in future.
+
+## What Was Not Planned but Also Shipped
+
+Everything here is unplanned by definition — the branch is post-#1511 hardening. Two things worth explicit call-out:
+
+- **The autofill/native-mirror divergence (`ed75e6147`) is a form-submission bug, not a display bug.** It is invisible in every unit test that doesn't dispatch a `change` event on the hidden native select, and invisible in every manual test that doesn't come from a browser autofill flow. Nothing in the PR #1511 adversarial review predicted it because the hidden-native-select approach was itself pre-adversarial-review. This is the kind of bug that only surfaces with autofill enabled, in production, after real users complete form submission — very expensive to discover the "normal" way.
+- **The chorded-key filter (`22cb4065f`) covers a class of daily-user annoyance that never lands in a bug tracker.** Users hitting Cmd+C to copy would not necessarily file "the select opened a menu"; they'd just retry. The fix is retroactively obvious once seen; the missing guard survived PR #1511 because typeahead was a new surface with no native-behavior baseline.
+
+## Lessons
+
+1. **Guard native writes.** Any DOM node retained under `name` submits with the form. `aria-hidden` + `tabindex="-1"` blocks users, not user agents. Autofill, bfcache, and password managers write directly. Every path that early-returns on a native-control change event needs a snap-back call, not a bare `return`.
+2. **Don't strip modifier keys silently.** Chorded keys (Ctrl/Meta/Alt) are the browser's / OS's / IME's / SR's channel. Custom `keydown` handlers on printable-key paths must gate on modifier state up front, not deep in the handler where side effects have already leaked (buffer mutation, bib toggle). Native `<select>` is the reference behavior.
+3. **Tests must fail loudly if wiring breaks silently.** `if (thing) expect(...)` is a vacuous test — a regression that removes `thing` passes green. Same for defensive `=== undefined || === null` chains that mask an unexpected shape. Assert the precondition, then assert the wiring; never gate the wiring check on the precondition.
+4. **Interaction buffers end with the interaction, not with the surface.** Typeahead is scoped to the user's current interaction. Programmatic assignment, `reset()`, and any state-ending path must clear buffers, not just any path that also happens to blur focus. Focus loss is a proxy for "interaction over," not the definition of it. `hideBib()` doesn't blur; therefore focus-based clears miss it.
+5. **Symmetric filtering across keyboard entry points.** If typeahead uses one helper (`getActiveOptions`) and Home/End/fallback use another (`getEnabledOptions`), you have two definitions of "focusable" and every entry point can produce a different first-highlight. Consolidate. When two helpers exist with subtly different filters, audit *every* call site and consider deleting the weaker helper.
+6. **Fake timers on the axis that flakes.** Wall-clock sleeps are a CI-flake source. `sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })` keeps rAF/microtasks/Date real (so Lit, `@open-wc/testing`, and rAF-scheduled work all keep functioning) while making just the timer under test deterministic. Install the clock *before* the code that schedules the timer.
+7. **Commented tests with `// BUG:` claims teach the wrong thing.** If you leave a commented test, someone will read it as canon. Delete, or rewrite. Never skip based on a stale assumption.
+8. **Comment the load-bearing "don't swap this" invariants.** `<auro-menu>` capture-once, `queueMicrotask` vs `auroDropdown-toggled`, "static and hidden must not land in `aria-activedescendant`" — these are non-obvious enough that the next editor will re-introduce the bug without a comment marking them as invariants. The next editor only reads the comment when they're about to break it.
+9. **Perf micro-optimizations only after correctness locks.** The valueless-click short-circuit (`9dc564cf5`) landed alongside four correctness fixes; the guard is structurally safe because programmatic-mismatch still passes `hasStaleState`. The right ordering is: fix, then trim churn — never the reverse.
+10. **A second pass by the same author, at higher scrutiny, finds real bugs.** The 13 commits here would not have landed in the same shape from a fresh reviewer — they lean heavily on the author's memory of what was intentional vs incidental in PR #1511. Two consecutive review passes by the same person is a viable pattern for RC hardening; it doesn't replace an external adversarial pass but it complements one.
+
+## Receipts
+
+Per-commit SHA, message, and files:
+
+| SHA | Message | Files |
+|---|---|---|
+| [`581e092ee`](https://github.com/AlaskaAirlines/auro-formkit/commit/581e092ee) | style(input): update ESLint rules to include complexity and max-lines | `components/input/src/utilities.js` |
+| [`d67c0cd1d`](https://github.com/AlaskaAirlines/auro-formkit/commit/d67c0cd1d) | fix(select): skip hidden/static options in Home/End and open-fallback | `components/select/src/auro-select.js`, `selectKeyboardStrategy.js`, `test/auro-select.test.js` |
+| [`5c8150766`](https://github.com/AlaskaAirlines/auro-formkit/commit/5c8150766) | docs(select): correct fullscreen Tab focus behavior in MANUAL_TESTING | `components/select/test/MANUAL_TESTING.md` |
+| [`edb70a0f3`](https://github.com/AlaskaAirlines/auro-formkit/commit/edb70a0f3) | docs(select): clarify typeahead-on-closed queueMicrotask guarantee | `components/select/src/auro-select.js` |
+| [`b2aed40f3`](https://github.com/AlaskaAirlines/auro-formkit/commit/b2aed40f3) | fix(select): clear typeahead buffer on programmatic value change and reset() | `components/select/src/auro-select.js`, `test/auro-select.test.js` |
+| [`d4842e2e8`](https://github.com/AlaskaAirlines/auro-formkit/commit/d4842e2e8) | docs(select): fill MANUAL_TESTING a11y gaps for typeahead and announcements | `components/select/test/MANUAL_TESTING.md` |
+| [`9dc564cf5`](https://github.com/AlaskaAirlines/auro-formkit/commit/9dc564cf5) | perf(select): skip updateDisplayedValue on valueless click with no prior selection | `components/select/src/auro-select.js` |
+| [`09e6c490d`](https://github.com/AlaskaAirlines/auro-formkit/commit/09e6c490d) | docs(select): note `<auro-menu>` is captured once and not re-targeted on slotchange | `components/select/src/auro-select.js` |
+| [`ed75e6147`](https://github.com/AlaskaAirlines/auro-formkit/commit/ed75e6147) | fix(select): revert hidden native select on autofill divergence in multiSelect | `components/select/src/auro-select.js`, `test/auro-select.test.js` |
+| [`25460cdfb`](https://github.com/AlaskaAirlines/auro-formkit/commit/25460cdfb) | test(select): fail loudly on aria-label wiring and static-skip regressions | `components/select/test/auro-select.test.js` |
+| [`e929c0c7f`](https://github.com/AlaskaAirlines/auro-formkit/commit/e929c0c7f) | test(select): drive live-region cleanup with sinon fake timers | `components/select/test/auro-select.test.js` |
+| [`2a324648a`](https://github.com/AlaskaAirlines/auro-formkit/commit/2a324648a) | test(select): remove commented-out outside-click dismissal test | `components/select/test/auro-select.test.js` |
+| [`22cb4065f`](https://github.com/AlaskaAirlines/auro-formkit/commit/22cb4065f) | fix(select): ignore Ctrl/Meta/Alt-chorded keys in typeahead and Space branches | `components/select/src/selectKeyboardStrategy.js`, `test/auro-select.test.js` |
+
+**Aggregate:** 4 correctness fixes + 1 perf + 3 test-hardening + 4 docs + 1 unrelated ESLint tweak. Zero new features. The autofill revert (`ed75e6147`) is the highest-impact commit (form submission correctness); the chorded-key filter (`22cb4065f`) is the most likely to have been catching real user friction; the sinon timer switch (`e929c0c7f`) is the highest-value CI hygiene change.
+
+**Base:** `origin/rc/1484` — the PR #1511 merge commit.
+**Head:** `22cb4065f` — chorded-key filter.

--- a/docs/post-mortem/1588304.md
+++ b/docs/post-mortem/1588304.md
@@ -1,0 +1,110 @@
+# Post-Mortem: Firefox Number-Input Spinners (AB#1588304 / PR #1518)
+
+**Branch:** `cfriedberg/input-firefox` → `dev`
+**PR:** [#1518](https://github.com/AlaskaAirlines/auro-formkit/pull/1518)
+**Released in:** `v6.0.0-rc-1484.11`
+**Scope:** Seven-line SCSS addition so `<auro-input type="number">` renders without native Firefox spin-buttons, matching Chromium/WebKit.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| A `type="number"` input renders bare in Chrome/Safari but shows native up/down chevrons in Firefox | The existing rule only targets `::-webkit-inner-spin-button`. Add `appearance: textfield` on the input itself to cover Gecko. |
+| Tempted to hide `::-webkit-inner-spin-button` with `display: none` | Don't. The retained comment in `style.scss:47` records that this crashes Chrome on hover. Use `-webkit-appearance: none` instead. |
+| Wondering whether `-moz-appearance: textfield` is still required | It is not. Unprefixed `appearance: textfield` covers every browser in the project's baseline (Firefox ≥ 80, Safari ≥ 15.4). Adding the vendor prefix is superstition. |
+| Considering an unscoped `appearance: textfield` on the top-level `input` selector | Sourcery's review already caught this. Scope with `&[type="number"]` — the standard `appearance` property also affects other type-specific chrome (search-cancel button, etc.). |
+| Firefox-visible regression that survived CI | web-test-runner and Chromatic are both Chromium-only. Anything that touches native form chrome needs a manual Firefox pass. |
+
+## The Bug
+
+`<auro-input type="number">` rendered clean in Chrome and Safari but still showed Firefox's native up/down spin controls pinned to the right edge of the field. Because the component draws its own end-of-field affordances (`.notification`, `.notificationBtn` at `style.scss:82`), the vendor spinners collided with the custom chrome and pushed the text-overflow ellipsis behind them. Semantics and keyboard behavior were unaffected — ArrowUp/ArrowDown still stepped the value, `min` / `max` / `step` validation still worked, and the underlying `<input>` remained a spinbutton. Only the rendered chrome was wrong.
+
+## Root Cause
+
+The pre-existing rule in `components/input/src/styles/style.scss:46-51` targeted only WebKit's shadow pseudo-element:
+
+```scss
+&::-webkit-inner-spin-button {
+  /* display: none; <- Crashes Chrome on hover */
+  margin: 0;
+  -webkit-appearance: none;
+}
+```
+
+There was no matching Firefox path. Gecko does not implement `::-webkit-inner-spin-button`; its knob for suppressing the spinner UI is the `appearance` property on the `<input>` element itself. The webkit rule was a no-op in Firefox, and the browser's default `appearance: auto` on `input[type="number"]` won.
+
+This is a classic single-vendor coverage regression: the original stylesheet author verified in Chromium, saw the arrows disappear, and never wrote the Gecko fallback. QA on Firefox surfaced it as AB#1588304.
+
+## The Fix
+
+Seven lines added to the top `input {}` block of `style.scss`, between the `text-overflow: ellipsis;` declaration (line 38) and the existing WebKit-pseudo rule (line 46):
+
+```scss
+// stylelint-disable-next-line selector-no-qualifying-type
+&[type="number"] {
+  // Hide number input spinner arrows (Firefox, etc)
+  appearance: textfield;
+}
+```
+
+Three deliberate choices in that block:
+
+1. **Unprefixed `appearance: textfield`.** `-moz-appearance` is redundant since Firefox 80 (2020) and the project's baseline is well above that. WebKit is already handled by the `::-webkit-inner-spin-button` rule below, so `-webkit-appearance: textfield` here would be additive noise.
+2. **Attribute-scoped with `&[type="number"]`.** Sourcery flagged the risk of applying `appearance: textfield` to the top-level `input` selector — it also affects `type="search"` chrome (the built-in clear button) and would over-broadly override any `appearance: auto` on other input types. Scoping the rule kept the blast radius to number inputs.
+3. **`stylelint-disable-next-line selector-no-qualifying-type`.** The project bans attribute-qualified type selectors by default. The disable comment documents that the rule is intentional here — the block is already nested inside `input {}`, so the outer selector is `input[type="number"]` and lint won't let that pass without the escape hatch.
+
+The existing WebKit rule at line 46 was retained deliberately, including its `display: none; <- Crashes Chrome on hover` breadcrumb. That comment is exactly why nobody has rewritten the block from scratch, and it earned its keep.
+
+## Accompanying Changes
+
+Four other files were touched in the merged PR, all lint / JSDoc polish with no behavioral effect. They were bundled because the pre-commit lint check was failing on the branch:
+
+- `components/input/src/base-input.js` — two `catch (error) { // eslint-disable-line no-unused-vars }` blocks collapsed to `catch { ... }` (ES2019 optional catch binding); two `@deprecated` JSDoc lines reformatted.
+- `components/input/src/auro-input.js` — one `@deprecated` JSDoc reformatted.
+- `components/input/src/utilities.js` — dropped a stale `/* eslint-disable max-lines */` file-level directive; tightened one `@returns` description.
+- `components/combobox/src/auro-combobox.js` — collapsed one nested `if`; clarified a JSDoc comment.
+
+The behavioral change is the seven SCSS lines. Everything else is cleanup. Reviewers who count files will overestimate the risk — a follow-up-only cleanup PR would have kept this at one file, seven lines.
+
+## Testing
+
+No new tests were added. The existing `type="number"` assertions in `components/input/test/auro-input.test.js` (lines 902, 958, 1191, 1270, 1283, 1432) exercise validity and range behavior, not rendered chrome — and web-test-runner is Chromium-only in this repo, so a Firefox-visual test could not have run there anyway.
+
+Verification path per the PR body:
+- Manual: open the input demo in Firefox, confirm no spin buttons; open in Chrome/Safari, confirm no visual regression.
+- Chromatic: 89 UI baselines re-approved by jason-capsule42, covering 491 stories. Chromatic runs Chromium, so it only guarded against the "did the fix break Chrome/Safari" question — not the "does Firefox look right" question. The Firefox check was human-in-the-loop.
+
+The manual testing checklist at `components/input/test/MANUAL_TESTING.md:38` already includes a `type="number"` line but does not specifically call out spinner chrome. A follow-up would be to add that callout so this exact regression cannot silently reappear.
+
+## What the Plan Got Right
+
+- Scoping the rule with `&[type="number"]` (Sourcery's callout, applied before merge) prevented an accidental blast radius into other input types.
+- Retaining the WebKit pseudo-element rule alongside the new Firefox path — instead of trying to unify both under `appearance: textfield` — kept the "why is this in a webkit block" comment intact and avoided a Chrome-crash regression that the old comment specifically warns against.
+
+## What the Plan Missed
+
+- **No visual regression coverage on Firefox.** The regression could not have been caught by the automated matrix as it stands. This PR added no test infrastructure to close that gap; the follow-up would be to either run Chromatic against a Firefox baseline or add a Playwright/Firefox story-snapshot smoke test for form chrome.
+- **Lint cleanup rolled into the same PR.** The 5-file diff makes the change look larger than it is. Future single-property fixes should keep unrelated cleanup out of the same commit.
+
+## Lessons
+
+1. **`::-webkit-inner-spin-button` alone is a half-fix.** Any pseudo-element targeting a UA-drawn control needs a matching non-webkit strategy — typically `appearance: textfield` on the host element — or Firefox is silently left behind.
+2. **Prefer unprefixed `appearance`.** Modern Firefox and Safari accept the standard property. `-moz-appearance` is a legacy alias with no additional coverage in the supported browser matrix. Adding vendor prefixes without a documented reason accretes cruft.
+3. **Scope the standard `appearance` property.** It is not a spinner-only knob — it also controls search-cancel buttons and other type-specific chrome. Attribute-qualify with `[type="number"]` when the intent is number inputs only.
+4. **Chromium-only CI needs an explicit Firefox story in the manual checklist.** web-test-runner is Chromium, Chromatic renders on Chromium. Any change touching native form chrome must be visually verified in Gecko by a human until the CI matrix expands.
+5. **Retain tribal-knowledge comments in style code.** The `display: none <- Crashes Chrome on hover` breadcrumb is why the rule looks the way it does. Delete it and the next author will "clean up" the vendor-prefixed rule into a crash regression.
+
+## Receipts
+
+- **Fix commit:** [`7396c42e0`](https://github.com/AlaskaAirlines/auro-formkit/commit/7396c42e0) `fix(input): hide number input spinners in Firefox AB#1588304` — 1 file, +7/−1.
+- **Bundled lint cleanup commits (same PR):** `d9b74d663`, `9ab644599`, `dd18c3fe9`.
+- **File changed:** [`components/input/src/styles/style.scss:40-44`](https://github.com/AlaskaAirlines/auro-formkit/blob/7396c42e0/components/input/src/styles/style.scss#L40-L44).
+- **Existing rule this complements:** [`components/input/src/styles/style.scss:46-51`](https://github.com/AlaskaAirlines/auro-formkit/blob/7396c42e0/components/input/src/styles/style.scss#L46-L51).
+- **Compiled output:** `components/input/src/styles/style.css:315-317` — `input[type=number] { appearance: textfield; }`.
+- **Related test surface (unchanged):** `components/input/test/auro-input.test.js` — number-type cases at lines 902, 958, 1191, 1270, 1283, 1432.
+- **Related demo/story surfaces (unchanged):** `components/input/apiExamples/number.html`, `max-number.html`, `min-number.html`, `set-custom-validity-bad-input.html`; `components/input/demo/customize.md` sections at 607, 911, 977, 1298-1304; `components/input/demo/css-only.md:68-70`.
+- **Release tag:** `v6.0.0-rc-1484.11`.
+
+## Outcome
+
+Shipped as a single-property SCSS addition. Firefox now matches the Chromium/WebKit rendering. No behavioral changes to keyboard, validation, or event surface. The gap that let this bug ship — Chromium-only CI and Chromatic — remains open; the mitigation is the manual Firefox pass on any PR touching native form chrome.


### PR DESCRIPTION
Fixes for Select based on adversarial review: https://github.com/AlaskaAirlines/auro-formkit/pull/1520

# Select

## High-impact — worth fixing before merge

✅ 1. Home/End filter mismatch (a11y agent)

   `selectKeyboardStrategy.js:53-69, 85-97` uses `getEnabledOptions` (filters only disabled) while typeahead uses `getActiveOptions` (also filters hidden/static). Home/End can land `aria-activedescendant` on a hidden/static option (e.g. a "no match" placeholder), which VoiceOver will announce as focused. Same issue at `auro-select.js:592` in the `configureDropdown` first-enabled fallback. Fix: swap to `getActiveOptions` in both places. Test agent noted the current static skip test at `test:4344` is conditionally gated and wouldn't catch this — tighten while you're in there.

✅ 2. Tab in fullscreen doesn't preventDefault (a11y agent)

JASON - Sounds like a doc only issue. Intended behavior is that tab should take you to the next focusable element after select (because select does not have a clear button like datepicker/combobox).

   `selectKeyboardStrategy.js:99-110`. `MANUAL_TESTING.md:51` says Tab in fullscreen returns focus to the trigger, but native Tab still fires after `hide()` and moves focus to the next focusable. `restoreTriggerAfterClose` races against native `<dialog>` focus restoration. Fix: in fullscreen only, `evt.preventDefault()` + explicit `dropdown.trigger.focus()`. Leave desktop as-is. Also update `keyEvents.md:191-211` to note the fullscreen caveat.

✅ 3. Modifier-key typeahead (correctness agent)

JASON - We did an update in Combobox recently to better handle paste workflows we can apply here. Let's sync on it Chris.

   `selectKeyboardStrategy.js:112-132` — default branch treats Cmd+C / Ctrl+V / Alt+X as typeahead because `evt.key` is a single letter and there's no modifier guard. Native `<select>` ignores modified keys. Fix: skip when `evt.ctrlKey || evt.metaKey || evt.altKey`. Applies to the Space branch too.

## Medium — followup fine

❌ 4. Typeahead announce race in fullscreen (a11y)

   `auro-select.js:919-931` `queueMicrotask` may fire before `isPopoverVisible` flips, sending the first-match announcement to the inert host root instead of the bib. Hook off `auroDropdown-toggled` (open branch) or defer a `requestAnimationFrame`.

```
Developer response:

Consensus: false alarm — no fix needed

  Both subagents independently traced the exact call sequence and reached the same conclusion.

  The trace (typeahead-when-closed, _handleTypeahead at auro-select.js:1114-1116):

  1. menu.updateActiveOption(match) → dispatches auroMenu-activatedOption synchronously
  2. Handler (line 907): dropdown.isPopoverVisible is false → schedules the microtask
  3. Handler returns; dropdown.show() is called
  4. showBib() in floatingUI.mjs:713 sets element.isPopoverVisible = true synchronously, then dispatches auroDropdown-toggled
  5. dropdown.show() then synchronously calls bibElement.value.open() → dialog.showModal() (auro-dropdownBib.js:310) — outer DOM inert on return
  6. _handleTypeahead unwinds; the current task completes
  7. Microtask queue drains — announcement fires with isPopoverVisible === true and the dialog already in the top layer. _getAnnouncementRoot() returns
  bibElement.value.shadowRoot, which is inside the modal and not inert.

  Why queueMicrotask is the right primitive: microtasks drain after the current synchronous task, which necessarily includes the whole show() → showModal() chain (all
  synchronous by design — the comment at auro-dropdown.js:205-211 explicitly requires this for iOS keyboard-preservation).

  Why the suggested alternatives are worse:
  - auroDropdown-toggled (open branch) fires before dialog.showModal() — announcement would race into a not-yet-modal state.
  - requestAnimationFrame adds a frame of latency for no additional guarantee.

  Recommendation: leave the code alone.
```

✅ 5. Typeahead buffer lifecycle gaps (correctness)

   Buffer survives programmatic `value =` and `reset()`. Rare, but next keystroke will concatenate. Clear in the value-changed branch of `updated()` and in `reset()`.

✅ 6. MANUAL_TESTING.md gaps (a11y)

   No manual steps for:
   - type-ahead cycle vs prefix
   - no-match keeps bib closed
   - Space extends buffer
   - Escape/blur clears buffer
   - multi-select add/remove announcement
   - `aria-setsize`/`aria-posinset` re-stamping
   - mobile announcement routing

## Nits

- ✅ `auroMenu-selectValueFailure` handler does needless `updateDisplayedValue()` on valueless clicks when nothing is selected (`auro-select.js:887-902`).
- ✅ `auroMenu-optionsChange` listener never re-targets if the `<auro-menu>` slot child is swapped at runtime (`auro-select.js:880-883`) — accept and document, or listen on `slotchange`.
- ✅ `multiSelect` ignores the native `<select>` `change` event; browser autofill on `multiSelect` can silently diverge (`auro-select.js:1400`).
- ✅ Two weak test assertions gated by `if (...)` guards that silently skip — `test:4344`, `test:2334`.
- ✅ `2200ms` hardcoded sleep in the live-region-cleanup test (`test:2219`) — drive with a fake clock.
- ✅ Commented-out `it(...)` at `test:2381` — convert to `.skip` or delete.