### PR TITLE
fix(combobox): shift+tab exits in one keypress AB#1592239

### DIFF
--- a/components/combobox/docs/partials/keyboard-behavior/keyEvents.md
+++ b/components/combobox/docs/partials/keyboard-behavior/keyEvents.md
@@ -158,7 +158,7 @@
         </div>
       </td>
       <td>
-        The current <code>focused</code> option is selected, the bib is closed and <strong>focus</strong> is moved to the <strong>clear button</strong> in the component trigger. A subsequent Shift+Tab moves focus back to the input, and another Shift+Tab exits the component to the previous focusable element on the page.
+        The current <code>focused</code> option is selected, the bib is closed and <strong>focus</strong> is moved to the previous focusable element on the page.
       </td>
     </tr>
   </tbody>

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1219,8 +1219,11 @@ export class AuroCombobox extends AuroElement {
         // do not close while typing in suggestion mode with no value selected, to allow freeform input
         this.hideBib();
 
-        // Move focus to the clear button when the user makes a selection.
-        if (!isEcho && this.menu.value !== undefined) {
+        // Move focus to the clear button when the user makes a selection,
+        // unless the Shift+Tab handler opted this selection out.
+        if (this._suppressClearBtnFocusOnSelection) {
+          this._suppressClearBtnFocusOnSelection = false;
+        } else if (!isEcho && this.menu.value !== undefined) {
           this.setClearBtnFocus();
         }
 

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -56,6 +56,25 @@ function selectAndClose(component) {
 }
 
 /**
+ * Whether `el` is currently visible enough to receive focus. Prefers the
+ * browser's `checkVisibility()` (Chrome/Safari; Firefox behind a flag until
+ * recently); otherwise combines a display/visibility check with an
+ * ancestor-hidden probe that keeps position:fixed elements visible.
+ * @param {Element} el - The element to test.
+ * @returns {boolean}
+ */
+function isVisibleForFocus(el) {
+  if (typeof el.checkVisibility === 'function') {
+    return el.checkVisibility();
+  }
+  const style = el.ownerDocument.defaultView.getComputedStyle(el);
+  if (style.display === 'none' || style.visibility === 'hidden') {
+    return false;
+  }
+  return el.offsetParent !== null || style.position === 'fixed';
+}
+
+/**
  * Return the tab stop that comes before `component` in page tab order,
  * skipping any hidden entries the walker doesn't filter itself.
  * @param {Element} component - The auro-combobox host element.
@@ -65,7 +84,7 @@ function getPreviousTabStop(component) {
   const tabStops = getFocusableElements(component.ownerDocument.body);
   const componentIndex = tabStops.indexOf(component);
   for (let index = componentIndex - 1; index >= 0; index -= 1) {
-    if (tabStops[index].checkVisibility()) {
+    if (isVisibleForFocus(tabStops[index])) {
       return tabStops[index];
     }
   }
@@ -85,9 +104,15 @@ function selectAndExitBackward(component) {
   const previousTabStop = getPreviousTabStop(component);
 
   // Opts this selection out of setClearBtnFocus so the focus move below
-  // isn't clobbered. Consumed by auro-combobox's selection listener.
+  // isn't clobbered. Consumed by auro-combobox's selection listener; also
+  // cleared via microtask in case makeSelection is a no-op and the listener
+  // never fires (microtasks run before the next user event, so this can't
+  // leak into an unrelated selection).
   component._suppressClearBtnFocusOnSelection = true;
   selectAndClose(component);
+  queueMicrotask(() => {
+    component._suppressClearBtnFocusOnSelection = false;
+  });
 
   if (!previousTabStop) {
     return false;

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import { navigateArrow } from '@aurodesignsystem/utils';
+import { doubleRaf, navigateArrow } from '@aurodesignsystem/utils';
+import { getFocusableElements } from '@aurodesignsystem/auro-library/scripts/runtime/Focusables/index.mjs';
 
 /**
  * Returns the clear button element from the active input's shadow
@@ -41,6 +42,51 @@ function reconcileMenuIndex(menu) {
     if (idx >= 0) {
       menu._index = idx;
     }
+  }
+}
+
+/**
+ * Commit the highlighted option and close the bib.
+ * @param {Element} component - The auro-combobox host element.
+ */
+function selectAndClose(component) {
+  reconcileMenuIndex(component.menu);
+  component.menu.makeSelection();
+  component.hideBib();
+}
+
+/**
+ * Return the tab stop that comes before `component` in page tab order,
+ * skipping any display:none entries the walker doesn't filter itself.
+ * @param {Element} component - The auro-combobox host element.
+ * @returns {Element|null}
+ */
+function getPreviousTabStop(component) {
+  const tabStops = getFocusableElements(component.ownerDocument.body);
+  const componentIndex = tabStops.indexOf(component);
+  for (let index = componentIndex - 1; index >= 0; index -= 1) {
+    if (tabStops[index].offsetParent !== null) {
+      return tabStops[index];
+    }
+  }
+  return null;
+}
+
+/**
+ * Commit the highlighted option, close the bib, and move focus to the tab
+ * stop before the combobox — the Shift+Tab exit path (AB#1592239).
+ * @param {Element} component - The auro-combobox host element.
+ */
+function selectAndExitBackward(component) {
+  const previousTabStop = getPreviousTabStop(component);
+
+  // Opts this selection out of setClearBtnFocus so the focus move below
+  // isn't clobbered. Consumed by auro-combobox's selection listener.
+  component._suppressClearBtnFocusOnSelection = true;
+  selectAndClose(component);
+
+  if (previousTabStop) {
+    doubleRaf(() => previousTabStop.focus());
   }
 }
 
@@ -142,36 +188,17 @@ export const comboboxKeyboardStrategy = {
   },
 
   Tab(component, evt, ctx) {
-    // Runs for both Tab and Shift+Tab.
-    //
-    // Current behavior:
-    //   Tab       — select the active option, close the bib, and (in fullscreen
-    //               modal mode only) explicitly move focus to the trigger's
-    //               clear button. In desktop popover mode the browser's native
-    //               tab traversal takes focus forward from the input.
-    //   Shift+Tab — select the active option and close the bib. Focus then
-    //               lands on the trigger's clear button as a byproduct of the
-    //               shadow-DOM tab order, so keyboard users must press
-    //               Shift+Tab three times to exit the component (clear button
-    //               → input → previous element on the page).
-    //
-    // Intended behavior for Shift+Tab (per team decision, tracked in
-    // AB#1590650): a single Shift+Tab should select the active option, close
-    // the bib, and move focus directly to the previous focusable element on
-    // the page — symmetric with Tab.
     if (ctx.isExpanded && !isClearBtnFocused(ctx)) {
-      // When the clear button is focused, Tab events do not bubble out of
-      // its shadow DOM, so this handler only fires when the clear button
-      // is NOT focused. In that case, select the active option and close.
-      reconcileMenuIndex(component.menu);
-      component.menu.makeSelection();
-      component.hideBib();
+      if (evt.shiftKey) {
+        evt.preventDefault();
+        selectAndExitBackward(component);
+        return;
+      }
 
-      // In fullscreen modal mode, closing the dialog does not
-      // automatically restores focus to the input. In the tab case,
-      // Explicitly move focus to the trigger's clear button so the
-      // user can continues tabbing through the page normally.
-      if (ctx.isModal && !evt.shiftKey) {
+      selectAndClose(component);
+
+      if (ctx.isModal) {
+        // Fullscreen close does not automatically restore focus to the input.
         component.setClearBtnFocus();
       }
     }

--- a/components/combobox/src/comboboxKeyboardStrategy.js
+++ b/components/combobox/src/comboboxKeyboardStrategy.js
@@ -57,7 +57,7 @@ function selectAndClose(component) {
 
 /**
  * Return the tab stop that comes before `component` in page tab order,
- * skipping any display:none entries the walker doesn't filter itself.
+ * skipping any hidden entries the walker doesn't filter itself.
  * @param {Element} component - The auro-combobox host element.
  * @returns {Element|null}
  */
@@ -65,7 +65,7 @@ function getPreviousTabStop(component) {
   const tabStops = getFocusableElements(component.ownerDocument.body);
   const componentIndex = tabStops.indexOf(component);
   for (let index = componentIndex - 1; index >= 0; index -= 1) {
-    if (tabStops[index].offsetParent !== null) {
+    if (tabStops[index].checkVisibility()) {
       return tabStops[index];
     }
   }
@@ -75,7 +75,11 @@ function getPreviousTabStop(component) {
 /**
  * Commit the highlighted option, close the bib, and move focus to the tab
  * stop before the combobox — the Shift+Tab exit path (AB#1592239).
+ * Returns true when this function moved focus and the caller should
+ * preventDefault; false when no previous tab stop was found and the browser's
+ * native traversal should run.
  * @param {Element} component - The auro-combobox host element.
+ * @returns {boolean}
  */
 function selectAndExitBackward(component) {
   const previousTabStop = getPreviousTabStop(component);
@@ -85,9 +89,11 @@ function selectAndExitBackward(component) {
   component._suppressClearBtnFocusOnSelection = true;
   selectAndClose(component);
 
-  if (previousTabStop) {
-    doubleRaf(() => previousTabStop.focus());
+  if (!previousTabStop) {
+    return false;
   }
+  doubleRaf(() => previousTabStop.focus());
+  return true;
 }
 
 export const comboboxKeyboardStrategy = {
@@ -190,8 +196,9 @@ export const comboboxKeyboardStrategy = {
   Tab(component, evt, ctx) {
     if (ctx.isExpanded && !isClearBtnFocused(ctx)) {
       if (evt.shiftKey) {
-        evt.preventDefault();
-        selectAndExitBackward(component);
+        if (selectAndExitBackward(component)) {
+          evt.preventDefault();
+        }
         return;
       }
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -3965,8 +3965,34 @@ function runFullTest(mobileView) {
       });
 
       describe('Shift', () => {
-        it('should make a selection and close the bib', async () => {
-          const el = await defaultFixture(mobileView);
+        it('should make a selection, close the bib, and move focus to the previous element on the page', async () => {
+          if (mobileView) {
+            await setViewport({
+              width: 500,
+              height: 800
+            });
+          } else {
+            await setViewport({
+              width: 800,
+              height: 800
+            });
+          }
+
+          const wrapper = await fixture(html`
+            <div>
+              <button id="before-combobox">Before</button>
+              <auro-combobox>
+                <span slot="label">Name</span>
+                <auro-menu>
+                  <auro-menuoption value="Apples" id="shift-tab-option-0">Apples</auro-menuoption>
+                  <auro-menuoption value="Oranges" id="shift-tab-option-1">Oranges</auro-menuoption>
+                </auro-menu>
+              </auro-combobox>
+            </div>
+          `);
+          const el = wrapper.querySelector('auro-combobox');
+          const beforeBtn = wrapper.querySelector('#before-combobox');
+          const options = el.querySelectorAll('auro-menuoption');
 
           el.focus();
           await elementUpdated(el);
@@ -3974,11 +4000,19 @@ function runFullTest(mobileView) {
           el.input.click();
           await elementUpdated(el);
           await expect(el.dropdown.isPopoverVisible).to.be.true;
+
           await sendKeys({ down: 'Shift' });
           await sendKeys({ press: 'Tab' });
           await sendKeys({ up: 'Shift' });
           await elementUpdated(el.dropdown);
+
+          // Wait for the doubleRaf-scheduled focus move in the strategy to run.
+          await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          await elementUpdated(el);
+
           await expect(el.dropdown.isPopoverVisible).to.be.false;
+          await expect(el.value).to.equal(options[0].getAttribute('value'));
+          await expect(document.activeElement).to.equal(beforeBtn);
         });
       });
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Selection listener's setClearBtnFocus was clobbering Shift+Tab focus. Added a per-selection suppress flag the listener uses, then move focus to the previous page selectable option.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
