### PR TITLE
Address small CSS issues with mobile strings in datepicker

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -2458,8 +2458,8 @@ export class AuroDatePicker extends AuroElement {
         <slot slot="bib.fullscreen.dateLabel" name="bib.fullscreen.dateLabel" @slotchange="${this.handleSlotToSlot}"></slot>
         <slot slot="bib.fullscreen.toLabel" name="bib.fullscreen.toLabel" @slotchange="${this.handleSlotToSlot}"></slot>
         <slot slot="bib.fullscreen.fromLabel" name="bib.fullscreen.fromLabel" @slotchange="${this.handleSlotToSlot}"></slot>
-        <span slot="bib.fullscreen.fromStr">${AuroInputUtil.toFormattedValue(this.valueObject, this.format) || html`<span class="placeholderDate">${(this.format || 'mm/dd/yyyy').toUpperCase()}</span>`}</span>
-        ${this.range ? html`<span slot="bib.fullscreen.toStr">${AuroInputUtil.toFormattedValue(this.valueEndObject, this.format) || html`<span class="placeholderDate">${(this.format || 'mm/dd/yyyy').toUpperCase()}</span>`}</span>` : undefined}
+        <span slot="bib.fullscreen.fromStr" class="body-default">${AuroInputUtil.toFormattedValue(this.valueObject, this.format) || html`<span class="placeholderDate">${(this.format || 'mm/dd/yyyy').toUpperCase()}</span>`}</span>
+        ${this.range ? html`<span slot="bib.fullscreen.toStr" class="body-default">${AuroInputUtil.toFormattedValue(this.valueEndObject, this.format) || html`<span class="placeholderDate">${(this.format || 'mm/dd/yyyy').toUpperCase()}</span>`}</span>` : undefined}
       </auro-formkit-calendar>
     `;
   }

--- a/components/datepicker/src/styles/style-auro-calendar.scss
+++ b/components/datepicker/src/styles/style-auro-calendar.scss
@@ -91,7 +91,7 @@
   flex-direction: column;
   justify-content: center;
 
-  padding: 0 var(--ds-size-150, vac.$ds-size-150) 0 var(--ds-size-200, vac.$ds-size-200);
+  padding: 0 var(--ds-size-150, vac.$ds-size-150) 0 0;
 }
 
 .mobileDateLabel {

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -253,7 +253,7 @@ export class AuroDropdown extends AuroElement {
         const assigned = slot.assignedElements();
         for (const el of assigned) {
           if (el.hasAttribute('disabled')) {
-            continue;
+            continue; // eslint-disable-line no-continue
           }
           // Try finding a focusable descendant first (handles non-focusable
           // wrappers like <div> containing a <button>). If none found, try

--- a/docs/post-mortem/1494481.md
+++ b/docs/post-mortem/1494481.md
@@ -1,0 +1,122 @@
+# Post-Mortem: Datepicker Mobile Header Alignment & Typography (AB#1494481, AB#1598648)
+
+**Branch:** datepicker mobile-header polish → `dev`
+**Scope:** Two small fixes to the fullscreen (mobile) datepicker header — left-align the from/to date columns with the rest of the mobile layout (AB#1494481), and apply the correct body typography to the rendered date-display strings (AB#1598648). One SCSS line, one JS template edit. Both touch the seam where `auro-datepicker` slots content *out* into `auro-formkit-calendar`.
+
+## Quick Reference
+
+| Symptom | Why it happens | Fix |
+|---|---|---|
+| Mobile header date columns (From/To) sit indented from the left edge while the headline / calendar body sit flush | `.headerDateFrom, .headerDateTo` carried a left `padding` of `--ds-size-200`, pushing the flex columns inward relative to everything else in the fullscreen layout | Drop the left padding to `0`; keep the right padding as the From/To gutter |
+| The From/To date **value** renders in a different size/line-height than the label above it | The `<span slot="bib.fullscreen.fromStr">` / `toStr` spans had no typography class — the `mobileDateLabel` spans use `body-xs`, but the value spans fell back to inherited/UA typography | Add `class="body-default"` to the value spans |
+| `body-default` on a slotted span "doesn't apply" from the calendar's styles | The span physically lives in `auro-datepicker`'s shadow root, so the class resolves against the **datepicker's** shadow styles — not the calendar's | Define/rely on `body-default` in the datepicker scope (it's bundled into its `style-css.js` via `webcorestylesheets` type classes) |
+| Setting the datepicker's `body-default` class doesn't change the date-value **color** | Color of the slotted value is owned by the calendar's `::slotted([slot="bib.fullscreen.fromStr"])` rule (`--ds-auro-datepicker-placeholder-color`) — `::slotted()` reaches across the boundary for directly-targeted properties | Change color on the calendar side; change typography on the datepicker side |
+
+## The Bugs
+
+### 1. Mobile header columns indented from the layout edge (AB#1494481)
+
+In the fullscreen calendar, the header is a flex row of two columns, `.headerDateFrom` and `.headerDateTo` (each `flex: 1`), holding the date label and the slotted date string:
+
+```
+<div slot="subheader" class="mobileHeader">
+  <div class="headerDateFrom">
+    <span class="mobileDateLabel body-xs">…label…</span>
+    <slot name="bib.fullscreen.fromStr"></slot>
+  </div>
+  <div class="headerDateTo"> … </div>
+</div>
+```
+
+Both columns carried:
+
+```scss
+padding: 0 var(--ds-size-150, vac.$ds-size-150) 0 var(--ds-size-200, vac.$ds-size-200);
+//        top  right                              bottom left  ← 1rem left indent
+```
+
+The `--ds-size-200` (1rem) **left** padding pushed the entire From column — label *and* value together — inward from the fullscreen layout's left edge, so the header text no longer lined up with the headline above or the calendar grid below. Because the padding sat on the column, the label and value stayed aligned *to each other* but the whole block was visibly indented.
+
+### 2. Date-display value rendered with the wrong typography (AB#1598648)
+
+The label spans (`.mobileDateLabel`) already declared `body-xs`. The value spans that render the formatted date (or the placeholder) declared no typography class:
+
+```js
+<span slot="bib.fullscreen.fromStr">${AuroInputUtil.toFormattedValue(this.valueObject, this.format) || html`<span class="placeholderDate">…</span>`}</span>
+```
+
+With no class, the value inherited whatever the ambient font metrics were rather than the intended `body-default` (1rem / 1.5rem line-height), so the value's size and line-height didn't match the design.
+
+## Root Causes
+
+1. **Left padding used as a layout gutter on a column that should be flush.** The `--ds-size-200` left padding on `.headerDateFrom`/`.headerDateTo` was doing double duty — the right `--ds-size-150` is a real inter-column gutter, but the left value indented the block away from the shared layout edge. The other fullscreen regions (`.headerActions`, headline) align to the container edge; the header columns didn't.
+
+2. **Typography class omitted at the slot authoring site.** The label spans were classed; the value spans were not. Easy to miss because the value span is authored in `auro-datepicker.js` (the slot *source*) while its visual siblings (the labels) are authored in `auro-calendar.js` (the slot *host*) — the two typography decisions live in different files.
+
+## The Fixes
+
+### `components/datepicker/src/styles/style-auro-calendar.scss` (AB#1494481)
+
+```diff
+ .headerDateFrom,
+ .headerDateTo {
+   …
+-  padding: 0 var(--ds-size-150, vac.$ds-size-150) 0 var(--ds-size-200, vac.$ds-size-200);
++  padding: 0 var(--ds-size-150, vac.$ds-size-150) 0 0;
+ }
+```
+
+Drops the left indent; keeps the right `--ds-size-150` gutter between the From and To columns. The header columns now align flush-left with the rest of the fullscreen layout.
+
+### `components/datepicker/src/auro-datepicker.js` (AB#1598648)
+
+```diff
+-<span slot="bib.fullscreen.fromStr">${AuroInputUtil.toFormattedValue(this.valueObject, this.format) || html`<span class="placeholderDate">${(this.format || 'mm/dd/yyyy').toUpperCase()}</span>`}</span>
+-${this.range ? html`<span slot="bib.fullscreen.toStr">${AuroInputUtil.toFormattedValue(this.valueEndObject, this.format) || html`<span class="placeholderDate">…</span>`}</span>` : undefined}
++<span slot="bib.fullscreen.fromStr" class="body-default">${AuroInputUtil.toFormattedValue(this.valueObject, this.format) || html`<span class="placeholderDate">${(this.format || 'mm/dd/yyyy').toUpperCase()}</span>`}</span>
++${this.range ? html`<span slot="bib.fullscreen.toStr" class="body-default">${AuroInputUtil.toFormattedValue(this.valueEndObject, this.format) || html`<span class="placeholderDate">…</span>`}</span>` : undefined}
+```
+
+`body-default` is defined in the datepicker's own shadow styles (`style-css.js`, compiled from `style.scss` which pulls in `@aurodesignsystem/webcorestylesheets` type classes). Because the span lives in the datepicker's shadow root before projection, the class resolves there — no calendar-side change required.
+
+## Why This Works (Shadow DOM slotting)
+
+The subtle part of AB#1598648 is *which stylesheet supplies `body-default`*:
+
+- The value span is authored inside `auro-datepicker`'s `render()` and assigned `slot="bib.fullscreen.fromStr"`. It is projected into a `<slot>` inside `auro-formkit-calendar`, but it **physically remains in the datepicker's shadow tree**.
+- Slotted content is styled by the tree that *owns* the node (datepicker), plus any `::slotted()` rules from the host (calendar). So:
+  - **Typography** (`body-default`) → datepicker's shadow styles. ✅ Adding the class there is sufficient.
+  - **Color** of the value → calendar's `::slotted([slot="bib.fullscreen.fromStr"])` rule (`--ds-auro-datepicker-placeholder-color`). The host can reach across the slot boundary for directly-targeted properties.
+
+Getting this backwards — e.g. trying to add `body-default` to the calendar's styles, or trying to override the color from the datepicker — would silently no-op.
+
+## What the Plan Got Right
+
+- The alignment fix kept the right-side `--ds-size-150` gutter intact; only the errant left indent was removed, so the From/To spacing is preserved.
+- The typography fix mirrored the pattern already used by the label spans (which carry a `body-*` class), keeping the header internally consistent.
+- Both fixes were placed on the *owning* side of the slot boundary (datepicker), so no calendar changes and no `::slotted()` churn were needed.
+
+## What the Plan Missed / Watch-Outs
+
+- **No test asserts header alignment or typography.** These are visual/CSS regressions with no WTR coverage; both could silently regress. If the mobile header is refactored, re-verify against the fullscreen layout in a device viewport, not just desktop.
+- **The label spans and value spans are authored in two different files.** Any future typography change to the mobile header has to be made in both `auro-calendar.js` (labels) and `auro-datepicker.js` (values) to stay consistent — they don't share a single class source.
+- **`--ds-size-200` was load-bearing elsewhere.** The same token is still used as the real gutter in `.headerActions` and `.mobileFooterActions`; the fix only removed it from the one place it caused an indent. Don't globally search-and-replace the token.
+
+## Lessons
+
+1. **On a slotted node, split "who owns typography" from "who owns color."** Typography inherits with the light-DOM/authoring tree (add the class where the node is authored); color and other directly-targeted properties can be reached by the host's `::slotted()` rules. When a slotted element looks wrong, first ask which shadow tree the property resolves in.
+2. **Padding on a flex column is not a free gutter.** Left/right padding shifts the column's *content edge* relative to sibling regions. If a block needs to align to a shared layout edge, keep the aligning side at `0` and use the opposite side (or `gap`) for spacing.
+3. **Class parity is a cheap correctness check.** When two visually-paired spans (label + value) live side by side, they should carry deliberate typography classes. A missing class on one of a pair is a reliable smell — the omission here was exactly that.
+4. **Verify CSS-only fixes in the target viewport.** Both bugs only manifest in the fullscreen/mobile calendar. Desktop rendering never exercised the affected rules, so the regressions were invisible in the default dev view.
+
+## Receipts
+
+- **Commits (most recent first):**
+  - [`cff920df7`](https://github.com/AlaskaAirlines/auro-formkit/commit/cff920df7) `fix: add body-default class to date display spans for improved styling AB#1598648` — `components/datepicker/src/auro-datepicker.js` (2 lines)
+  - [`4340fe7d2`](https://github.com/AlaskaAirlines/auro-formkit/commit/4340fe7d2) `fix: align datepicker mobile header and label AB#1494481` — `components/datepicker/src/styles/style-auro-calendar.scss` (1 line)
+- **Slot authoring site (values):** `components/datepicker/src/auro-datepicker.js:2461-2462` (`bib.fullscreen.fromStr` / `toStr`).
+- **Slot host / label markup:** `components/datepicker/src/auro-calendar.js:1948-1957` (`.mobileHeader` → `.headerDateFrom` / `.headerDateTo`, `.mobileDateLabel body-xs`).
+- **Alignment rule:** `components/datepicker/src/styles/style-auro-calendar.scss:85-93` (`.headerDateFrom, .headerDateTo`).
+- **Typography source:** `body-default` bundled into the datepicker shadow scope via `components/datepicker/src/styles/style.scss` → `@aurodesignsystem/webcorestylesheets` type classes (compiled to `style-css.js`).
+- **Color owner (calendar side):** `components/datepicker/src/styles/color-calendar.scss:52` — `::slotted([slot="bib.fullscreen.fromStr"]), ::slotted([slot="mobileDateToStr"])` → `--ds-auro-datepicker-placeholder-color`.
+- **Test coverage:** none added — both are visual CSS/markup fixes with no WTR assertions.


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adjust datepicker fullscreen mobile layout to improve display of selected and placeholder date strings.

Enhancements:
- Apply body-default typography styling to fullscreen from/to date strings in the datepicker.
- Update fullscreen mobile container padding to align content without left inset on smaller screens.