### PR TITLE
Address gaps in auro-form docs

### DIFF
--- a/components/form/apiExamples/complex.html
+++ b/components/form/apiExamples/complex.html
@@ -1,64 +1,174 @@
+<auro-form id="bookingForm" class="trip-form">
+  <!-- Cabin — auro-radio-group -->
+  <div class="form-section">
+    <auro-radio-group required name="cabin">
+      <span slot="legend">Cabin</span>
+      <auro-radio id="cabin-main" name="cabinChoice" label="Main" value="main" checked></auro-radio>
+      <auro-radio id="cabin-premium" name="cabinChoice" label="Premium" value="premium"></auro-radio>
+      <auro-radio id="cabin-first" name="cabinChoice" label="First class" value="first"></auro-radio>
+    </auro-radio-group>
+  </div>
+
+  <!-- Route — auro-select (from) + auro-combobox (to) -->
+  <div class="form-section">
+    <h4 class="section-heading">Where are you going?</h4>
+    <div class="field-row">
+      <auro-select required name="departureAirport">
+        <span slot="label">From</span>
+        <span slot="bib.fullscreen.headline">Choose a departure city</span>
+        <auro-menu>
+          <auro-menuoption value="SEA">Seattle (SEA)</auro-menuoption>
+          <auro-menuoption value="PDX">Portland (PDX)</auro-menuoption>
+          <auro-menuoption value="SFO">San Francisco (SFO)</auro-menuoption>
+          <auro-menuoption value="LAX">Los Angeles (LAX)</auro-menuoption>
+          <auro-menuoption value="ANC">Anchorage (ANC)</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+
+      <auro-combobox required name="destination">
+        <span slot="label">To</span>
+        <span slot="bib.fullscreen.headline">Search destinations</span>
+        <auro-menu>
+          <auro-menuoption value="HNL">Honolulu (HNL)</auro-menuoption>
+          <auro-menuoption value="OGG">Maui (OGG)</auro-menuoption>
+          <auro-menuoption value="JFK">New York (JFK)</auro-menuoption>
+          <auro-menuoption value="ORD">Chicago (ORD)</auro-menuoption>
+          <auro-menuoption value="DFW">Dallas–Fort Worth (DFW)</auro-menuoption>
+          <auro-menuoption static nomatch>No matching destinations</auro-menuoption>
+        </auro-menu>
+      </auro-combobox>
+    </div>
+  </div>
+
+  <!-- When & who — auro-datepicker (range) + auro-counter-group -->
+  <div class="form-section">
+    <h4 class="section-heading">When and who?</h4>
+    <div class="field-row">
+      <auro-datepicker required range name="travelDates">
+        <span slot="fromLabel">Departure</span>
+        <span slot="toLabel">Return</span>
+        <span slot="bib.fullscreen.fromLabel">Departure</span>
+        <span slot="bib.fullscreen.toLabel">Return</span>
+      </auro-datepicker>
+
+      <auro-counter-group isDropdown max="9" name="travelers">
+        <div slot="label">Travelers</div>
+        <span slot="bib.fullscreen.headline">Travelers</span>
+        <span slot="ariaLabel.bib.close">Close</span>
+        <auro-counter name="adults" min="1" max="9" value="1">
+          Adults
+          <span slot="description">Age 18+</span>
+        </auro-counter>
+        <auro-counter name="children" min="0" max="8" value="0">
+          Children
+          <span slot="description">Age 2–17</span>
+        </auro-counter>
+        <auro-counter name="infants" min="0" max="4" value="0">
+          Lap infants
+          <span slot="description">Under 2</span>
+        </auro-counter>
+      </auro-counter-group>
+    </div>
+  </div>
+
+  <!-- Lead traveler — auro-input -->
+  <div class="form-section">
+    <h4 class="section-heading">Lead traveler</h4>
+    <div class="field-row">
+      <auro-input id="first-name" name="firstName" required>
+        <span slot="label">First name</span>
+      </auro-input>
+
+      <auro-input id="last-name" name="lastName" required>
+        <span slot="label">Last name</span>
+      </auro-input>
+
+      <auro-input id="email" name="email" type="email" class="span-2" required>
+        <span slot="label">Email</span>
+        <span slot="helpText">We'll send your confirmation here.</span>
+      </auro-input>
+    </div>
+  </div>
+
+  <!-- Extras — auro-checkbox-group -->
+  <div class="form-section">
+    <auro-checkbox-group name="extras">
+      <span slot="legend">Add to your trip (optional)</span>
+      <auro-checkbox id="extra-bags" value="bags">First checked bag</auro-checkbox>
+      <auro-checkbox id="extra-insurance" value="insurance">Travel insurance</auro-checkbox>
+      <auro-checkbox id="extra-lounge" value="lounge">Alaska Lounge+ day pass</auro-checkbox>
+    </auro-checkbox-group>
+  </div>
+
+  <div class="form-actions">
+    <auro-button type="reset" variant="secondary">Reset</auro-button>
+    <auro-button type="submit">Search flights</auro-button>
+  </div>
+</auro-form>
+
+<output id="bookingFormOutput" aria-live="polite">Fill in the required fields and submit to see the collected form value. Notice the shapes each field contributes — <code>travelDates</code> as a two-item <code>[departure, return]</code> array, <code>travelers</code> as an object keyed by counter name, <code>extras</code> as an array, and <code>cabin</code> as the selected value.</output>
+
 <style>
