### PR TITLE
fix(form): use currentTarget for Enter submit handling AB#1499589

### DIFF
--- a/components/form/src/auro-form.js
+++ b/components/form/src/auro-form.js
@@ -731,15 +731,23 @@ export class AuroForm extends LitElement {
    * @private
    */
   handleKeyDown(event) {
-    if (event.key === 'Enter' && this.isFormElement(event.target)) {
+
+    /**
+     * Use `currentTarget` because it is the tracked form element
+     * handling the event, while `target` may be an inner radio,
+     * checkbox, or counter inside that form control.
+     */
+    const formElement = event.currentTarget;
+
+    if (event.key === 'Enter' && this.isFormElement(formElement)) {
       // Disabled controls do not submit a form natively.
-      if (this._isDisabled(event.target)) {
+      if (this._isDisabled(formElement)) {
         return;
       }
 
       // Don't submit if it's a textarea (allow new lines)
-      if (event.target.tagName.toLowerCase() === 'textarea' ||
-          event.target.hasAttribute('textarea')) {
+      if (formElement.tagName.toLowerCase() === 'textarea' ||
+          formElement.hasAttribute('textarea')) {
         return;
       }
 

--- a/components/form/test/auro-form.test.js
+++ b/components/form/test/auro-form.test.js
@@ -24,10 +24,10 @@ async function expectSubmitOnEnter(markup, selector, innerSelector) {
   await elementUpdated(el);
 
   const control = el.querySelector(selector);
-  const dispatchTarget = innerSelector ? control.shadowRoot?.querySelector(innerSelector) : control;
+  const dispatchTarget = innerSelector ? control?.shadowRoot?.querySelector(innerSelector) : control;
 
   if (!dispatchTarget) {
-    throw new Error(`Unable to find Enter dispatch target for ${selector}`);
+    throw new Error(`Unable to find Enter dispatch target for ${selector}${innerSelector ? ' (' + innerSelector + ')' : ''}`);
   }
 
   const submitPromise = new Promise((resolve, reject) => {

--- a/components/form/test/auro-form.test.js
+++ b/components/form/test/auro-form.test.js
@@ -11,6 +11,48 @@ import '../src/registered.js';
 const mobileBreakpointWidth = parseInt(designTokens['ds-grid-breakpoint-sm'], 10) - 1;
 
 /**
+ * Verifies that pressing Enter on a form control submits the form.
+ * When `innerSelector` is provided, dispatches from a shadow child so the
+ * event reaches the form with a different origin node than the listener host.
+ * @param {*} markup - The fixture markup.
+ * @param {string} selector - Selector for the host control.
+ * @param {string} [innerSelector] - Optional selector for the interactive node inside the host's shadow root.
+ * @returns {Promise<void>}
+ */
+async function expectSubmitOnEnter(markup, selector, innerSelector) {
+  const el = await fixture(markup);
+  await elementUpdated(el);
+
+  const control = el.querySelector(selector);
+  const dispatchTarget = innerSelector ? control.shadowRoot?.querySelector(innerSelector) : control;
+
+  if (!dispatchTarget) {
+    throw new Error(`Unable to find Enter dispatch target for ${selector}`);
+  }
+
+  const submitPromise = new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Expected submit event when pressing Enter on ${selector}`));
+    // eslint-disable-next-line no-magic-numbers
+    }, 100);
+
+    el.addEventListener('submit', () => {
+      clearTimeout(timeoutId);
+      resolve(true);
+    }, { once: true });
+  });
+
+  dispatchTarget.dispatchEvent(new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    composed: true
+  }));
+
+  await submitPromise;
+}
+
+/**
  * Runs the full form test suite for a given viewport mode.
  * @param {boolean} mobileView - Whether tests should run in small or large viewport mode.
  * @returns {void}
@@ -478,34 +520,6 @@ function runFullTest(mobileView) {
 
   describe('Keyboard Behavior', () => {
     describe('Enter', () => {
-      // eslint-disable-next-line jsdoc/require-jsdoc
-      async function expectSubmitOnEnter(markup, selector) {
-        const el = await fixture(markup);
-        await elementUpdated(el);
-
-        const control = el.querySelector(selector);
-        const submitPromise = new Promise((resolve, reject) => {
-          const timeoutId = setTimeout(() => {
-            reject(new Error(`Expected submit event when pressing Enter on ${selector}`));
-          // eslint-disable-next-line no-magic-numbers
-          }, 100);
-
-          el.addEventListener('submit', () => {
-            clearTimeout(timeoutId);
-            resolve(true);
-          }, { once: true });
-        });
-
-        control.dispatchEvent(new KeyboardEvent('keydown', {
-          key: 'Enter',
-          bubbles: true,
-          cancelable: true,
-          composed: true
-        }));
-
-        await submitPromise;
-      }
-
       it('should submit the form when Enter is pressed on an input element', async () => {
         const el = await fixture(html`
           <auro-form>
@@ -576,7 +590,7 @@ function runFullTest(mobileView) {
               <auro-checkbox value="value2" checked>Checkbox option</auro-checkbox>
             </auro-checkbox-group>
           </auro-form>
-        `, 'auro-checkbox');
+        `, 'auro-checkbox', 'input');
       });
 
       it('should submit the form when Enter is pressed on an auro-radio inside an auro-radio-group', async () => {
@@ -588,7 +602,7 @@ function runFullTest(mobileView) {
               <auro-radio label="No" name="radioDemo" value="no"></auro-radio>
             </auro-radio-group>
           </auro-form>
-        `, 'auro-radio');
+        `, 'auro-radio', 'input');
       });
 
       it('should submit the form when Enter is pressed on an auro-counter inside an auro-counter-group', async () => {
@@ -600,7 +614,7 @@ function runFullTest(mobileView) {
               </auro-counter>
             </auro-counter-group>
           </auro-form>
-        `, 'auro-counter');
+        `, 'auro-counter', '[part="counterControl"]');
       });
 
       it('does not submit when Enter is pressed on a disabled form element', async () => {

--- a/components/form/test/auro-form.test.js
+++ b/components/form/test/auro-form.test.js
@@ -478,6 +478,34 @@ function runFullTest(mobileView) {
 
   describe('Keyboard Behavior', () => {
     describe('Enter', () => {
+      // eslint-disable-next-line jsdoc/require-jsdoc
+      async function expectSubmitOnEnter(markup, selector) {
+        const el = await fixture(markup);
+        await elementUpdated(el);
+
+        const control = el.querySelector(selector);
+        const submitPromise = new Promise((resolve, reject) => {
+          const timeoutId = setTimeout(() => {
+            reject(new Error(`Expected submit event when pressing Enter on ${selector}`));
+          // eslint-disable-next-line no-magic-numbers
+          }, 100);
+
+          el.addEventListener('submit', () => {
+            clearTimeout(timeoutId);
+            resolve(true);
+          }, { once: true });
+        });
+
+        control.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }));
+
+        await submitPromise;
+      }
+
       it('should submit the form when Enter is pressed on an input element', async () => {
         const el = await fixture(html`
           <auro-form>
@@ -537,6 +565,42 @@ function runFullTest(mobileView) {
 
         await elementUpdated(el);
         await expect(defaultPrevented).to.be.true;
+      });
+
+      it('should submit the form when Enter is pressed on an auro-checkbox inside an auro-checkbox-group', async () => {
+        await expectSubmitOnEnter(html`
+          <auro-form>
+            <auro-checkbox-group name="testGroup">
+              <span slot="legend">Form label goes here</span>
+              <auro-checkbox value="value1">Checkbox option</auro-checkbox>
+              <auro-checkbox value="value2" checked>Checkbox option</auro-checkbox>
+            </auro-checkbox-group>
+          </auro-form>
+        `, 'auro-checkbox');
+      });
+
+      it('should submit the form when Enter is pressed on an auro-radio inside an auro-radio-group', async () => {
+        await expectSubmitOnEnter(html`
+          <auro-form>
+            <auro-radio-group name="testGroup">
+              <span slot="legend">Form label goes here</span>
+              <auro-radio label="Yes" name="radioDemo" value="yes" checked></auro-radio>
+              <auro-radio label="No" name="radioDemo" value="no"></auro-radio>
+            </auro-radio-group>
+          </auro-form>
+        `, 'auro-radio');
+      });
+
+      it('should submit the form when Enter is pressed on an auro-counter inside an auro-counter-group', async () => {
+        await expectSubmitOnEnter(html`
+          <auro-form>
+            <auro-counter-group name="someCounterGroup" isDropdown>
+              <auro-counter name="shortLabel">
+                Short label
+              </auro-counter>
+            </auro-counter-group>
+          </auro-form>
+        `, 'auro-counter');
       });
 
       it('does not submit when Enter is pressed on a disabled form element', async () => {

--- a/components/form/test/auro-form.test.js
+++ b/components/form/test/auro-form.test.js
@@ -31,11 +31,12 @@ async function expectSubmitOnEnter(markup, selector, innerSelector) {
   }
 
   const submitPromise = new Promise((resolve, reject) => {
+    // eslint-disable-next-line no-magic-numbers
+    const submitTimeoutMs = 1000;
+
     const timeoutId = setTimeout(() => {
       reject(new Error(`Expected submit event when pressing Enter on ${selector}`));
-    // eslint-disable-next-line no-magic-numbers
-    }, 100);
-
+    }, submitTimeoutMs);
     el.addEventListener('submit', () => {
       clearTimeout(timeoutId);
       resolve(true);

--- a/docs/post-mortem/1499589.md
+++ b/docs/post-mortem/1499589.md
@@ -1,0 +1,141 @@
+# Post-Mortem: Enter-to-Submit Missed Grouped Controls (AB#1499589)
+
+**Branch:** `rmenner/form/component-submit-logic`
+**Scope:** Restore Enter-to-submit for grouped form controls inside `auro-form`, specifically `auro-radio`, `auro-checkbox`, and `auro-counter` when used through `auro-radio-group`, `auro-checkbox-group`, and `auro-counter-group`.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| Pressing Enter from `auro-input` submits the form, but Enter from `auro-radio`, `auro-checkbox`, or `auro-counter` does nothing | The form listener is firing, but the gate is checking the wrong node. `event.target` points at the inner control; the form needs the tracked listener host via `event.currentTarget`. |
+| Grouped controls work when clicking Submit, but not when using Enter from the control itself | Submission logic is intact. The bug is in Enter-key qualification, not in validation or `submit()` dispatch. |
+| A regression test passes even though it dispatches directly on the custom-element host | That may miss the real shadow-DOM event path. Dispatch from the inner interactive node so `target !== currentTarget` is actually exercised. |
+| Browser verification shows `form.submit()` is called but no `submit` event fires | That usually means the form is still invalid. This fix restores the Enter path into `submit()`; the form still correctly blocks dispatch when validation fails. |
+
+## The Bug
+
+`auro-form` already owned Enter-to-submit behavior in `handleKeyDown()`, but it qualified the event like this:
+
+- the listener was attached to each tracked form element
+- the guard checked `this.isFormElement(event.target)`
+
+That worked for direct controls like `auro-input`, where the event target and the tracked form element are effectively the same component boundary.
+
+It failed for grouped controls:
+
+- `auro-form` tracks `auro-radio-group`, `auro-checkbox-group`, and `auro-counter-group`
+- the actual key event can originate from an inner `auro-radio`, `auro-checkbox`, or the interactive counter control
+- for those cases, `event.target` is the inner control, not the tracked form element
+
+So Enter reached the listener, but the form rejected it before calling `submit()`.
+
+## Root Cause
+
+The implementation mixed up two different DOM event concepts:
+
+- `event.target` is where the event started
+- `event.currentTarget` is the element whose listener is currently running
+
+In this code, the form attaches the keydown listener directly to each tracked form element. That means `currentTarget` is the form element the form intentionally registered and wants to reason about. `target` is only the deepest originating node, which varies across grouped controls and shadow-DOM boundaries.
+
+The result was a host/origin mismatch:
+
+- the listener host was valid for form submission
+- the originating target was sometimes a nested child the form does not track
+
+## The Fix
+
+The Enter gate in `components/form/src/auro-form.js` was changed to resolve the form element from `event.currentTarget` instead of `event.target`.
+
+Concretely:
+
+- `handleKeyDown()` now assigns `const formElement = event.currentTarget`
+- the form-element, disabled, and textarea checks now evaluate `formElement`
+- `submit()` ownership and validation behavior were left unchanged
+
+This keeps the submission contract where it already belonged: the form still owns validation and dispatch, but Enter from grouped controls now reaches that existing path.
+
+## Test Strategy
+
+The original regression tests were strengthened after review so they cover the real bug shape instead of a simplified host-dispatch path.
+
+A shared helper was moved to the top of `components/form/test/auro-form.test.js` and updated to accept an optional `innerSelector`.
+
+For grouped-control cases, the test now dispatches Enter from the inner interactive node:
+
+- `auro-checkbox` → `input`
+- `auro-radio` → `input`
+- `auro-counter` → `[part="counterControl"]`
+
+That ensures the test covers the important condition:
+
+- `event.target !== event.currentTarget`
+
+New regression coverage was added for:
+
+- Enter on `auro-checkbox` inside `auro-checkbox-group`
+- Enter on `auro-radio` inside `auro-radio-group`
+- Enter on `auro-counter` inside `auro-counter-group`
+
+## Browser Verification
+
+The fix was also checked against the local form demo with `playwright-cli` on `http://localhost:8804/customize.html`.
+
+The verification instrumented `#bookingForm` to count:
+
+- calls to `form.submit()`
+- emitted form-level `submit` events
+
+Results:
+
+1. Pressing Enter from a radio control invoked `form.submit()`.
+2. Pressing Enter from a checkbox control invoked `form.submit()`.
+3. Pressing Enter from the counter control invoked `form.submit()`.
+
+In that demo state, the form remained invalid, so no final `submit` event was dispatched. That is expected and confirms the fix restored the Enter path into the form without bypassing validation.
+
+## What Landed
+
+### Source change
+- `components/form/src/auro-form.js`
+  - `handleKeyDown()` now evaluates the tracked form element from `event.currentTarget`
+
+### Test change
+- `components/form/test/auro-form.test.js`
+  - shared `expectSubmitOnEnter()` helper moved near the top of the file
+  - helper strengthened to dispatch from inner interactive nodes when required
+  - grouped-control Enter regression tests added
+
+## Lessons
+
+1. When a listener is attached directly to a tracked host element, `currentTarget` is usually the semantic node you want. `target` is often too low-level once shadow DOM or grouped controls are involved.
+2. Regression tests should model the real event origin. Dispatching on the custom-element host can hide bugs where the production path actually starts inside shadow DOM.
+3. Browser verification for keyboard bugs should distinguish “did Enter reach `submit()`?” from “did the form emit `submit`?” They are not the same when validation is supposed to block dispatch.
+4. Grouped form controls are a recurring abstraction boundary in `auro-form`. Any future keyboard or validation change should test both direct controls and grouped controls explicitly.
+
+## Receipts
+
+**Branch:** `rmenner/form/component-submit-logic`
+
+**Key file anchors:**
+- `components/form/src/auro-form.js:733` — `handleKeyDown(event)`
+- `components/form/src/auro-form.js:740` — `const formElement = event.currentTarget;`
+- `components/form/test/auro-form.test.js:22` — `expectSubmitOnEnter(markup, selector, innerSelector)`
+- `components/form/test/auro-form.test.js:27` — inner dispatch-target resolution
+- `components/form/test/auro-form.test.js:585` — checkbox-group Enter regression
+- `components/form/test/auro-form.test.js:597` — radio-group Enter regression
+- `components/form/test/auro-form.test.js:609` — counter-group Enter regression
+
+**Validation commands run:**
+```bash
+npm test -w components/form -- test/auro-form.test.js
+npm run build
+```
+
+**Browser verification:**
+- `playwright-cli` against `http://localhost:8804/customize.html`
+- instrumented `#bookingForm` to verify Enter from radio, checkbox, and counter reached `form.submit()`
+
+## Outcome
+
+`auro-form` now treats Enter from grouped controls the same way it already treated Enter from direct controls: the key event reaches the form-owned submit path, and the form decides whether to dispatch based on its normal validation rules. Regression coverage now locks both the logic fix and the real shadow-DOM event path.


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request improves the way keyboard events are handled in the `auro-form` component, specifically around submitting forms when pressing Enter on custom form controls. It also adds comprehensive tests to ensure correct behavior for various custom elements such as checkboxes, radios, and counters.

### Keyboard event handling improvements

* Updated the `handleKeyDown` method in `auro-form.js` to use `event.currentTarget` instead of `event.target`. This ensures that the correct form control element is referenced, even when the event originates from an inner element (like a radio, checkbox, or counter inside a group).

### Expanded test coverage

* Added a reusable `expectSubmitOnEnter` helper function in `auro-form.test.js` to streamline testing form submission on Enter key events for different controls.
* Added new tests to verify that pressing Enter on an `auro-checkbox` inside an `auro-checkbox-group`, an `auro-radio` inside an `auro-radio-group`, and an `auro-counter` inside an `auro-counter-group` correctly triggers form submission.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve auro-form Enter key handling to submit forms correctly from grouped custom controls and expand keyboard behavior test coverage.

Bug Fixes:
- Fix Enter key handling to use the form control element as the event source, ensuring correct submit behavior when the event originates from inner elements within custom groups.

Tests:
- Add a reusable helper to assert form submission on Enter key press across controls.
- Add keyboard behavior tests verifying Enter submits the form from checkbox, radio, and counter elements inside their respective groups.