### PR TITLE
fix(combobox): clearing value now properly resets both html5 inputs

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1626,6 +1626,12 @@ export class AuroCombobox extends AuroElement {
     this.value = undefined;
     this.typedValue = undefined;
     this.input.value = undefined;
+    // Fullscreen bib mounts a second auro-input that holds the user-facing
+    // native <input> on mobile; clearing only the trigger leaves stale text
+    // there when the bib is reopened after reset.
+    if (this.inputInBib) {
+      this.inputInBib.value = undefined;
+    }
     this.menu.value = undefined;
     this.validation.reset(this);
     this.touched = false;

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -2466,6 +2466,57 @@ function runFullTest(mobileView) {
         await expect(el.optionSelected).to.be.undefined;
         await expect(el.touched).to.be.false;
       });
+
+      it('should clear the inner native input element value', async () => {
+        const el = await presetValueFixture(mobileView);
+        await elementUpdated(el);
+
+        await expect(el.input.inputElement.value).to.equal('Apples');
+
+        el.reset();
+        await elementUpdated(el);
+        await el.input.updateComplete;
+
+        await expect(el.input.value).to.be.undefined;
+        await expect(el.input.inputElement.value).to.equal('');
+      });
+
+      it('should clear the inner native input element value after typing without selection', async () => {
+        const el = await defaultFixture(mobileView);
+        await elementUpdated(el);
+
+        setInputValue(el, 'App');
+        await elementUpdated(el);
+        await el.input.updateComplete;
+
+        await expect(el.input.inputElement.value).to.equal('App');
+
+        el.reset();
+        await elementUpdated(el);
+        await el.input.updateComplete;
+
+        await expect(el.input.value).to.be.undefined;
+        await expect(el.input.inputElement.value).to.equal('');
+      });
+
+      it('should also clear the inputInBib native input value in mobile fullscreen', async () => {
+        if (!mobileView) {
+          return;
+        }
+        const el = await presetValueFixture(mobileView);
+        await elementUpdated(el);
+
+        await expect(el.inputInBib).to.exist;
+        await expect(el.inputInBib.value).to.equal('Apples');
+
+        el.reset();
+        await elementUpdated(el);
+        await el.input.updateComplete;
+        await el.inputInBib.updateComplete;
+
+        await expect(el.inputInBib.value).to.be.undefined;
+        await expect(el.inputInBib.inputElement.value).to.equal('');
+      });
     });
 
     describe('clear', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