-  .submitBlock {
-    margin-top: 1rem;
-    display: flex;
-    justify-content: flex-end;
-    gap: 1rem;
-  }
-  .datepickerBlock {
-    margin-top: 1rem;
-  }
-  .complex-form {
+  #bookingFormOutput {
     display: block;
-    padding: 1rem;
+    margin-top: 2rem;
+    padding: 1rem 1.25rem;
+    border-left: 4px solid #2a2a2a;
+    border-radius: 0.25rem;
+    background: #f5f5f5;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875rem;
+    white-space: pre-wrap;
+  }
+
+  .trip-form {
+    display: block;
+    padding: 1.5rem;
     border: 1px solid #2a2a2a;
     border-radius: 1rem;
   }
+
+  .trip-form .form-section {
+    margin-top: 1.5rem;
+  }
+
+  .trip-form .form-section:first-of-type {
+    margin-top: 0;
+  }
+
+  .trip-form .section-heading {
+    margin: 0 0 0.75rem;
+  }
+
+  .trip-form .field-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .trip-form .field-row + .field-row {
+    margin-top: 1rem;
+  }
+
+  .trip-form .span-2 {
+    grid-column: span 2;
+  }
+
+  @media (max-width: 660px) {
+    .trip-form .field-row {
+      grid-template-columns: 1fr;
+    }
+
+    .trip-form .span-2 {
+      grid-column: span 1;
+    }
+  }
+
+  .trip-form .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 2rem;
+  }
 </style>
-
-<auro-form class="complex-form">
-  <auro-input id="first-name" name="firstName" required>
-    <span slot="label">First Name</span>
-  </auro-input>
-
-  <br />
-
-  <auro-input id="last-name" name="lastName" required>
-    <span slot="label">Last Name</span>
-  </auro-input>
-  
-  <br />
-
-  <auro-input id="occupation" name="occupation" required>
-    <span slot="label">Occupation</span>
-  </auro-input>
-
-  <br />
-
-  <auro-input-two id="cool-fact" name="coolFact" required>
-    <span slot="label">Cool Fact</span>
-  </auro-input-two>
-
-  <div class="datepickerBlock">
-    <h4>Pick a cool date</h4>
-    <auro-datepicker id="date-example" name="dateExample" required>
-      <span slot="fromLabel">Choose a date</span>
-      <span slot="bib.fullscreen.fromLabel">Choose a date</span>
-    </auro-datepicker>
-  </div>
-
-  <div class="datepickerBlock">
-    <h4>Pick a date range</h4>
-    <auro-datepicker id="date-range" name="dateRange" required range>
-      <span slot="fromLabel">Start</span>
-      <span slot="toLabel">End</span>
-      <span slot="bib.fullscreen.fromLabel">Start</span>
-      <span slot="bib.fullscreen.toLabel">End</span>
-    </auro-datepicker>
-  </div>
-
-  <div class="submitBlock">
-    <auro-button type="reset">Reset</auro-button>
-    <auro-button type="submit">Submit</auro-button>
-  </div>
-</auro-form>

