### PR TITLE
Select: Missing Unit Tests

### DIFF
--- a/components/form/test/auro-form-interactions.test.js
+++ b/components/form/test/auro-form-interactions.test.js
@@ -307,6 +307,69 @@ function runFullTest(mobileView) {
 
       await expect(form.value.selectExample).to.deep.equal(JSON.stringify(['stops']));
     });
+
+    it('emits submit with detail.value containing single-select value', async () => {
+      const form = await fixture(componentTemplate);
+      const [select] = form._elements;
+
+      select.value = 'stops';
+      await elementUpdated(select);
+      await elementUpdated(form);
+
+      const submitPromise = oneEvent(form, 'submit');
+      form.submit();
+      const submitEvent = await submitPromise;
+
+      await expect(submitEvent.detail.value.selectExample).to.equal('stops');
+    });
+
+    it('emits submit with detail.value containing multi-select value', async () => {
+      const form = await fixture(componentTemplate);
+      const [select] = form._elements;
+      select.multiSelect = true;
+      await elementUpdated(select);
+
+      select.value = ['stops', 'price'];
+      await elementUpdated(select);
+      await elementUpdated(form);
+
+      const submitPromise = oneEvent(form, 'submit');
+      form.submit();
+      const submitEvent = await submitPromise;
+
+      await expect(submitEvent.detail.value.selectExample).to.equal(JSON.stringify(['stops', 'price']));
+    });
+
+    it('exposes preset select value on form.value at initial render', async () => {
+      const form = await fixture(html`
+        <auro-form>
+          <auro-select name="selectExample" value="stops">
+            <auro-menu>
+              <auro-menuoption value="stops">Stops</auro-menuoption>
+              <auro-menuoption value="price">Price</auro-menuoption>
+            </auro-menu>
+          </auro-select>
+        </auro-form>
+      `);
+      const [select] = form._elements;
+      await elementUpdated(select);
+      await elementUpdated(form);
+
+      await expect(form.value.selectExample).to.equal('stops');
+    });
+
+    it('fires change on form when select value changes programmatically', async () => {
+      const form = await fixture(componentTemplate);
+      const [select] = form._elements;
+
+      const changePromise = oneEvent(form, 'change');
+      select.value = 'stops';
+      const changeEvent = await changePromise;
+
+      await expect(changeEvent).to.exist;
+      await elementUpdated(form);
+      await expect(form.value.selectExample).to.equal('stops');
+    });
   });
 }
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -815,6 +815,24 @@ function runTest(mobileView) {
           await expect(el.getAttribute('validity')).to.equal('valueMissing');
         });
 
+        it('should clear valueMissing error after selecting a value following blur', async () => {
+          const el = await requiredFixture();
+          await elementUpdated(el);
+
+          el.dispatchEvent(new Event('focusin'));
+          await elementUpdated(el);
+
+          el.dispatchEvent(new Event('blur'));
+          await elementUpdated(el);
+
+          await expect(el.getAttribute('validity')).to.equal('valueMissing');
+
+          el.value = 'Apples';
+          await elementUpdated(el);
+
+          await expect(el.getAttribute('validity')).to.equal('valid');
+        });
+
       });
 
       describe('setCustomValidity', () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -5203,61 +5203,6 @@ function runTest(mobileView) {
         await expect(form.validity).to.be.null;
       });
 
