### PR TITLE
fix(datepicker): calendarFocusDate now works when value and valueend are preset

### DIFF
--- a/components/datepicker/apiExamples/calendar-focus-date.html
+++ b/components/datepicker/apiExamples/calendar-focus-date.html
@@ -1,5 +1,7 @@
-<auro-datepicker calendarStartDate="2022-01-01" calendarEndDate="2023-12-01" calendarFocusDate="2022-11-01">
+<auro-datepicker range value="2026-06-15" valueEnd="2026-06-22" calendarFocusDate="2026-12-01">
   <span slot="bib.fullscreen.headline">calendarFocusDate Example</span>
-  <span slot="fromLabel">Choose a date</span>
-  <span slot="bib.fullscreen.fromLabel">Choose a date</span>
+  <span slot="fromLabel">Departure</span>
+  <span slot="toLabel">Return</span>
+  <span slot="bib.fullscreen.fromLabel">Departure</span>
+  <span slot="bib.fullscreen.toLabel">Return</span>
 </auro-datepicker>

--- a/components/datepicker/docs/pages/customize.md
+++ b/components/datepicker/docs/pages/customize.md
@@ -13,6 +13,7 @@
     <auro-anchorlink fluid href="#layout" class="level2 body-xs">Shape, Size & Layout</auro-anchorlink>
     <auro-anchorlink fluid href="#cssTokens" class="level2 body-xs">Tokens</auro-anchorlink>
     <auro-anchorlink fluid href="#customBehavior">Behavior</auro-anchorlink>
+    <auro-anchorlink fluid href="#calendarFocusDate" class="level2 body-xs">Calendar Focus Date</auro-anchorlink>
     <auro-anchorlink fluid href="#customValidation" class="level2 body-xs">Custom Validation</auro-anchorlink>
     <auro-anchorlink fluid href="#disableComponent" class="level2 body-xs">Disable Component</auro-anchorlink>
     <auro-anchorlink fluid href="#forceError" class="level2 body-xs">Force Error State</auro-anchorlink>
@@ -120,6 +121,17 @@
 </section>
 <section>
 <auro-header level="2" id="customBehavior">Behavior</auro-header>
+<auro-header level="3" id="calendarFocusDate">Calendar Focus Date</auro-header>
+<p>Use the <code>calendarFocusDate</code> attribute to control which month the calendar first renders. When set alongside <code>value</code> and <code>valueEnd</code>, <code>calendarFocusDate</code> takes precedence for the visible month.</p>
+<div class="exampleWrapper">
+<!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/calendar-focus-date.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+<span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/calendar-focus-date.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
 <auro-header level="3" id="customValidation">Custom Validation</auro-header>
 <p>Use the <code>validity</code> attribute with a custom error message to provide specific feedback.</p>
 <div class="exampleWrapper">

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1173,12 +1173,11 @@ export class AuroDatePicker extends AuroElement {
         // what centralDate renders, causing all cells to have tabindex="-1".
         this.calendar.activeCellDate = null;
 
-        // Show the month containing the selected date (or today) instead of
-        // whichever month the user last navigated to. Route through
-        // updateCentralDate so centralDate stays first-of-month.
-        // calendarFocusDate wins over value so consumers who set it explicitly
-        // get their chosen initial month even when a value is also preset.
-        // Respect consumer-provided centralDate/calendarStartDate if no value is set.
+        // On open, reset the visible month to a predictable source rather than
+        // whichever month the user last navigated to. Route through updateCentralDate
+        // so centralDate stays first-of-month.
+        // Priority: calendarFocusDate (when valid) -> value (when set) -> today (when neither is set).
+        // Respect consumer-provided centralDate/calendarStartDate/minDate when neither calendarFocusDate nor value is set.
         if (this.calendarFocusDate && dateFormatter.isValidDate(this.calendarFocusDate)) {
           this.calendarRenderUtil.updateCentralDate(this, this.calendarFocusDateObject);
         } else if (this.valueObject) {

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1176,8 +1176,12 @@ export class AuroDatePicker extends AuroElement {
         // Show the month containing the selected date (or today) instead of
         // whichever month the user last navigated to. Route through
         // updateCentralDate so centralDate stays first-of-month.
+        // calendarFocusDate wins over value so consumers who set it explicitly
+        // get their chosen initial month even when a value is also preset.
         // Respect consumer-provided centralDate/calendarStartDate if no value is set.
-        if (this.valueObject) {
+        if (this.calendarFocusDate && dateFormatter.isValidDate(this.calendarFocusDate)) {
+          this.calendarRenderUtil.updateCentralDate(this, this.calendarFocusDateObject);
+        } else if (this.valueObject) {
           this.calendarRenderUtil.updateCentralDate(this, this.value);
         } else if (!this.centralDate && !this.calendarStartDate && !this.minDate) {
           this.calendarRenderUtil.updateCentralDate(this, new Date());
@@ -1718,10 +1722,6 @@ export class AuroDatePicker extends AuroElement {
       }
     }
 
-    if (changedProperties.has('calendarFocusDate')) {
-      this.handleFocusDateChange();
-    }
-
     if (changedProperties.has('calendarStartDate')) {
       this.calendar.setAttribute('calendarStartDate', this.calendarStartDate || '');
     }
@@ -1842,6 +1842,13 @@ export class AuroDatePicker extends AuroElement {
 
       this.validate();
       this.setHasValue();
+    }
+
+    // Run focus-date handling AFTER value/valueEnd so that when a consumer sets
+    // calendarFocusDate together with value, the focus date wins for the visible
+    // month instead of being overwritten by the value branch's updateCentralDate.
+    if (changedProperties.has('calendarFocusDate')) {
+      this.handleFocusDateChange();
     }
 
     if (changedProperties.has('error')) {

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -601,6 +601,29 @@ function runFullTest(mobileView) {
         await expect(el.centralDateObject.getFullYear()).to.equal(2024);
       });
 
+      // Verify calendarFocusDate wins over value/valueEnd when the dropdown opens on a range datepicker.
+      // Desktop-only: on mobile/fullscreen the visible month is driven by scroll position, not the first rendered month.
+      if (!mobileView) {
+        it('should render at the calendarFocusDate month on dropdown open when range value and valueEnd are preset', async () => {
+          const el = await fixture(html`
+            <auro-datepicker range value="2026-06-15" valueEnd="2026-06-22" calendarFocusDate="2026-12-01"></auro-datepicker>
+          `);
+
+          await elementUpdated(el);
+
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+          const calendar = el.shadowRoot.querySelector('auro-formkit-calendar');
+          await dropdown.querySelector('[auro-input]').click();
+          await expect(dropdown.isPopoverVisible).to.be.true;
+          await elementUpdated(calendar.shadowRoot);
+          await nextFrame();
+
+          const calendarMonth = calendar.shadowRoot.querySelector('auro-formkit-calendar-month');
+          await expect(calendarMonth.getAttribute('month')).to.equal('12'); // December
+          await expect(calendarMonth.getAttribute('year')).to.equal('2026');
+        });
+      }
+
     });
 
     describe('calendarStartDate', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