--- a/components/form/apiExamples/complex.js
+++ b/components/form/apiExamples/complex.js
@@ -1,0 +1,27 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
+/**
+ * Displays the collected value of the complex booking form on submit, mirroring
+ * the Disabled Fields example. Every field in this form — including the cabin
+ * radio group — is collected into `form.value` automatically by `auro-form`; no
+ * per-field wiring is needed.
+ */
+export async function complexExample() {
+  await customElements.whenDefined('auro-form');
+
+  const form = document.querySelector('#bookingForm');
+  if (!form) {
+    throw new Error('complexExample: #bookingForm not yet rendered');
+  }
+
+  const output = document.querySelector('#bookingFormOutput');
+  if (!output) {
+    throw new Error('complexExample: #bookingFormOutput not yet rendered');
+  }
+
+  await form.updateComplete;
+
+  form.addEventListener('submit', (event) => {
+    output.textContent = JSON.stringify(event.detail.value, null, 2);
+  });
+}

--- a/components/form/demo/customize.js
+++ b/components/form/demo/customize.js
@@ -6,6 +6,7 @@ import { AuroInput } from '@aurodesignsystem/auro-input';
 import { AuroDatePicker } from '@aurodesignsystem/auro-datepicker';
 import { disabledExample } from '../apiExamples/disabled.js';
 import { disableAfterEditExample } from '../apiExamples/disabled-after-edit.js';
+import { complexExample } from '../apiExamples/complex.js';
 
 AuroInput.register('input-two');
 AuroDatePicker.register();