-      // The existing Enter propagation tests at :3397-3463 use a native <form>
-      // and only assert that keydown does not bubble to the wrapper. auro-form
-      // attaches handleKeyDown directly to each child element
-      // (auro-form.js:762-767), so bubbling isn't the only path to submit —
-      // any listener on the auro-select itself would still fire. Confirm the
-      // select's Enter handler (selectKeyboardStrategy.js:73-85) actually
-      // prevents auro-form's submit path in the real form context.
-      it('Enter on the select does not submit the surrounding auro-form when the bib is closed', async () => {
-        const form = await formFixture();
-        const select = form.querySelector('auro-select');
-        await elementUpdated(form);
-        await elementUpdated(select);
-
-        let submitFired = false;
-        form.addEventListener('submit', () => { submitFired = true; });
-
-        const dropdown = select.shadowRoot.querySelector('[auro-dropdown]');
-        await expect(dropdown.isPopoverVisible).to.be.false;
-
-        select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-        await elementUpdated(select);
-        await elementUpdated(form);
-
-        // Enter must open the bib, not submit the form.
-        await expect(submitFired).to.be.false;
-        await expect(dropdown.isPopoverVisible).to.be.true;
-      });
-
-      it('Enter on the select does not submit the surrounding auro-form when the bib is open', async () => {
-        const form = await formFixture();
-        const select = form.querySelector('auro-select');
-        await elementUpdated(form);
-        await elementUpdated(select);
-
-        const dropdown = select.shadowRoot.querySelector('[auro-dropdown]');
-        const trigger = dropdown.querySelector('[slot="trigger"]');
-        trigger.click();
-        await elementUpdated(select);
-        await expect(dropdown.isPopoverVisible).to.be.true;
-
-        select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-        await elementUpdated(select);
-
-        let submitFired = false;
-        form.addEventListener('submit', () => { submitFired = true; });
-
-        select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-        await elementUpdated(select);
-        await elementUpdated(form);
-
-        // Enter must select the active option — not submit the form.
-        await expect(submitFired).to.be.false;
-        await expect(select.value).to.equal('Oranges');
-      });
-
       describe('multiselect', () => {
         const multiselectFormFixture = (opts = {}) => fixture(html`
           <auro-form>

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -2230,6 +2230,115 @@ function runTest(mobileView) {
         await expect(trigger.ariaActiveDescendantElement === firstOption).to.be.true;
       });
 
+      it('should apply role="listbox" to the menu', async () => {
+        const el = await defaultFixture();
+        const menu = el.querySelector('auro-menu');
+
+        await elementUpdated(menu);
+        await expect(menu.getAttribute('role')).to.equal('listbox');
+      });
+
+      it('should apply role="option" to each menu option', async () => {
+        const el = await defaultFixture();
+        const options = el.querySelectorAll('auro-menuoption');
+
+        await elementUpdated(el);
+        expect(options.length).to.be.greaterThan(0);
+        options.forEach((option) => {
+          expect(option.getAttribute('role')).to.equal('option');
+        });
+      });
+
+      it('should toggle aria-expanded on the trigger from false to true and back to false', async () => {
+        const el = await defaultFixture();
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.shadowRoot.querySelector('#trigger');
+
+        await expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+
+        el.showBib();
+        await elementUpdated(el);
+        await expect(trigger.getAttribute('aria-expanded')).to.equal('true');
+
+        el.hideBib();
+        await elementUpdated(el);
+        await expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+      });
+
+      it('should set trigger aria-controls to the bib element id', async () => {
+        const el = await defaultFixture();
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.shadowRoot.querySelector('#trigger');
+
+        await elementUpdated(el);
+
+        const controlsId = trigger.getAttribute('aria-controls');
+        expect(controlsId).to.not.be.empty;
+
+        // The referenced element must live in the same shadow root as the trigger.
+        const bib = dropdown.shadowRoot.getElementById(controlsId);
+        expect(bib).to.exist;
+        expect(bib.id).to.equal(controlsId);
+      });
+
+      it('should set trigger aria-labelledby to the label element id', async () => {
+        const el = await defaultFixture();
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.shadowRoot.querySelector('#trigger');
+
+        await elementUpdated(el);
+
+        const labelledById = trigger.getAttribute('aria-labelledby');
+        expect(labelledById).to.not.be.empty;
+
+        const labelEl = dropdown.shadowRoot.getElementById(labelledById);
+        expect(labelEl).to.exist;
+      });
+
+      it('should reflect the disabled state via aria-disabled on the trigger', async () => {
+        const el = await defaultFixture();
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.shadowRoot.querySelector('#trigger');
+
+        await elementUpdated(el);
+        await expect(trigger.hasAttribute('aria-disabled')).to.be.false;
+
+        el.disabled = true;
+        await elementUpdated(el);
+        await elementUpdated(dropdown);
+        await expect(trigger.getAttribute('aria-disabled')).to.equal('true');
+
+        el.disabled = false;
+        await elementUpdated(el);
+        await elementUpdated(dropdown);
+        await expect(trigger.hasAttribute('aria-disabled')).to.be.false;
+      });
+
+      if (mobileView) {
+        it('should keep ariaActiveDescendantElement pointing at the activated option in fullscreen mode', async () => {
+          const el = await defaultFixture();
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+          const trigger = dropdown.shadowRoot.querySelector('#trigger');
+
+          el.showBib();
+          await waitUntil(() => el.dropdown.isPopoverVisible);
+
+          // Simulate fullscreen (resize observers don't fire in test env).
+          // In fullscreen, the trigger lives in select's shadow DOM while the
+          // options render inside the bib dialog — a different shadow root —
+          // so the element-reference binding must cross that boundary.
+          el.dropdown.isBibFullscreen = true;
+          await elementUpdated(el.dropdown);
+
+          el.menu.navigateOptions('down');
+          await elementUpdated(el);
+
+          const activeOption = el.menu.optionActive;
+          expect(activeOption).to.exist;
+          await expect(trigger.ariaActiveDescendantElement === activeOption).to.be.true;
+        });
+      }
+
       describe('announceToScreenReader', function() {
         this.timeout(5000);
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -4750,6 +4750,285 @@ function runTest(mobileView) {
       });
     });
 
+    describe('Behavioral Edge Cases', () => {
+      // #1 — Arrow-key navigation must scroll the newly-active option into view
+      // with `behavior: 'auto'` when the OS reports prefers-reduced-motion. The
+      // scroll-method unit tests already prove the behavior branch, but they
+      // call the method directly; this test drives the real code path — a
+      // keyboard event that flips the menu's active option and triggers
+      // scrollActiveOptionIntoView via the auroMenu-activatedOption listener.
+      it('arrow-key navigation uses auto scroll behavior when prefers-reduced-motion matches', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        const originalMatchMedia = window.matchMedia;
+        window.matchMedia = (query) => {
+          if (query === '(prefers-reduced-motion: reduce)') {
+            return { matches: true };
+          }
+          return originalMatchMedia(query);
+        };
+
+        const capturedBehaviors = [];
+        const originalScrollIntoViews = new Map();
+        el.menu.querySelectorAll('auro-menuoption').forEach((opt) => {
+          originalScrollIntoViews.set(opt, opt.scrollIntoView);
+          opt.scrollIntoView = (opts) => { capturedBehaviors.push(opts && opts.behavior); };
+        });
+
+        try {
+          el.showBib();
+          await elementUpdated(el);
+          await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+          // Drain any scroll calls from the initial-active setup so we only
+          // observe the ones triggered by the ArrowDown below.
+          capturedBehaviors.length = 0;
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+          await elementUpdated(el);
+
+          expect(capturedBehaviors.length, 'scrollIntoView must fire on arrow-key nav').to.be.greaterThan(0);
+          capturedBehaviors.forEach((behavior) => {
+            expect(behavior).to.equal('auto');
+          });
+        } finally {
+          window.matchMedia = originalMatchMedia;
+          originalScrollIntoViews.forEach((fn, opt) => { opt.scrollIntoView = fn; });
+        }
+      });
+
+      // #3 — Remove every menu option while the bib is open. Space must still
+      // toggle the bib (would fail if the empty menu armed the typeahead
+      // buffer), and no option can remain "active" once its DOM node is gone.
+      it('removing all options while the bib is open leaves Space as a bib toggle and clears optionActive', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        el.showBib();
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        const menu = el.querySelector('auro-menu');
+        menu.querySelectorAll('auro-menuoption').forEach((opt) => opt.remove());
+        await elementUpdated(menu);
+        await elementUpdated(el);
+
+        // No option node exists — none can be active.
+        expect(menu.querySelector('auro-menuoption.active')).to.be.null;
+
+        // Space toggles the bib closed (the standard combobox toggle behavior
+        // must survive an empty menu).
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+        await elementUpdated(el);
+        // Typeahead buffer must remain empty so Space kept its toggle semantics.
+        expect(el.typeaheadBuffer).to.equal('');
+      });
+
+      // #4 — Removing the currently-active option via slot mutation must not
+      // leave the keyboard nav pointing at a detached node. The next ArrowDown
+      // press has to land on a valid remaining option.
+      it('removing the active option via slot mutation leaves keyboard nav on a valid remaining option', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        el.showBib();
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        const menu = el.querySelector('auro-menu');
+        // Move active to the second option so we have neighbors on both sides.
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+        const active = el.menu.optionActive;
+        expect(active).to.exist;
+
+        active.remove();
+        await elementUpdated(menu);
+        await elementUpdated(el);
+
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        const remaining = [...menu.querySelectorAll('auro-menuoption')];
+        expect(remaining.length).to.be.greaterThan(0);
+        expect(el.menu.optionActive, 'next nav must land on a still-attached option').to.exist;
+        expect(remaining).to.include(el.menu.optionActive);
+        expect(el.menu.optionActive.isConnected).to.be.true;
+      });
+
+      // #5 — Multi-select complement to "should close the bib when an option is
+      // selected". Setting `value` programmatically while the bib is open must
+      // NOT close the bib in multi-select mode, so users can continue toggling
+      // additional options.
+      it('multi-select value set programmatically while bib open keeps the bib open', async () => {
+        const el = await multiSelectFixture();
+        await elementUpdated(el);
+
+        el.showBib();
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        el.value = JSON.stringify(['Apples']);
+        await elementUpdated(el);
+        await elementUpdated(el.menu);
+
+        const parsed = JSON.parse(el.value);
+        expect(parsed).to.include('Apples');
+        // Single-select would call hideBib() here; multiselect must not.
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+      });
+
+      // #6 — Setting disabled=true while the bib is open. The current
+      // architecture propagates `disabled` to the underlying auro-dropdown as
+      // an attribute (see performUpdate at auro-select.js:1240) and applies
+      // the `is-disabled` host class. That guards subsequent open/close
+      // toggles in auro-dropdown's floater layer — a follow-up hide() becomes
+      // a no-op — so the observable contract from the select's side is that
+      // (a) the disabled attribute is reflected onto the dropdown, and (b) the
+      // is-disabled class is set on the host, which the styles use to render
+      // the trigger non-interactive.
+      it('setting disabled=true while bib open propagates disabled state to dropdown and host', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        el.showBib();
+        await elementUpdated(el);
+        await expect(el.dropdown.isPopoverVisible).to.be.true;
+
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.dropdown.hasAttribute('disabled'), 'disabled must propagate to auro-dropdown').to.be.true;
+        expect(el.classList.contains('is-disabled') || el.shadowRoot.querySelector('.is-disabled'), 'is-disabled class must be applied to render the trigger non-interactive').to.exist;
+      });
+
+      // #7 — Full roundtrip of trigger.inert as the bib transitions between
+      // popover and fullscreen while OPEN. Existing tests cover each direction
+      // in isolation; this exercises both transitions on the same instance to
+      // guard against state that only correctly clears in one direction.
+      it('bib crossing fullscreenBreakpoint while open toggles trigger.inert in both directions', async () => {
+        const el = await defaultFixture();
+        await elementUpdated(el);
+
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+
+        el.showBib();
+        await elementUpdated(el);
+        await expect(dropdown.isPopoverVisible).to.be.true;
+
+        // Popover → fullscreen: inert must be added to the trigger.
+        dropdown.isBibFullscreen = true;
+        await elementUpdated(el);
+        dropdown.dispatchEvent(new CustomEvent('auroDropdown-strategy-change', {
+          bubbles: true,
+          composed: true
+        }));
+        await elementUpdated(el);
+        await expect(dropdown.trigger.inert, 'trigger must be inert while fullscreen dialog is open').to.be.true;
+
+        // Fullscreen → popover: inert must be removed.
+        dropdown.isBibFullscreen = false;
+        await elementUpdated(el);
+        dropdown.dispatchEvent(new CustomEvent('auroDropdown-strategy-change', {
+          bubbles: true,
+          composed: true
+        }));
+        await elementUpdated(el);
+        await expect(dropdown.trigger.inert, 'trigger must be interactive again after returning to popover mode').to.be.false;
+      });
+
+      // #9 — Runtime mutation of the ariaLabel.bib.close slot content. The
+      // slot forwards through auro-select's shadow (as a nested <slot> with
+      // slot="ariaLabel.close">) into auro-bibtemplate, which projects it into
+      // the close button's visible content — no explicit aria-label. Slots
+      // are live, so the accessible name follows the mutation automatically:
+      // the observable contract is that the auro-select forwarding slot's
+      // assignedNodes reflect the updated text.
+      it('runtime mutation of the ariaLabel.bib.close slot content is reflected in the forwarding slot', async () => {
+        const el = await fixture(html`
+          <auro-select>
+            <span slot="bib.fullscreen.headline">Bib Headline</span>
+            <span slot="label">Name</span>
+            <span slot="ariaLabel.bib.close">Close menu</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+            </auro-menu>
+          </auro-select>
+        `);
+        await elementUpdated(el);
+
+        const forwardingSlot = el.shadowRoot.querySelector('slot[name="ariaLabel.bib.close"]');
+        expect(forwardingSlot, 'auro-select shadow must expose the ariaLabel.bib.close forwarding slot').to.exist;
+
+        const initialText = forwardingSlot
+          .assignedNodes({ flatten: true })
+          .map((n) => n.textContent)
+          .join('')
+          .trim();
+        expect(initialText).to.equal('Close menu');
+
+        const closeSlotContent = el.querySelector('[slot="ariaLabel.bib.close"]');
+        closeSlotContent.textContent = 'Dismiss picker';
+        await new Promise((r) => requestAnimationFrame(r));
+
+        const updatedText = forwardingSlot
+          .assignedNodes({ flatten: true })
+          .map((n) => n.textContent)
+          .join('')
+          .trim();
+        expect(updatedText).to.equal('Dismiss picker');
+      });
+
+      // #10 — Deselecting the last selected option in multi-select must return
+      // the trigger to its placeholder state, not just clear the displayed
+      // value. The #placeholder node is always in the DOM; visibility is
+      // toggled via the util_displayHidden class based on truthiness of
+      // this.value. Existing coverage proves the value text clears; this
+      // locks in that the placeholder itself is visible again.
+      it('deselecting the last selected option in multi-select restores the placeholder in the trigger', async () => {
+        const el = await fixture(html`
+          <auro-select multiselect placeholder="Pick a fruit">
+            <span slot="bib.fullscreen.headline">Bib Headline</span>
+            <span slot="label">Name</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+            </auro-menu>
+          </auro-select>
+        `);
+        await elementUpdated(el);
+
+        const menu = el.querySelector('auro-menu');
+        const apples = menu.querySelector('auro-menuoption[value="Apples"]');
+
+        apples.click();
+        await elementUpdated(el);
+        await elementUpdated(menu);
+        await new Promise((r) => setTimeout(r, 0));
+        await elementUpdated(el);
+
+        // Sanity check: something is selected, so the placeholder is hidden.
+        expect(JSON.parse(el.value || '[]')).to.include('Apples');
+        const placeholderBefore = el.shadowRoot.querySelector('#placeholder');
+        expect(placeholderBefore, 'placeholder node is always rendered').to.exist;
+        expect(placeholderBefore.classList.contains('util_displayHidden'), 'placeholder must be hidden while a value is selected').to.be.true;
+
+        // Deselect the last selected chip (click the same option again).
+        apples.click();
+        await elementUpdated(el);
+        await elementUpdated(menu);
+        await new Promise((r) => setTimeout(r, 0));
+        await elementUpdated(el);
+
+        // Placeholder must be visible in the trigger again.
+        const placeholderAfter = el.shadowRoot.querySelector('#placeholder');
+        expect(placeholderAfter.classList.contains('util_displayHidden'), 'placeholder must be visible after last chip is deselected').to.be.false;
+        expect(placeholderAfter.textContent.trim()).to.equal('Pick a fruit');
+      });
+    });
+
     describe('auro-form integration', () => {
       const formFixture = (opts = {}) => fixture(html`
         <auro-form>

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -5034,6 +5034,7 @@ function runTest(mobileView) {
         <auro-form>
           <auro-select name="fruit" ?required=${Boolean(opts.required)}>
             <span slot="label">Fruit</span>
+            <span slot="bib.fullscreen.headline">Bib Headline</span>
             <auro-menu>
               <auro-menuoption value="Apples">Apples</auro-menuoption>
               <auro-menuoption value="Oranges">Oranges</auro-menuoption>
@@ -5141,6 +5142,226 @@ function runTest(mobileView) {
 
         await expect(form.value).to.not.have.key('fruit');
         await expect(form.value.produce).to.equal('Oranges');
+      });
+
+      // The empty-required negative test at :5074-5088 only proves submit is
+      // blocked; a broken "always block" implementation would still pass it.
+      // Complement with a positive path: a filled valid required select must
+      // reach the submit dispatch with the value in detail.value.fruit.
+      it('dispatches submit with detail.value.fruit when a required select has a valid value', async () => {
+        const form = await formFixture({ required: true });
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        select.value = 'Oranges';
+        await elementUpdated(select);
+        await elementUpdated(form);
+
+        const submitEventPromise = oneEvent(form, 'submit');
+        await form.submit();
+        const submitEvent = await submitEventPromise;
+
+        await expect(submitEvent.detail).to.exist;
+        await expect(submitEvent.detail.value.fruit).to.equal('Oranges');
+      });
+
+      // form.validity is a public contract on auro-form (auro-form.js:404-420):
+      // null in the initial state, 'valid' / 'invalid' after interaction.
+      // Existing coverage only checks the select's own validity attribute — not
+      // the form-level rollup that consumers gate submit buttons on.
+      it('form.validity transitions from null → valid → invalid → null across interactions', async () => {
+        const form = await formFixture({ required: true });
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        // Fresh required form, nothing touched — validity is null.
+        await expect(form.validity).to.be.null;
+
+        // Fill it → form is valid.
+        select.value = 'Apples';
+        await elementUpdated(select);
+        await elementUpdated(form);
+        await expect(form.validity).to.equal('valid');
+
+        // Force-validate on empty → form is invalid.
+        select.value = undefined;
+        await elementUpdated(select);
+        select.validate(true);
+        await elementUpdated(select);
+        await elementUpdated(form);
+        await expect(form.validity).to.equal('invalid');
+
+        // Reset returns to initial state → validity back to null.
+        const resetBtn = form.querySelector('button[type="reset"]');
+        const resetEventPromise = oneEvent(form, 'reset');
+        resetBtn.click();
+        await resetEventPromise;
+        await elementUpdated(select);
+        await elementUpdated(form);
+        await expect(form.validity).to.be.null;
+      });
+
+      // The existing Enter propagation tests at :3397-3463 use a native <form>
+      // and only assert that keydown does not bubble to the wrapper. auro-form
+      // attaches handleKeyDown directly to each child element
+      // (auro-form.js:762-767), so bubbling isn't the only path to submit —
+      // any listener on the auro-select itself would still fire. Confirm the
+      // select's Enter handler (selectKeyboardStrategy.js:73-85) actually
+      // prevents auro-form's submit path in the real form context.
+      it('Enter on the select does not submit the surrounding auro-form when the bib is closed', async () => {
+        const form = await formFixture();
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        let submitFired = false;
+        form.addEventListener('submit', () => { submitFired = true; });
+
+        const dropdown = select.shadowRoot.querySelector('[auro-dropdown]');
+        await expect(dropdown.isPopoverVisible).to.be.false;
+
+        select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        await elementUpdated(select);
+        await elementUpdated(form);
+
+        // Enter must open the bib, not submit the form.
+        await expect(submitFired).to.be.false;
+        await expect(dropdown.isPopoverVisible).to.be.true;
+      });
+
+      it('Enter on the select does not submit the surrounding auro-form when the bib is open', async () => {
+        const form = await formFixture();
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        const dropdown = select.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.querySelector('[slot="trigger"]');
+        trigger.click();
+        await elementUpdated(select);
+        await expect(dropdown.isPopoverVisible).to.be.true;
+
+        select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(select);
+
+        let submitFired = false;
+        form.addEventListener('submit', () => { submitFired = true; });
+
+        select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        await elementUpdated(select);
+        await elementUpdated(form);
+
+        // Enter must select the active option — not submit the form.
+        await expect(submitFired).to.be.false;
+        await expect(select.value).to.equal('Oranges');
+      });
+
+      describe('multiselect', () => {
+        const multiselectFormFixture = (opts = {}) => fixture(html`
+          <auro-form>
+            <auro-select multiselect name="fruit" ?required=${Boolean(opts.required)}>
+              <span slot="label">Fruit</span>
+              <span slot="bib.fullscreen.headline">Bib Headline</span>
+              <auro-menu>
+                <auro-menuoption value="Apples">Apples</auro-menuoption>
+                <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+                <auro-menuoption value="Bananas">Bananas</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+            <button type="submit">Submit</button>
+            <button type="reset">Reset</button>
+          </auro-form>
+        `);
+
+        // auro-form.value reads select.value directly (auro-form.js:273-284),
+        // so a multiselect select stores its JSON-encoded array under the
+        // element's name. The native <select> mirror in auro-select.js:1465-1504
+        // only reflects the FIRST selection — form.value must not silently pick
+        // that up in place of the real multiselect payload.
+        it('form.value carries the full multiselect payload as a JSON-encoded array', async () => {
+          const form = await multiselectFormFixture();
+          const select = form.querySelector('auro-select');
+          const menu = select.querySelector('auro-menu');
+          await elementUpdated(form);
+          await elementUpdated(select);
+
+          menu.querySelector('auro-menuoption[value="Apples"]').click();
+          await elementUpdated(select);
+          await elementUpdated(menu);
+          await new Promise((r) => setTimeout(r, 0));
+          menu.querySelector('auro-menuoption[value="Bananas"]').click();
+          await elementUpdated(select);
+          await elementUpdated(menu);
+          await new Promise((r) => setTimeout(r, 0));
+          await elementUpdated(form);
+
+          expect(form.value).to.have.key('fruit');
+          const parsed = JSON.parse(form.value.fruit);
+          expect(parsed).to.include('Apples');
+          expect(parsed).to.include('Bananas');
+          expect(parsed).to.have.length(2);
+        });
+
+        it('dispatches submit with the full multiselect payload in detail.value.fruit', async () => {
+          const form = await multiselectFormFixture();
+          const select = form.querySelector('auro-select');
+          await elementUpdated(form);
+          await elementUpdated(select);
+
+          select.value = JSON.stringify(['Apples', 'Oranges']);
+          await elementUpdated(select);
+          await elementUpdated(form);
+
+          const submitEventPromise = oneEvent(form, 'submit');
+          await form.submit();
+          const submitEvent = await submitEventPromise;
+
+          const parsed = JSON.parse(submitEvent.detail.value.fruit);
+          expect(parsed).to.include('Apples');
+          expect(parsed).to.include('Oranges');
+          expect(parsed).to.have.length(2);
+        });
+
+        it('reset event previousValue.fruit carries the full multiselect payload', async () => {
+          const form = await multiselectFormFixture();
+          const select = form.querySelector('auro-select');
+          await elementUpdated(form);
+          await elementUpdated(select);
+
+          select.value = JSON.stringify(['Oranges', 'Bananas']);
+          await elementUpdated(select);
+          await elementUpdated(form);
+
+          const resetBtn = form.querySelector('button[type="reset"]');
+          const resetEventPromise = oneEvent(form, 'reset');
+          resetBtn.click();
+          const resetEvent = await resetEventPromise;
+
+          expect(resetEvent.detail.previousValue).to.exist;
+          const parsed = JSON.parse(resetEvent.detail.previousValue.fruit);
+          expect(parsed).to.include('Oranges');
+          expect(parsed).to.include('Bananas');
+        });
+
+        it('removes disabled multiselect from form.value at runtime', async () => {
+          const form = await multiselectFormFixture();
+          const select = form.querySelector('auro-select');
+          await elementUpdated(form);
+          await elementUpdated(select);
+
+          select.value = JSON.stringify(['Apples']);
+          await elementUpdated(select);
+          await elementUpdated(form);
+          expect(form.value).to.have.key('fruit');
+
+          select.setAttribute('disabled', '');
+          await elementUpdated(select);
+          await elementUpdated(form);
+
+          expect(form.value).to.not.have.key('fruit');
+        });
       });
     });
   });

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -4821,6 +4821,7 @@ function runTest(mobileView) {
         // must survive an empty menu).
         el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
         await elementUpdated(el);
+        expect(el.dropdown.isPopoverVisible).to.be.false;
         // Typeahead buffer must remain empty so Space kept its toggle semantics.
         expect(el.typeaheadBuffer).to.equal('');
       });

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -4883,13 +4883,14 @@ function runTest(mobileView) {
       // #6 — Setting disabled=true while the bib is open. The current
       // architecture propagates `disabled` to the underlying auro-dropdown as
       // an attribute (see performUpdate at auro-select.js:1240) and applies
-      // the `is-disabled` host class. That guards subsequent open/close
-      // toggles in auro-dropdown's floater layer — a follow-up hide() becomes
-      // a no-op — so the observable contract from the select's side is that
-      // (a) the disabled attribute is reflected onto the dropdown, and (b) the
-      // is-disabled class is set on the host, which the styles use to render
-      // the trigger non-interactive.
-      it('setting disabled=true while bib open propagates disabled state to dropdown and host', async () => {
+      // the `is-disabled` class on the internal #dropdownLabel via
+      // commonLabelClasses. That guards subsequent open/close toggles in
+      // auro-dropdown's floater layer — a follow-up hide() becomes a no-op —
+      // so the observable contract from the select's side is that (a) the
+      // disabled attribute is reflected onto the dropdown, and (b) the
+      // is-disabled class is set on #dropdownLabel, which the styles use to
+      // render the trigger non-interactive.
+      it('setting disabled=true while bib open propagates disabled state to dropdown and dropdownLabel', async () => {
         const el = await defaultFixture();
         await elementUpdated(el);
 
@@ -4901,7 +4902,9 @@ function runTest(mobileView) {
         await elementUpdated(el);
 
         expect(el.dropdown.hasAttribute('disabled'), 'disabled must propagate to auro-dropdown').to.be.true;
-        expect(el.classList.contains('is-disabled') || el.shadowRoot.querySelector('.is-disabled'), 'is-disabled class must be applied to render the trigger non-interactive').to.exist;
+        const dropdownLabel = el.shadowRoot.querySelector('#dropdownLabel');
+        expect(dropdownLabel, '#dropdownLabel must exist').to.exist;
+        expect(dropdownLabel.classList.contains('is-disabled'), 'is-disabled class must be applied on #dropdownLabel to render the trigger non-interactive').to.be.true;
       });
 
       // #7 — Full roundtrip of trigger.inert as the bib transitions between

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1,12 +1,13 @@
 /* eslint-disable max-lines, jsdoc/require-jsdoc, no-return-await, no-undef, no-unused-expressions */
 import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
 
-import { fixture, html, expect, elementUpdated, waitUntil } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated, oneEvent, waitUntil } from '@open-wc/testing';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '@aurodesignsystem/auro-dropdown';
 import '../../menu/src/registered.js';
 import '../src/registered.js';
+import '../../form/src/registered.js';
 import {
   defaultFixture,
   emphasizedFixture,
@@ -4619,6 +4620,121 @@ function runTest(mobileView) {
           // Selection state is unchanged — type-ahead must not toggle checks in multiselect
           expect([...(el.optionSelected || [])]).to.deep.equal(previouslySelected);
         });
+      });
+    });
+
+    describe('auro-form integration', () => {
+      const formFixture = (opts = {}) => fixture(html`
+        <auro-form>
+          <auro-select name="fruit" ?required=${Boolean(opts.required)}>
+            <span slot="label">Fruit</span>
+            <auro-menu>
+              <auro-menuoption value="Apples">Apples</auro-menuoption>
+              <auro-menuoption value="Oranges">Oranges</auro-menuoption>
+            </auro-menu>
+          </auro-select>
+          <button type="submit">Submit</button>
+          <button type="reset">Reset</button>
+        </auro-form>
+      `);
+
+      it('clears selection and resets validation when <button type="reset"> is clicked', async () => {
+        const form = await formFixture({ required: true });
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        select.value = 'Oranges';
+        await elementUpdated(select);
+        await expect(select.value).to.equal('Oranges');
+
+        select.validate(true);
+        await elementUpdated(select);
+        await expect(select.getAttribute('validity')).to.equal('valid');
+
+        const resetBtn = form.querySelector('button[type="reset"]');
+        const resetEventPromise = oneEvent(form, 'reset');
+        resetBtn.click();
+        await resetEventPromise;
+        await elementUpdated(select);
+
+        await expect(select.value).to.be.undefined;
+        // reset() clears validity to undefined and re-runs non-forced validation,
+        // which short-circuits on the untouched empty value — so the reflected
+        // attribute should be removed entirely, not just != 'valueMissing'.
+        await expect(select.getAttribute('validity')).to.be.null;
+      });
+
+      it('blocks submit when required select is empty', async () => {
+        const form = await formFixture({ required: true });
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        let submitFired = false;
+        form.addEventListener('submit', () => { submitFired = true; });
+
+        // Drive submit() directly so we can await the async validation chain.
+        await form.submit();
+        await elementUpdated(select);
+
+        await expect(submitFired).to.be.false;
+      });
+
+      it('dispatches reset event with detail.previousValue when reset button is clicked', async () => {
+        const form = await formFixture();
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        select.value = 'Oranges';
+        await elementUpdated(select);
+        await elementUpdated(form);
+
+        const resetBtn = form.querySelector('button[type="reset"]');
+        const resetEventPromise = oneEvent(form, 'reset');
+        resetBtn.click();
+        const resetEvent = await resetEventPromise;
+
+        await expect(resetEvent.detail.previousValue).to.exist;
+        await expect(resetEvent.detail.previousValue.fruit).to.equal('Oranges');
+      });
+
+      it('removes disabled select from form.value at runtime', async () => {
+        const form = await formFixture();
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        select.value = 'Apples';
+        await elementUpdated(select);
+        await elementUpdated(form);
+        await expect(form.value.fruit).to.equal('Apples');
+
+        select.setAttribute('disabled', '');
+        await elementUpdated(select);
+        await elementUpdated(form);
+
+        await expect(form.value).to.not.have.key('fruit');
+      });
+
+      it('re-keys form.value when select name changes at runtime', async () => {
+        const form = await formFixture();
+        const select = form.querySelector('auro-select');
+        await elementUpdated(form);
+        await elementUpdated(select);
+
+        select.value = 'Oranges';
+        await elementUpdated(select);
+        await elementUpdated(form);
+        await expect(form.value.fruit).to.equal('Oranges');
+
+        select.setAttribute('name', 'produce');
+        await elementUpdated(select);
+        await elementUpdated(form);
+
+        await expect(form.value).to.not.have.key('fruit');
+        await expect(form.value.produce).to.equal('Oranges');
       });
     });
   });


