### PR TITLE
Datepicker fixes for docs and toggle behavior

### DIFF
--- a/components/datepicker/docs/partials/getting-started/react.md
+++ b/components/datepicker/docs/partials/getting-started/react.md
@@ -37,8 +37,8 @@ function MyDatePicker() {
     const el = datepickerRef.current;
     if (!el) return;
 
-    const handleInput = () => {
-      console.log('Selected date:', (el as any).value);
+    const handleInput = (event: Event) => {
+      console.log('Selected date:', (event as CustomEvent<string>).detail);
     };
 
     el.addEventListener('input', handleInput);

--- a/components/datepicker/docs/partials/getting-started/react.md
+++ b/components/datepicker/docs/partials/getting-started/react.md
@@ -1,1 +1,65 @@
-The `<auro-datepicker>` custom element is compatible with React. See the auro-formkit README for general [React integration guidance](https://github.com/AuroDesignSystem/auro-formkit#react).
+React 19 includes <auro-hyperlink href="https://react.dev/blog/2024/12/05/react-19#support-for-custom-elements">native support for custom elements</auro-hyperlink>, so <code>&lt;auro-datepicker&gt;</code> works directly in JSX without any wrapper library.
+
+<auro-header level="3" id="reactImport">Import the Component</auro-header>
+Import and register the component at the top level of your application (e.g. in your root `main.tsx` or `App.tsx`):
+
+```js
+import { AuroDatePicker } from '@aurodesignsystem/auro-formkit/auro-datepicker/class';
+
+AuroDatePicker.register('[custom]-datepicker');
+```
+
+<auro-header level="3" id="reactTypeScript">TypeScript Declarations</auro-header>
+The component ships with TypeScript type definitions for the `AuroDatePicker` class. However, React's JSX does not automatically map custom element tag names to their types. To get type checking for <code>&lt;auro-datepicker&gt;</code> in JSX, add the following declaration to a <code>.d.ts</code> file in your project:
+
+```js
+import type { AuroDatePicker } from '@aurodesignsystem/auro-formkit/auro-datepicker/class';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      '[custom]-datepicker': React.HTMLAttributes<AuroDatePicker> & Partial<AuroDatePicker>;
+    }
+  }
+}
+```
+
+<auro-header level="3" id="reactEvents">Event Handling</auro-header>
+Auro components emit native <code>CustomEvent</code>s. Use a <code>ref</code> to attach event listeners in a <code>useEffect</code>:
+
+```js
+import { useRef, useEffect } from 'react';
+
+function MyDatePicker() {
+  const datepickerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = datepickerRef.current;
+    if (!el) return;
+
+    const handleInput = () => {
+      console.log('Selected date:', (el as any).value);
+    };
+
+    el.addEventListener('input', handleInput);
+    return () => el.removeEventListener('input', handleInput);
+  }, []);
+
+  return (
+    <custom-datepicker ref={datepickerRef}>
+      <span slot="fromLabel">Choose a date</span>
+    </custom-datepicker>
+  );
+}
+```
+
+<auro-header level="3" id="reactModuleResolution">Module Resolution</auro-header>
+Ensure your <code>tsconfig.json</code> uses <code>"moduleResolution": "bundler"</code> so TypeScript can resolve the component's package exports:
+
+```js
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
+}
+```

--- a/components/datepicker/docs/partials/getting-started/svelte.md
+++ b/components/datepicker/docs/partials/getting-started/svelte.md
@@ -50,7 +50,7 @@ Auro components emit native `CustomEvent`s. Use the `oninput` handler directly o
   let value = $state('');
 
   function handleInput(e: Event) {
-    value = (e.target as HTMLElement & { value: string }).value;
+    value = (e as CustomEvent<string>).detail;
   }
 </script>
 <custom-datepicker oninput={handleInput}>

--- a/components/datepicker/docs/partials/getting-started/svelte.md
+++ b/components/datepicker/docs/partials/getting-started/svelte.md
@@ -1,1 +1,71 @@
-The `<auro-datepicker>` custom element is compatible with Svelte. See the auro-formkit README for general [Svelte integration guidance](https://github.com/AuroDesignSystem/auro-formkit#svelte).
+Svelte has <auro-hyperlink href="https://svelte.dev/docs/svelte/custom-elements">native support for custom elements</auro-hyperlink>, so <code>&lt;auro-datepicker&gt;</code> works directly in Svelte templates without any wrapper or configuration.
+
+<auro-header level="3" id="svelteImport">Import the Component</auro-header>
+Import and register the component in the <code>&lt;script&gt;</code> block:
+
+```html
+<script lang="ts">
+  import { AuroDatePicker } from '@aurodesignsystem/auro-formkit/auro-datepicker/class';
+
+  AuroDatePicker.register('[custom]-datepicker');
+</script>
+```
+
+<auro-header level="3" id="svelteUsage">Basic Usage</auro-header>
+Use `<auro-datepicker>` directly in your Svelte template. Properties can be bound using standard Svelte attribute syntax:
+
+```html
+<script lang="ts">
+  import { AuroDatePicker } from '@aurodesignsystem/auro-formkit/auro-datepicker/class';
+
+  AuroDatePicker.register('[custom]-datepicker');
+
+  let datepickerValue = $state<string>('');
+</script>
+<custom-datepicker value={datepickerValue}>
+  <span slot="fromLabel">Choose a date</span>
+</custom-datepicker>
+```
+
+<auro-header level="3" id="svelteTypeScript">TypeScript Declarations</auro-header>
+Svelte does not automatically know about custom element attributes. To get autocomplete and type checking for <code>&lt;auro-datepicker&gt;</code> props in templates, add the following to a <code>.d.ts</code> file in your project (e.g. <code>src/auro-elements.d.ts</code>):
+
+```js
+import type { AuroDatePicker } from '@aurodesignsystem/auro-formkit/auro-datepicker/class';
+
+declare namespace svelteHTML {
+  interface IntrinsicElements {
+    '[custom]-datepicker': Partial<AuroDatePicker> & svelteHTML.HTMLAttributes<AuroDatePicker>;
+  }
+}
+```
+
+This enables prop hinting for attributes like <code>value</code>, <code>range</code>, <code>disabled</code>, and others directly in Svelte templates.
+
+<auro-header level="3" id="svelteEvents">Event Handling</auro-header>
+Auro components emit native `CustomEvent`s. Use the `oninput` handler directly on the element:
+
+```html
+<script lang="ts">
+  let value = $state('');
+
+  function handleInput(e: Event) {
+    value = (e.target as HTMLElement & { value: string }).value;
+  }
+</script>
+<custom-datepicker oninput={handleInput}>
+  <span slot="fromLabel">Choose a date</span>
+</custom-datepicker>
+<p>Selected: {value}</p>
+```
+
+<auro-header level="3" id="svelteModuleResolution">Module Resolution</auro-header>
+Ensure your <code>tsconfig.json</code> uses <code>"moduleResolution": "bundler"</code> so TypeScript can resolve the component's package exports:
+
+```js
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
+}
+```

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1961,6 +1961,7 @@ export class AuroDatePicker extends AuroElement {
     const path = event.composedPath();
     const [initTarget] = path;
     const pathIncludesBib = path.includes(this.dropdown?.bibContent);
+    const triggerIsInert = this.dropdown?.trigger?.inert;
 
     // When desktopModal is open, the datepicker marks the dropdown's #trigger
     // element inert to keep AT and Tab off the input. Inert also blocks pointer
@@ -1971,7 +1972,7 @@ export class AuroDatePicker extends AuroElement {
     // and closes the bib. Suppress that misdetection here: if the click lands
     // inside the trigger's bounds and outside the bib, stop propagation before
     // it reaches the window listener.
-    if (this.dropdown?.isPopoverVisible && !pathIncludesBib) {
+    if (this.dropdown?.isPopoverVisible && triggerIsInert && !pathIncludesBib) {
       const triggerRect = this.dropdown.trigger?.getBoundingClientRect();
       if (triggerRect &&
           event.clientX >= triggerRect.left && event.clientX <= triggerRect.right &&

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1958,9 +1958,27 @@ export class AuroDatePicker extends AuroElement {
    * @returns {void}
    */
   handleClick(event) {
+    const path = event.composedPath();
+    const [initTarget] = path;
+    const pathIncludesBib = path.includes(this.dropdown?.bibContent);
 
-    // Get the initial target of the click event
-    const [initTarget] = event.composedPath();
+    // When desktopModal is open, the datepicker marks the dropdown's #trigger
+    // element inert to keep AT and Tab off the input. Inert also blocks pointer
+    // events, so a click on the visible trigger area passes through to the
+    // wrapper <div> that sits alongside #trigger in the dropdown's shadow root.
+    // composedPath() then no longer contains #trigger, and the floater's
+    // window-level click-outside handler treats the click as an outside click
+    // and closes the bib. Suppress that misdetection here: if the click lands
+    // inside the trigger's bounds and outside the bib, stop propagation before
+    // it reaches the window listener.
+    if (this.dropdown?.isPopoverVisible && !pathIncludesBib) {
+      const triggerRect = this.dropdown.trigger?.getBoundingClientRect();
+      if (triggerRect &&
+          event.clientX >= triggerRect.left && event.clientX <= triggerRect.right &&
+          event.clientY >= triggerRect.top && event.clientY <= triggerRect.bottom) {
+        event.stopPropagation();
+      }
+    }
 
     // Determine if the current layout requires special handling
     const layoutRequiresHandling = ['snowflake'].includes(this.layout);
@@ -1969,7 +1987,7 @@ export class AuroDatePicker extends AuroElement {
     const targetIsInput = initTarget.tagName === 'INPUT';
     const isFocusAlreadyOnInput = this.inputList.includes(this.shadowRoot.activeElement);
 
-    if (layoutRequiresHandling && !targetIsInput && !isFocusAlreadyOnInput && !event.composedPath().includes(this.dropdown.bibContent)) {
+    if (layoutRequiresHandling && !targetIsInput && !isFocusAlreadyOnInput && !pathIncludesBib) {
       // Focus the first input
       this.inputList[0].focus();
     }

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -9675,6 +9675,41 @@ function runFullTest(mobileView) {
         await expect(el.dropdown.isPopoverVisible).to.be.true;
       });
 
+      // Regression: with desktopModal, the datepicker inerts #trigger while the
+      // bib is open. Inert also blocks pointer events, so a click on the visible
+      // trigger area falls through to the wrapper next to #trigger and the
+      // floater's window click-outside handler previously misread this as an
+      // outside click and closed the bib. handleClick now stops propagation for
+      // clicks whose coordinates land inside the trigger's bounds.
+      it('should keep the bib open when a click lands inside the inert trigger bounds', async () => {
+        const el = await fixture(html`
+          <auro-datepicker></auro-datepicker>
+        `);
+
+        el.dropdown.desktopModal = true;
+        el.dropdown.show();
+        await elementUpdated(el);
+        await nextFrame();
+
+        // Confirm we're in the desktopModal-inert path this test guards against.
+        await expect(el.dropdown.trigger.inert).to.be.true;
+
+        // setTimeout(0) inside the floater installs its window click-outside
+        // listener; wait a tick so the listener is live for this test.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const rect = el.dropdown.trigger.getBoundingClientRect();
+        el.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          composed: true,
+          clientX: rect.left + (rect.width / 2),
+          clientY: rect.top + (rect.height / 2),
+        }));
+
+        await nextFrame();
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
       // Verify click sets the correct dateFrom value when a date is clicked on the calendar.
       it('should set the correct dateFrom value when a date is clicked on the calendar', async () => {
         const el = await fixture(html`


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve auro-datepicker integration guidance for Svelte and React and fix click handling so the dropdown remains open when interacting with the desktop modal trigger area.

Bug Fixes:
- Prevent desktop modal datepicker dropdown from closing when clicking within the inert trigger area by suppressing misdetected outside clicks.

Documentation:
- Expand Svelte getting-started guide for auro-datepicker with import/registration, usage, TypeScript, events, and module resolution details.
- Expand React getting-started guide for auro-datepicker with import/registration, JSX typing, event handling, and module resolution guidance.