@@ -18,6 +19,7 @@ export async function initExamples(initCount) {
   try {
     await disabledExample();
     await disableAfterEditExample();
+    await complexExample();
   } catch (err) {
     if (initCount <= 20) {
       setTimeout(() => {

--- a/components/form/demo/getting-started.js
+++ b/components/form/demo/getting-started.js
@@ -1,9 +1,28 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
 import { AuroForm } from '../src/auro-form.js';
 import './registerDemoDeps.js';
 import { AuroInput } from '@aurodesignsystem/auro-input';
 import { AuroDatePicker } from '@aurodesignsystem/auro-datepicker';
+import { complexExample } from '../apiExamples/complex.js';
 
 AuroInput.register('input-two');
 AuroDatePicker.register();
 AuroForm.register();
 AuroForm.register('custom-form');
+
+export async function initExamples(initCount) {
+  initCount = initCount || 0;
+
+  try {
+    await complexExample();
+  } catch (err) {
+    if (initCount <= 20) {
+      setTimeout(() => {
+        initExamples(initCount + 1);
+      }, 100);
+    }
+  }
+}
+
+initExamples();

--- a/components/form/docs/api.md
+++ b/components/form/docs/api.md
@@ -8,7 +8,7 @@ The `auro-form` element provides users a way to create and manage forms in a con
 |------------------|-----------|--------------------------------------------------|--------------------------------------------------|
 | `isInitialState` | readonly  | `boolean`                                        | Returns `true` if no form element has been interacted with or had its value changed since the form was initialized or last reset. |
 | `validity`       | readonly  | `"valid" \| "invalid" \| null`                   | Returns `'valid'` if all required and interacted-with form elements are valid, `'invalid'` if any are not, or `null` if the form has not been interacted with yet. |
-| `value`          | readonly  | `Record<string, string \| number \| boolean \| string[] \| null>` | Returns the current values of all named form elements as a key-value object, keyed by each element's `name` attribute. |
+| `value`          | readonly  | `Record<string, string \| number \| boolean \| string[] \| Record<string, number> \| null>` | Returns the current values of all named, enabled form elements as a key-value object, keyed by each element's `name` attribute. Each value is the child component's own `.value`, so the shape depends on the element type — see that component's documentation for its exact shape (for example, `auro-checkbox-group` yields an array, `auro-counter-group` yields an object keyed by counter name, and `auro-select` with `multiSelect` yields a JSON-encoded string). The one form-specific exception is a `range` `auro-datepicker`, whose `.values` array (`[start, end]`) is stored instead of its single `.value` string. |
 
 ## Methods
 
@@ -23,8 +23,8 @@ The `auro-form` element provides users a way to create and manage forms in a con
 |----------|--------------------------------------------------|--------------------------------------------------|
 | `change` |                                                  | Fires when a child form element's value changes or the form is initialized. |
 | `input`  |                                                  | Fires when a child form element receives user input. |
-| `reset`  | `CustomEvent<{ previousValue: Record<string, string \| number \| boolean \| string[] \| null>; }>` | Fires when the form is reset. The event detail contains the previous value of the form before reset. |
-| `submit` | `CustomEvent<{ value: Record<string, string \| number \| boolean \| string[] \| null>; }>` | Fires when the form is submitted. The event detail contains the current value of the form. |
+| `reset`  | `CustomEvent<{ previousValue: Record<string, string \| number \| boolean \| string[] \| Record<string, number> \| null>; }>` | Fires when the form is reset. The event detail contains the previous value of the form before reset. |
+| `submit` | `CustomEvent<{ value: Record<string, string \| number \| boolean \| string[] \| Record<string, number> \| null>; }>` | Fires when the form is submitted. The event detail contains the current value of the form. |
 
 ## Slots
 

--- a/components/form/docs/pages/customize.md
+++ b/components/form/docs/pages/customize.md
@@ -31,7 +31,7 @@
         <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
         <auro-header level="3" id="complexForm">Complex Form</auro-header>
-        <p>A more complex form layout with multiple element types, nested containers, and a submit/cancel button group.</p>
+        <p>A realistic booking form that exercises every form element <code>auro-form</code> manages — <code>auro-input</code>, <code>auro-select</code>, <code>auro-combobox</code>, a range <code>auro-datepicker</code>, <code>auro-counter-group</code>, <code>auro-radio-group</code>, and <code>auro-checkbox-group</code> — arranged with nested containers and a reset/submit button group.</p>
         <div class="exampleWrapper">
         <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/complex.html) -->
         <!-- AURO-GENERATED-CONTENT:END -->
@@ -39,6 +39,8 @@
         <auro-accordion alignRight>
         <span slot="trigger">See code</span>
         <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/complex.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/complex.js) -->
         <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
       </section>

--- a/components/form/docs/pages/getting-started.md
+++ b/components/form/docs/pages/getting-started.md
@@ -52,6 +52,8 @@
         <span slot="trigger">See code</span>
         <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/complex.html) -->
         <!-- AURO-GENERATED-CONTENT:END -->
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/complex.js) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
       </section>
       <section>

--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -14,7 +14,7 @@ import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/util
 
 /**
  * @typedef {Object} FormStateMember - The form state member.
- * @property {string | number | boolean | string[] | null} value - The value of the form element.
+ * @property {string | number | boolean | string[] | Record<string, number> | null} value - The value of the form element. Mirrors the child component's own `.value`, so the shape varies by element type (e.g. an array for `auro-checkbox-group`, an object keyed by counter name for `auro-counter-group`). A `range` `auro-datepicker` is the one form-specific case: its `.values` array is stored rather than its single `.value` string.
  * @property {ValidityState} validity - The validity state of the form element, stored when fired from the form element.
  * @property {boolean} required - Whether the form element is required or not.
  * @property {boolean} disabled - Whether the form element is currently disabled. Cached from the live attribute via the MutationObserver in `connectedCallback` and refreshed from `_handleAttributeMutations`.
@@ -108,7 +108,7 @@ export class AuroForm extends LitElement {
      * `_setInitialState` can detect user edits as `current !== initial`,
      * matching HTML's `dirtyValueFlag` semantics.
      * @private
-     * @type {Record<string, string | number | boolean | string[] | null | undefined>}
+     * @type {Record<string, string | number | boolean | string[] | Record<string, number> | null | undefined>}
      */
     this._initialValues = {};
 
@@ -267,8 +267,8 @@ export class AuroForm extends LitElement {
   }
 
   /**
-   * Returns the current values of all named form elements as a key-value object, keyed by each element's `name` attribute.
-   * @returns {Record<string, string | number | boolean | string[] | null>} The current form values.
+   * Returns the current values of all named, enabled form elements as a key-value object, keyed by each element's `name` attribute. Each value is the child component's own `.value`, so the shape depends on the element type — see that component's documentation for its exact shape (for example, `auro-checkbox-group` yields an array, `auro-counter-group` yields an object keyed by counter name, and `auro-select` with `multiSelect` yields a JSON-encoded string). The one form-specific exception is a `range` `auro-datepicker`, whose `.values` array (`[start, end]`) is stored instead of its single `.value` string.
+   * @returns {Record<string, string | number | boolean | string[] | Record<string, number> | null>} The current form values.
    */
   get value() {
     return Object.keys(this.formState).reduce((acc, key) => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce a comprehensive booking-form demo wired to auro-form, and update auro-form APIs and docs to better describe the shapes of collected field values across different child components.

New Features:
- Add a complex trip-booking form example that exercises all supported auro-form field types and displays collected values on submit.

Enhancements:
- Clarify auro-form value typing and documentation to cover array/object-valued fields, multi-select behavior, and range datepicker value handling.
- Integrate the complex form example into the getting-started and customize demos so it initializes alongside existing examples.