### PR DESCRIPTION
Series of missing unit tests sourced during manual testing for v6.

Adds missing/expanded unit test coverage for auro-select and its integration with auro-form, focusing on accessibility semantics, validation regressions, behavioral edge cases, and form submit/reset/change contracts.

Changes:

- Expanded auro-select tests for validation blur/select flows, ARIA roles/attributes, keyboard/slot/disabled edge cases, and auro-form integration (submit/reset/value/validity behavior).
- Extended auro-form interaction tests to assert select values appear in submit event detail, are reflected in initial form.value, and that programmatic select changes trigger form-level change.

## Summary by Sourcery

Add comprehensive test coverage for auro-select behavior, accessibility, and auro-form integration, including single- and multi-select scenarios.

Tests:
- Add validation regression tests for required auro-select, including clearing valueMissing after user selection.
- Add accessibility tests for select dropdown trigger, menu, and options, covering ARIA roles, attributes, and active-descendant behavior in fullscreen mode.
- Add behavioral edge-case tests for keyboard navigation, dynamic option removal, multiselect bib behavior, disabled state handling, inert toggling, slot content mutation, and multiselect placeholder visibility.
- Add auro-form integration tests for auro-select covering reset, submit blocking and payload, runtime disabled/name changes, form.validity transitions, and multiselect value propagation.
- Extend auro-form interaction tests to verify submit and change event payloads and initial form.value when auro-select has preset values.