### PR TITLE
RC #1557

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -732,7 +732,6 @@ export class AuroCombobox extends AuroElement {
       // hidden when input.value is set in the same tick as the append.
       if (typeof this.input.checkDisplayValueSlotChange === 'function') {
         this.input.checkDisplayValueSlotChange();
-        this.input.requestUpdate();
       }
     } else if (this.value) {
       // No optionSelected yet (e.g. setMenuValue was called but the menu's

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -739,6 +739,14 @@ export class AuroCombobox extends AuroElement {
       // auroMenu-selectedOption event hasn't fired yet, or we're on remount
       // with no options loaded). Synthesize a displayValue from the value so
       // the overlay isn't blank.
+      //
+      // NOTE: This renders the raw machine value (e.g. "SEA"), not the
+      // human-readable label (e.g. "Seattle, WA"). For consumers where
+      // value ≠ label, this produces a brief flash of the raw value until
+      // the option elements load and updateTriggerTextDisplay re-runs with
+      // the correct label. This is intentionally preferred over a blank
+      // state — the displayValueInTrigger.remove() cleanup above ensures
+      // this placeholder is replaced once the real option is available.
       const syntheticDV = document.createElement('span');
       syntheticDV.setAttribute('slot', 'displayValue');
       syntheticDV.textContent = this.value;
@@ -917,6 +925,10 @@ export class AuroCombobox extends AuroElement {
     // Prevent dropdown from closing on focus loss since menu content is slotted
     // from combobox's light DOM and won't be detected by dropdown's contains() check.
     this.dropdown.noHideOnThisFocusLoss = true;
+
+    // Suppress the dropdown's generic focus restoration on close — the combobox
+    // manages its own focus via setClearBtnFocus / setInputFocus / keyboard strategy.
+    this.dropdown.noFocusRestoreOnClose = true;
 
     // Listen for the ID to be added to the dropdown so we can capture it and use it for accessibility.
     this.dropdown.addEventListener('auroDropdown-idAdded', (event) => {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1276,6 +1276,9 @@ export class AuroCombobox extends AuroElement {
       // only — fresh user selections take the existing hideBib path.
       if (isEcho && this.menu.optionSelected) {
         this._programmaticFilterRefresh = true;
+        this.updateComplete.then(() => {
+          this._programmaticFilterRefresh = false;
+        });
       }
     });
 
@@ -1506,15 +1509,6 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   handleTriggerInputValueChange(event) {
-    // Clear a stale _programmaticFilterRefresh when the user is genuinely
-    // interacting. On mount, updated('value') sets the flag, but the early
-    // return at `this.value === this.input.value` exits before clearing it.
-    // Without this, the first keystroke after mount fails to set _userTyped
-    // and the bib doesn't open.
-    if (this._programmaticFilterRefresh && this.componentHasFocus) {
-      this._programmaticFilterRefresh = false;
-    }
-
     // 'input' fires for every user-initiated value change — typing, paste,
     // IME composition end, dead-key composition, drag-drop. Flip _userTyped
     // here so updated('availableOptions') auto-opens the bib for sources
@@ -1536,10 +1530,6 @@ export class AuroCombobox extends AuroElement {
 
     if (this.dropdown.isBibFullscreen && this.input.value && this.input.value.length > 0 && this.dropdown.isPopoverVisible) {
       this.setInputFocus();
-    }
-
-    if (this._programmaticFilterRefresh) {
-      this._programmaticFilterRefresh = false;
     }
   }
 
@@ -1739,6 +1729,12 @@ export class AuroCombobox extends AuroElement {
       // setting the flag unconditionally here masks the user-typed open path.
       if (!this._userTyped) {
         this._programmaticFilterRefresh = true;
+        // Self-clear after this update cycle completes. This collapses
+        // the previous scattered clear-points into one and prevents the
+        // flag from surviving into the next user interaction.
+        this.updateComplete.then(() => {
+          this._programmaticFilterRefresh = false;
+        });
       }
 
       if (this.input.value !== this.value) {
@@ -1827,10 +1823,6 @@ export class AuroCombobox extends AuroElement {
         }
       } else if (!this.dropdown.isBibFullscreen) {
         this.hideBib();
-      }
-
-      if (this._programmaticFilterRefresh) {
-        this._programmaticFilterRefresh = false;
       }
     }
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -752,7 +752,6 @@ export class AuroCombobox extends AuroElement {
       this.input.appendChild(syntheticDV);
       if (typeof this.input.checkDisplayValueSlotChange === 'function') {
         this.input.checkDisplayValueSlotChange();
-        this.input.requestUpdate();
       }
     }
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1546,7 +1546,7 @@ export class AuroCombobox extends AuroElement {
     this.addEventListener('focusin', (event) => {
       this.touched = true;
 
-      if (event.target === this) {
+      if (event.composedPath()[0] === this) {
         this.focus();
       }
     });

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -724,14 +724,28 @@ export class AuroCombobox extends AuroElement {
       const displayValueEl = this.menu.optionSelected.querySelector("[slot='displayValue']");
       if (displayValueEl) {
         this.input.appendChild(displayValueEl.cloneNode(true));
-        // auro-input's hasDisplayValueContent is non-reactive; nudge it to
-        // re-evaluate the slot and re-render so the displayValue wrapper
-        // gets its hasContent class. Without this, the apple/icon stays
-        // hidden when input.value is set in the same tick as the append.
-        if (typeof this.input.checkDisplayValueSlotChange === 'function') {
-          this.input.checkDisplayValueSlotChange();
-          this.input.requestUpdate();
-        }
+      }
+
+      // auro-input's hasDisplayValueContent is non-reactive; nudge it to
+      // re-evaluate the slot and re-render so the displayValue wrapper
+      // gets its hasContent class. Without this, the apple/icon stays
+      // hidden when input.value is set in the same tick as the append.
+      if (typeof this.input.checkDisplayValueSlotChange === 'function') {
+        this.input.checkDisplayValueSlotChange();
+        this.input.requestUpdate();
+      }
+    } else if (this.value) {
+      // No optionSelected yet (e.g. setMenuValue was called but the menu's
+      // auroMenu-selectedOption event hasn't fired yet, or we're on remount
+      // with no options loaded). Synthesize a displayValue from the value so
+      // the overlay isn't blank.
+      const syntheticDV = document.createElement('span');
+      syntheticDV.setAttribute('slot', 'displayValue');
+      syntheticDV.textContent = this.value;
+      this.input.appendChild(syntheticDV);
+      if (typeof this.input.checkDisplayValueSlotChange === 'function') {
+        this.input.checkDisplayValueSlotChange();
+        this.input.requestUpdate();
       }
     }
 
@@ -1481,6 +1495,15 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   handleTriggerInputValueChange(event) {
+    // Clear a stale _programmaticFilterRefresh when the user is genuinely
+    // interacting. On mount, updated('value') sets the flag, but the early
+    // return at `this.value === this.input.value` exits before clearing it.
+    // Without this, the first keystroke after mount fails to set _userTyped
+    // and the bib doesn't open.
+    if (this._programmaticFilterRefresh && this.componentHasFocus) {
+      this._programmaticFilterRefresh = false;
+    }
+
     // 'input' fires for every user-initiated value change — typing, paste,
     // IME composition end, dead-key composition, drag-drop. Flip _userTyped
     // here so updated('availableOptions') auto-opens the bib for sources
@@ -1520,10 +1543,12 @@ export class AuroCombobox extends AuroElement {
       inputResolver: (comp, ctx) => (ctx.isModal && comp.inputInBib ? comp.inputInBib : comp.input),
     });
 
-    this.addEventListener('focusin', () => {
+    this.addEventListener('focusin', (event) => {
       this.touched = true;
 
-      this.focus();
+      if (event.target === this) {
+        this.focus();
+      }
     });
 
     this.addEventListener('auroFormElement-validated', (evt) => {

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -991,7 +991,11 @@ export class AuroCombobox extends AuroElement {
         // after the dropdown layout settles.
 
         doubleRaf(() => {
-          this.setInputFocus();
+          // Guard: skip if the dropdown closed before this rAF fired
+          // (e.g. user selected an option immediately after the bib opened).
+          if (this.dropdownOpen) {
+            this.setInputFocus();
+          }
           if (this._inFullscreenTransition) {
             this._inFullscreenTransition = false;
           }
@@ -1038,7 +1042,9 @@ export class AuroCombobox extends AuroElement {
       }
 
       this._scheduleTimer(() => {
-        this.setInputFocus();
+        if (this.dropdown.isPopoverVisible) {
+          this.setInputFocus();
+        }
       }, 0);
     });
   }
@@ -1047,14 +1053,19 @@ export class AuroCombobox extends AuroElement {
    * @private
    */
   setClearBtnFocus() {
-    const clearBtn = this.input.shadowRoot.querySelector('.clearBtn');
-    if (clearBtn) {
-      // Wait for the element to fully render across
-      // multiple Lit update cycles before moving focus
-      doubleRaf(() => {
+    doubleRaf(() => {
+      // First establish focus inside the input's shadow root.
+      // Without this, clearBtn.focus() silently fails when focus is on
+      // document.body (e.g. after a click selection closes the bib dialog).
+      // delegatesFocus on BaseInput routes this to the native <input>.
+      this.input.focus();
+
+      // Now move focus to the clear button within the same shadow root.
+      const clearBtn = this.input.shadowRoot.querySelector('.clearBtn');
+      if (clearBtn) {
         clearBtn.focus();
-      });
-    }
+      }
+    });
   }
 
   /**
@@ -2003,7 +2014,7 @@ export class AuroCombobox extends AuroElement {
             <slot @slotchange="${this.handleSlotChange}"></slot>
             <${this.inputTag}
               id="inputInBib"
-              autofocus
+              ?autofocus="${this.dropdownOpen && this.dropdown?.isBibFullscreen}"
               @input="${this.handleInputValueChange}"
               .a11yActivedescendant="${this.dropdownOpen && this.optionActive ? this.optionActive.id : undefined}"
               .a11yControls=${`${this.dropdownId}-floater-bib`}

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -3270,6 +3270,65 @@ function runFullTest(mobileView) {
       // Cleanup
       el.focus = origFocus;
     });
+
+    // ─── Bug #1: synthetic displayValue when optionSelected is null ──
+    it('synthesizes a displayValue placeholder when value is set but optionSelected is null', async () => {
+      // Mount with a preset value and matching options present synchronously.
+      // The fixture resolves optionSelected, so we clear it to simulate the
+      // "options haven't loaded yet" state that triggers the synthetic branch.
+      const el = await presetValueFixture(mobileView);
+      await elementUpdated(el);
+
+      // Force the synthetic path: clear optionSelected so the
+      // `else if (this.value)` branch runs on the next updateTriggerTextDisplay call.
+      el.optionSelected = undefined;
+      el.menu.optionSelected = undefined;
+
+      // Remove any existing displayValue clone from the prior match
+      const existing = el.input.querySelector('[slot="displayValue"]:not(slot)');
+      if (existing) {
+        existing.remove();
+      }
+
+      // Trigger updateTriggerTextDisplay — with optionSelected null and
+      // this.value = 'Apples', the synthetic branch should create a
+      // <span slot="displayValue"> with the raw value.
+      el.updateTriggerTextDisplay('');
+      await elementUpdated(el);
+
+      const syntheticDV = el.input.querySelector('[slot="displayValue"]:not(slot)');
+      expect(syntheticDV).to.exist;
+      expect(syntheticDV.textContent).to.equal('Apples');
+    });
+
+    // ─── Bug #4: first keystroke after preset-value mount opens the bib ──
+    it('opens the bib on the first keystroke after mounting with a preset value', async () => {
+      // Mount with a preset value — updated('value') sets
+      // _programmaticFilterRefresh = true, which previously suppressed
+      // _userTyped on the first keystroke. The self-clearing flag fix
+      // ensures it's cleared by the time the user types.
+      const el = await presetValueFixture(mobileView);
+      await elementUpdated(el);
+      await el.updateComplete;
+
+      // Wait for the self-clearing updateComplete.then() to fire
+      await el.updateComplete;
+
+      // Verify precondition: value is set, bib is closed
+      expect(el.value).to.equal('Apples');
+      expect(el.dropdown.isPopoverVisible).to.be.false;
+
+      // Simulate user interaction: focus and delete a character.
+      // Backspace changes "Apples" → "Apple" which still matches,
+      // so the bib should open.
+      el.focus();
+      await elementUpdated(el);
+      await sendKeys({ press: 'Backspace' });
+      await elementUpdated(el);
+
+      // The bib should open on the first keystroke
+      expect(el.dropdown.isPopoverVisible).to.be.true;
+    });
   });
 
   describe('A11Y', () => {

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -3185,6 +3185,93 @@ function runFullTest(mobileView) {
 
       await expect(dropdown.dropdownWidth).to.equal('400px');
     });
+
+    // ─── programmatic value sync does not set _userTyped ──
+    it('programmatic value sync via syncInputValuesAcrossTriggerAndBib does not set _userTyped', async () => {
+      if (mobileView) {
+        await setViewport({ width: 500, height: 800 });
+      } else {
+        await setViewport({ width: 800, height: 800 });
+      }
+
+      const el = await defaultFixture(mobileView);
+      await elementUpdated(el);
+
+      expect(el._userTyped).to.be.false;
+
+      // Programmatic value set goes through syncInputValuesAcrossTriggerAndBib
+      // which guards with _syncingDisplayValue, preventing _userTyped from
+      // being set. This simulates what happens when a framework binding
+      // pushes a new value into the combobox.
+      el.value = 'Apples';
+      await elementUpdated(el);
+      await el.menu.updateComplete;
+
+      // _userTyped must remain false because the sync was programmatic
+      // (guarded by _syncingDisplayValue / _programmaticFilterRefresh)
+      expect(el._userTyped).to.be.false;
+    });
+
+    // ─── setClearBtnFocus is skipped when combobox does not have focus ──
+    it('does not move focus to clear button on selection when combobox lacks focus', async () => {
+      if (mobileView) {
+        await setViewport({ width: 500, height: 800 });
+      } else {
+        await setViewport({ width: 800, height: 800 });
+      }
+
+      const el = await defaultFixture(mobileView);
+      await elementUpdated(el);
+
+      // Spy on the clear button's focus()
+      const clearBtn = el.input.shadowRoot.querySelector('.clearBtn');
+      expect(clearBtn).to.exist;
+      let focusCalled = false;
+      const origFocus = clearBtn.focus.bind(clearBtn);
+      clearBtn.focus = () => { focusCalled = true; origFocus(); };
+
+      // Programmatically select a value WITHOUT giving the combobox focus.
+      // This simulates a framework-driven value sync where the user is
+      // interacting with a different field.
+      el.value = 'Apples';
+      await elementUpdated(el);
+      await el.menu.updateComplete;
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // setClearBtnFocus must NOT have been called because the selection
+      // was an echo of setMenuValue (isEcho guard) — only fresh user-initiated
+      // selections should move focus.
+      expect(focusCalled).to.be.false;
+
+      // Cleanup
+      clearBtn.focus = origFocus;
+    });
+
+    // ─── focusin handler only calls this.focus() when target is the host ──
+    it('focusin from a child element does not call this.focus()', async () => {
+      const el = await defaultFixture(mobileView);
+      await elementUpdated(el);
+
+      let hostFocusCalled = false;
+      const origFocus = el.focus.bind(el);
+      el.focus = () => { hostFocusCalled = true; origFocus(); };
+
+      // Dispatch a focusin event that originates from a child element
+      // (simulating e.g. the internal input receiving focus). The handler
+      // should NOT call this.focus() because event.target !== this.
+      const childFocusIn = new FocusEvent('focusin', {
+        bubbles: true,
+        composed: true,
+      });
+      Object.defineProperty(childFocusIn, 'target', { value: el.input });
+      el.dispatchEvent(childFocusIn);
+
+      expect(hostFocusCalled).to.be.false;
+
+      // Cleanup
+      el.focus = origFocus;
+    });
   });
 
   describe('A11Y', () => {

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -3248,8 +3248,8 @@ function runFullTest(mobileView) {
       clearBtn.focus = origFocus;
     });
 
-    // ─── focusin handler only calls this.focus() when target is the host ──
-    it('focusin from a child element does not call this.focus()', async () => {
+    // ─── focusin handler only calls this.focus() when composedPath origin is the host ──
+    it('focusin from a shadow-DOM child does not call this.focus()', async () => {
       const el = await defaultFixture(mobileView);
       await elementUpdated(el);
 
@@ -3257,15 +3257,13 @@ function runFullTest(mobileView) {
       const origFocus = el.focus.bind(el);
       el.focus = () => { hostFocusCalled = true; origFocus(); };
 
-      // Dispatch a focusin event that originates from a child element
-      // (simulating e.g. the internal input receiving focus). The handler
-      // should NOT call this.focus() because event.target !== this.
-      const childFocusIn = new FocusEvent('focusin', {
-        bubbles: true,
-        composed: true,
-      });
-      Object.defineProperty(childFocusIn, 'target', { value: el.input });
-      el.dispatchEvent(childFocusIn);
+      // Focus the internal input directly — the composed focusin event
+      // bubbles to the host with composedPath()[0] pointing at the native
+      // input inside auro-input's shadow DOM, not the combobox host.
+      // The handler should NOT call this.focus() in this case.
+      const nativeInput = el.input.shadowRoot.querySelector('input');
+      nativeInput.focus();
+      await elementUpdated(el);
 
       expect(hostFocusCalled).to.be.false;
 

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -264,8 +264,10 @@ export class AuroDropdown extends AuroElement {
             descendants[0].focus();
             return;
           }
-          el.focus();
-          return;
+el.focus();
+if (document.activeElement === el) {
+  return;
+}
         }
       }
       // Fallback: try DOM children (non-slotted content)

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -264,10 +264,10 @@ export class AuroDropdown extends AuroElement {
             descendants[0].focus();
             return;
           }
-el.focus();
-if (document.activeElement === el) {
-  return;
-}
+          el.focus();
+          if (document.activeElement === el) {
+            return;
+          }
         }
       }
       // Fallback: try DOM children (non-slotted content)

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -57,7 +57,6 @@ export class AuroDropdown extends AuroElement {
   static get shadowRootOptions() {
     return {
       ...AuroElement.shadowRootOptions,
-      delegatesFocus: true,
     };
   }
 
@@ -224,7 +223,36 @@ export class AuroDropdown extends AuroElement {
         focusables[0].focus();
       }
     } else {
+      this.focusTrigger();
+    }
+  }
+
+  /**
+   * Focus the trigger content. When the trigger wrapper itself is focusable
+   * (has tabindex), focus it directly. Otherwise, focus the first focusable
+   * element slotted into the trigger slot (e.g. the auro-input).
+   * @private
+   */
+  focusTrigger() {
+    if (this.trigger.hasAttribute('tabindex')) {
       this.trigger.focus();
+    } else {
+      // Slotted content isn't a DOM child of the trigger div, so
+      // getFocusableElements can't find it. Query assigned nodes directly.
+      const slot = this.trigger.querySelector('slot[name="trigger"]');
+      if (slot) {
+        const assigned = slot.assignedElements();
+        const focusable = assigned.find((el) => !el.hasAttribute('disabled'));
+        if (focusable) {
+          focusable.focus();
+          return;
+        }
+      }
+      // Fallback: try DOM children (non-slotted content)
+      const focusables = getFocusableElements(this.trigger);
+      if (focusables.length > 0) {
+        focusables[0].focus();
+      }
     }
   }
 
@@ -678,14 +706,16 @@ export class AuroDropdown extends AuroElement {
 
     const eventType = event.detail.eventType || "unknown";
     if (!this.isPopoverVisible && this.hasFocus && eventType === "keydown") {
-      this.trigger.focus();
+      this.focusTrigger();
     }
 
 
     // On Tab-driven close (eventType "focusloss"), let focus advance naturally
     // — restoring to the trigger would trap the user on this dropdown, forcing
     // an extra Tab to move on. Escape and outside-click still restore.
-    if (!this.isPopoverVisible && eventType !== "focusloss") {
+    // When noHideOnThisFocusLoss is true, the consumer (e.g. combobox) manages
+    // its own focus restoration — skip the generic trigger focus to avoid races.
+    if (!this.isPopoverVisible && eventType !== "focusloss" && !this.noHideOnThisFocusLoss) {
       // wait til the bib gets fully closed and rendered
       setTimeout(() => {
         // Skip if the bib re-opened, or if focus moved intentionally outside the dropdown (not to body).
@@ -697,7 +727,7 @@ export class AuroDropdown extends AuroElement {
           return;
         }
         // Restore focus to the trigger.
-        this.trigger.focus();
+        this.focusTrigger();
       });
     }
   }

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -73,7 +73,7 @@ export class AuroDropdown extends AuroElement {
      * Set by consumers (e.g. combobox) that manage their own focus routing
      * via setClearBtnFocus / setInputFocus / keyboard strategy.
      * Separate from noHideOnThisFocusLoss (which controls auto-close behavior).
-     * @private
+     * @public
      */
     this.noFocusRestoreOnClose = false;
 

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -68,6 +68,15 @@ export class AuroDropdown extends AuroElement {
     this.matchWidth = false;
     this.noHideOnThisFocusLoss = false;
 
+    /**
+     * When true, the dropdown skips its generic focus restoration on close.
+     * Set by consumers (e.g. combobox) that manage their own focus routing
+     * via setClearBtnFocus / setInputFocus / keyboard strategy.
+     * Separate from noHideOnThisFocusLoss (which controls auto-close behavior).
+     * @private
+     */
+    this.noFocusRestoreOnClose = false;
+
     this.errorMessage = undefined; // TODO - check with Doug if there is still more to do here
 
     // Layout Config
@@ -242,9 +251,20 @@ export class AuroDropdown extends AuroElement {
       const slot = this.trigger.querySelector('slot[name="trigger"]');
       if (slot) {
         const assigned = slot.assignedElements();
-        const focusable = assigned.find((el) => !el.hasAttribute('disabled'));
-        if (focusable) {
-          focusable.focus();
+        for (const el of assigned) {
+          if (el.hasAttribute('disabled')) {
+            continue;
+          }
+          // Try finding a focusable descendant first (handles non-focusable
+          // wrappers like <div> containing a <button>). If none found, try
+          // focusing the element directly (works for custom elements like
+          // auro-input that have delegatesFocus or a custom focus() method).
+          const descendants = getFocusableElements(el);
+          if (descendants.length > 0) {
+            descendants[0].focus();
+            return;
+          }
+          el.focus();
           return;
         }
       }
@@ -705,7 +725,7 @@ export class AuroDropdown extends AuroElement {
     }
 
     const eventType = event.detail.eventType || "unknown";
-    if (!this.isPopoverVisible && this.hasFocus && eventType === "keydown") {
+    if (!this.isPopoverVisible && this.hasFocus && eventType === "keydown" && !this.noFocusRestoreOnClose) {
       this.focusTrigger();
     }
 
@@ -713,9 +733,9 @@ export class AuroDropdown extends AuroElement {
     // On Tab-driven close (eventType "focusloss"), let focus advance naturally
     // — restoring to the trigger would trap the user on this dropdown, forcing
     // an extra Tab to move on. Escape and outside-click still restore.
-    // When noHideOnThisFocusLoss is true, the consumer (e.g. combobox) manages
+    // When noFocusRestoreOnClose is true, the consumer (e.g. combobox) manages
     // its own focus restoration — skip the generic trigger focus to avoid races.
-    if (!this.isPopoverVisible && eventType !== "focusloss" && !this.noHideOnThisFocusLoss) {
+    if (!this.isPopoverVisible && eventType !== "focusloss" && !this.noFocusRestoreOnClose) {
       // wait til the bib gets fully closed and rendered
       setTimeout(() => {
         // Skip if the bib re-opened, or if focus moved intentionally outside the dropdown (not to body).

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -73,7 +73,7 @@ export class AuroDropdown extends AuroElement {
      * Set by consumers (e.g. combobox) that manage their own focus routing
      * via setClearBtnFocus / setInputFocus / keyboard strategy.
      * Separate from noHideOnThisFocusLoss (which controls auto-close behavior).
-     * @public
+     * @private
      */
     this.noFocusRestoreOnClose = false;
 

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -3195,6 +3195,62 @@ function runFullTest(mobileView) {
       expectPopoverHidden(el);
     });
   });
+
+  describe('Focus Restoration', () => {
+    it('should focus slotted trigger content when trigger wrapper has no tabindex', async () => {
+      const el = await fixture(html`
+        <auro-dropdown>
+          <input slot="trigger" type="text" aria-label="test input" />
+          <div>Bib content</div>
+        </auro-dropdown>
+      `);
+      await elementUpdated(el);
+
+      const trigger = el.shadowRoot.querySelector('#trigger');
+      const slottedInput = el.querySelector('input[slot="trigger"]');
+
+      // Verify trigger has no tabindex (focusable content detected)
+      expect(trigger.hasAttribute('tabindex')).to.be.false;
+
+      // focusTrigger should route focus to the slotted input
+      el.focusTrigger();
+
+      expect(slottedInput).to.equal(document.activeElement);
+    });
+
+    it('should suppress focus restoration when noFocusRestoreOnClose is true', async () => {
+      const el = await fixture(html`
+        <auro-dropdown>
+          <div slot="trigger" tabindex="0">Trigger</div>
+          <div>Bib content</div>
+        </auro-dropdown>
+      `);
+      await elementUpdated(el);
+
+      // Set the flag (as the combobox does)
+      el.noFocusRestoreOnClose = true;
+      el.hasFocus = true;
+
+      // Spy on focusTrigger
+      let focusTriggerCalled = false;
+      const origFocusTrigger = el.focusTrigger.bind(el);
+      el.focusTrigger = () => { focusTriggerCalled = true; origFocusTrigger(); };
+
+      // Simulate keydown-driven close
+      el.dispatchEvent(new CustomEvent('auroDropdown-toggled', {
+        detail: { expanded: false, eventType: 'keydown' }
+      }));
+
+      // Also wait for the setTimeout path
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(focusTriggerCalled).to.be.false;
+
+      // Cleanup
+      el.focusTrigger = origFocusTrigger;
+      el.noFocusRestoreOnClose = false;
+    });
+  });
 }
 
 // Desktop Test Suite

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -330,12 +330,12 @@ export class AuroInput extends BaseInput {
       // before firstUpdated (e.g. from auro-combobox during mount).
       // Check for any element (including custom elements like <auro-icon>
       // that render via shadow DOM with no text content).
-      const lightDomContent = this.querySelector('[slot="displayValue"]:not(slot)');
-      this.hasDisplayValueContent = Boolean(lightDomContent && (
-        lightDomContent.textContent.trim().length > 0 ||
-        lightDomContent.children.length > 0 ||
-        lightDomContent.shadowRoot !== null
-      ));
+const lightDomNodes = Array.from(this.querySelectorAll('[slot="displayValue"]:not(slot)'));
+this.hasDisplayValueContent = lightDomNodes.some((node) => (
+  node.textContent.trim().length > 0 ||
+  node.children.length > 0 ||
+  node.shadowRoot !== null
+));
       this.requestUpdate();
       return;
     }

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -330,6 +330,12 @@ export class AuroInput extends BaseInput {
     // discarded any siblings past the forwarder.
     const slot = this.shadowRoot?.querySelector('slot[name="displayValue"]');
     if (!slot) {
+      // Shadow root not yet rendered — fall back to checking light-DOM
+      // children so hasDisplayValueContent isn't stuck false after an
+      // early call from auro-combobox during mount.
+      this.hasDisplayValueContent = Boolean(
+        this.querySelector('[slot="displayValue"]:not(slot)')
+      );
       return;
     }
     const nodes = slot.assignedNodes({ flatten: true });

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -323,24 +323,27 @@ export class AuroInput extends BaseInput {
    * @returns {void}
    */
   checkDisplayValueSlotChange() {
-    // flatten:true resolves through auro-combobox's forwarding slot
-    // (<slot name="displayValue" slot="displayValue">) so a clone appended
-    // directly to auro-input's light DOM alongside the forwarder still
-    // counts as content. The prior nodes[0].tagName === 'SLOT' recursion
-    // discarded any siblings past the forwarder.
     const slot = this.shadowRoot?.querySelector('slot[name="displayValue"]');
     if (!slot) {
-      // Shadow root not yet rendered — fall back to checking light-DOM
-      // children so hasDisplayValueContent isn't stuck false after an
-      // early call from auro-combobox during mount.
-      this.hasDisplayValueContent = Boolean(
-        this.querySelector('[slot="displayValue"]:not(slot)')
-      );
       return;
     }
     const nodes = slot.assignedNodes({ flatten: true });
 
-    this.hasDisplayValueContent = nodes.length > 0;
+    // Check for actual visible content, not just node existence.
+    // An empty <span slot="displayValue"></span> forwarded from the
+    // consumer should not be treated as "has content" — it causes the
+    // displayValue wrapper to render (with hasContent class) but show
+    // nothing, blocking the combobox's synthetic displayValue from
+    // being visible on preset/deeplink load.
+    this.hasDisplayValueContent = nodes.some((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        return node.textContent.trim().length > 0;
+      }
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        return node.textContent.trim().length > 0 || node.children.length > 0;
+      }
+      return false;
+    });
   }
 
   firstUpdated() {

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -330,12 +330,12 @@ export class AuroInput extends BaseInput {
       // before firstUpdated (e.g. from auro-combobox during mount).
       // Check for any element (including custom elements like <auro-icon>
       // that render via shadow DOM with no text content).
-const lightDomNodes = Array.from(this.querySelectorAll('[slot="displayValue"]:not(slot)'));
-this.hasDisplayValueContent = lightDomNodes.some((node) => (
-  node.textContent.trim().length > 0 ||
-  node.children.length > 0 ||
-  node.shadowRoot !== null
-));
+      const lightDomNodes = Array.from(this.querySelectorAll('[slot="displayValue"]:not(slot)'));
+      this.hasDisplayValueContent = lightDomNodes.some((node) => (
+        node.textContent.trim().length > 0 ||
+        node.children.length > 0 ||
+        node.shadowRoot !== null
+      ));
       this.requestUpdate();
       return;
     }

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -336,6 +336,7 @@ export class AuroInput extends BaseInput {
         lightDomContent.children.length > 0 ||
         lightDomContent.shadowRoot !== null
       ));
+      this.requestUpdate();
       return;
     }
     const nodes = slot.assignedNodes({ flatten: true });

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -328,7 +328,10 @@ export class AuroInput extends BaseInput {
     // directly to auro-input's light DOM alongside the forwarder still
     // counts as content. The prior nodes[0].tagName === 'SLOT' recursion
     // discarded any siblings past the forwarder.
-    const slot = this.shadowRoot.querySelector('slot[name="displayValue"]');
+    const slot = this.shadowRoot?.querySelector('slot[name="displayValue"]');
+    if (!slot) {
+      return;
+    }
     const nodes = slot.assignedNodes({ flatten: true });
 
     this.hasDisplayValueContent = nodes.length > 0;

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -360,6 +360,7 @@ export class AuroInput extends BaseInput {
       }
       return false;
     });
+    this.requestUpdate();
   }
 
   firstUpdated() {

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -331,12 +331,15 @@ export class AuroInput extends BaseInput {
       // Check for any element (including custom elements like <auro-icon>
       // that render via shadow DOM with no text content).
       const lightDomNodes = Array.from(this.querySelectorAll('[slot="displayValue"]:not(slot)'));
-      this.hasDisplayValueContent = lightDomNodes.some((node) => (
+      const hasContent = lightDomNodes.some((node) => (
         node.textContent.trim().length > 0 ||
         node.children.length > 0 ||
         node.shadowRoot !== null
       ));
-      this.requestUpdate();
+      if (this.hasDisplayValueContent !== hasContent) {
+        this.hasDisplayValueContent = hasContent;
+        this.requestUpdate();
+      }
       return;
     }
     const nodes = slot.assignedNodes({ flatten: true });
@@ -349,7 +352,7 @@ export class AuroInput extends BaseInput {
     // being visible on preset/deeplink load.
     // Custom elements (e.g. <auro-icon>) that render via shadow DOM are
     // treated as content even when they have no text or light-DOM children.
-    this.hasDisplayValueContent = nodes.some((node) => {
+    const hasContent = nodes.some((node) => {
       if (node.nodeType === Node.TEXT_NODE) {
         return node.textContent.trim().length > 0;
       }
@@ -360,7 +363,10 @@ export class AuroInput extends BaseInput {
       }
       return false;
     });
-    this.requestUpdate();
+    if (this.hasDisplayValueContent !== hasContent) {
+      this.hasDisplayValueContent = hasContent;
+      this.requestUpdate();
+    }
   }
 
   firstUpdated() {

--- a/components/input/src/auro-input.js
+++ b/components/input/src/auro-input.js
@@ -325,6 +325,17 @@ export class AuroInput extends BaseInput {
   checkDisplayValueSlotChange() {
     const slot = this.shadowRoot?.querySelector('slot[name="displayValue"]');
     if (!slot) {
+      // Shadow slot not yet rendered — fall back to checking light-DOM
+      // children so hasDisplayValueContent isn't stuck false when called
+      // before firstUpdated (e.g. from auro-combobox during mount).
+      // Check for any element (including custom elements like <auro-icon>
+      // that render via shadow DOM with no text content).
+      const lightDomContent = this.querySelector('[slot="displayValue"]:not(slot)');
+      this.hasDisplayValueContent = Boolean(lightDomContent && (
+        lightDomContent.textContent.trim().length > 0 ||
+        lightDomContent.children.length > 0 ||
+        lightDomContent.shadowRoot !== null
+      ));
       return;
     }
     const nodes = slot.assignedNodes({ flatten: true });
@@ -335,12 +346,16 @@ export class AuroInput extends BaseInput {
     // displayValue wrapper to render (with hasContent class) but show
     // nothing, blocking the combobox's synthetic displayValue from
     // being visible on preset/deeplink load.
+    // Custom elements (e.g. <auro-icon>) that render via shadow DOM are
+    // treated as content even when they have no text or light-DOM children.
     this.hasDisplayValueContent = nodes.some((node) => {
       if (node.nodeType === Node.TEXT_NODE) {
         return node.textContent.trim().length > 0;
       }
       if (node.nodeType === Node.ELEMENT_NODE) {
-        return node.textContent.trim().length > 0 || node.children.length > 0;
+        return node.textContent.trim().length > 0 ||
+          node.children.length > 0 ||
+          node.shadowRoot !== null;
       }
       return false;
     });

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -23,9 +23,10 @@ import { dateFormatter } from "@aurodesignsystem/auro-library/scripts/runtime/da
 export default class BaseInput extends AuroElement {
 
   // Delegate focus to the native <input> inside the shadow root so that
-  // showModal()'s dialog focusing steps reach the input element.
-  // This keeps the mobile virtual keyboard open when the fullscreen dialog
-  // opens, because the browser sees an input-to-input focus transfer.
+  // clicking anywhere on the input wrapper focuses the native input, and
+  // programmatic .focus() calls on elements in the shadow DOM work correctly.
+  // The initial-load focus theft was caused by the static `autofocus`
+  // attribute on the bib input (now conditional), not by delegatesFocus.
   static get shadowRootOptions() {
     return {
       ...AuroElement.shadowRootOptions,

--- a/components/input/test/auro-input.test.js
+++ b/components/input/test/auro-input.test.js
@@ -2148,16 +2148,23 @@ function runFullTest(mobileView) {
 
         const displayValueSlot = el.shadowRoot.querySelector('slot[name="displayValue"]');
 
-        // Mock assignedNodes to return a <slot> element that itself returns assigned nodes
+        // Mock assignedNodes to verify flatten:true is passed and return
+        // the resolved inner content (matching browser behavior where
+        // flatten resolves through nested slots).
         const innerContent = document.createTextNode('nested content');
-        const innerSlot = document.createElement('slot');
+        let flattenRequested = false;
 
         const originalAssignedNodes = displayValueSlot.assignedNodes.bind(displayValueSlot);
-        displayValueSlot.assignedNodes = () => [innerSlot];
-        innerSlot.assignedNodes = () => [innerContent];
+        displayValueSlot.assignedNodes = (options) => {
+          if (options && options.flatten) {
+            flattenRequested = true;
+          }
+          return [innerContent];
+        };
 
         el.checkDisplayValueSlotChange();
 
+        expect(flattenRequested).to.be.true;
         expect(el.hasDisplayValueContent).to.be.true;
 
         // Restore

--- a/docs/post-mortem/1598671.md
+++ b/docs/post-mortem/1598671.md
@@ -1,0 +1,143 @@
+# Post-Mortem: Flight-Search DisplayValue & Focus Regressions
+
+**Branch:** `jbaker/comboboxDisplayValueFixForFlightSearch` → `dev`
+**Scope:** Four behavioral fixes in auro-combobox and one defensive guard in auro-input, all surfaced by the flight-search planbook integration.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| Combobox's displayValue overlay is blank after a programmatic `value` set when options haven't loaded yet | `updateTriggerTextDisplay` only cloned from `optionSelected`; if `optionSelected` is null (e.g. on remount before slot population) no visual was rendered. The new `else if (this.value)` branch synthesizes a temporary `<span slot="displayValue">` from the raw value. |
+| `focusin` handler on the combobox was calling `this.focus()` on every child-element focus, causing focus-redirect loops in certain frameworks | The old unconditional `this.focus()` call in the `focusin` listener conflicted with framework focus management. Now only fires when `event.target === this` (the host itself receives focus, not a shadow DOM child). |
+| `checkDisplayValueSlotChange` throws in auro-input during early lifecycle (before shadow root renders) | `this.shadowRoot.querySelector(...)` can fail if called before `firstUpdated`. Added optional chaining (`?.`) and early return. |
+| `setClearBtnFocus` stealing focus during programmatic value syncs | The `isEcho` guard (from `_pendingMenuValueSync`) already prevented this for setMenuValue-driven selections — no additional `componentHasFocus` gate was needed. |
+| Bib doesn't open on the first character typed after page load (but opens on the second) | Stale `_programmaticFilterRefresh` flag from mount-time `updated('value')` suppresses `_userTyped` on the first keystroke. Clear the flag at the top of `handleTriggerInputValueChange` when `componentHasFocus` is true. |
+
+## The Bugs
+
+### 1. Blank displayValue on pre-selected combobox (flight-search remount)
+
+When the flight-search planbook mounts a combobox with a pre-set `value` attribute, the option elements may not yet be slotted into the menu. `updateTriggerTextDisplay` checked `this.menu.optionSelected` — which was null — and did nothing. The input's displayValue slot remained empty, showing no visual feedback for the pre-selected airport code.
+
+### 2. Unconditional `this.focus()` in focusin handler
+
+The combobox's `configureCombobox()` registered:
+
+```js
+this.addEventListener('focusin', () => {
+  this.touched = true;
+  this.focus();
+});
+```
+
+Every `focusin` bubble from shadow DOM children called `this.focus()`. Because `focus()` guards with `!this.componentHasFocus`, this was usually a no-op — but in framework integration scenarios where focus management is controlled externally, the unconditional call created redirect loops.
+
+### 3. Null-safety in `checkDisplayValueSlotChange`
+
+When the synthetic displayValue span was appended and `checkDisplayValueSlotChange()` was called, the auro-input's shadow root might not yet have rendered the `<slot name="displayValue">` element. The querySelector call threw on null `shadowRoot`.
+
+### 4. Bib doesn't open on first keystroke after mount
+
+When the flight-search planbook first loads, typing a character into the combobox does nothing — the bib doesn't open. On the second character, it opens normally. The sequence:
+
+1. On mount, setting `value` triggers `updated()` which sets `_programmaticFilterRefresh = true`
+2. The flag is only cleared at the END of `handleTriggerInputValueChange` — but the early return at `if (this.value === this.input.value) return` exits before reaching it
+3. On first keystroke, `_programmaticFilterRefresh` is still `true` → `_userTyped` is NOT set → bib doesn't open
+4. The flag IS cleared at the end of that first keystroke's full path
+5. On second keystroke, flag is cleared → `_userTyped = true` → bib opens
+
+## Root Causes
+
+1. **displayValue synthesis:** `updateTriggerTextDisplay` only had a path for `this.menu.optionSelected` being truthy. No fallback path existed for pre-selected values before option elements load.
+
+2. **focusin over-delegation:** The original handler pre-dated the keyboard strategy refactor. Its purpose was to ensure `this.touched = true` and delegate focus to the input — but `delegatesFocus` is not set on the combobox, and `focus()` already short-circuits when `componentHasFocus` is true. The unconditional call was vestigial.
+
+3. **Null slot reference:** `checkDisplayValueSlotChange` assumed the shadow root's displayValue slot always existed. The method was originally only called from slotchange callbacks (guaranteed to fire after render), but moving it to be called from `updateTriggerTextDisplay` exposed it to earlier lifecycle timing.
+
+4. **Stale `_programmaticFilterRefresh` flag:** `updated('value')` sets the flag unconditionally (when `!_userTyped`), but the clear-point at the end of `handleTriggerInputValueChange` is unreachable when the early return `if (this.value === this.input.value) return` fires. The flag survives into the next user interaction, suppressing `_userTyped` on the first keystroke.
+
+## The Fixes
+
+### `components/combobox/src/auro-combobox.js`
+
+**displayValue synthesis** — moved `checkDisplayValueSlotChange()` outside the `if (displayValueEl)` block (so it always evaluates the slot state), and added a fallback branch:
+
+```js
+} else if (this.value) {
+  const syntheticDV = document.createElement('span');
+  syntheticDV.setAttribute('slot', 'displayValue');
+  syntheticDV.textContent = this.value;
+  this.input.appendChild(syntheticDV);
+  if (typeof this.input.checkDisplayValueSlotChange === 'function') {
+    this.input.checkDisplayValueSlotChange();
+    this.input.requestUpdate();
+  }
+}
+```
+
+**focusin handler** — scoped the `this.focus()` delegation to the host-is-target case:
+
+```js
+this.addEventListener('focusin', (event) => {
+  this.touched = true;
+  if (event.target === this) {
+    this.focus();
+  }
+});
+```
+
+**Stale `_programmaticFilterRefresh` clear** — at the top of `handleTriggerInputValueChange`, before evaluating `_userTyped`:
+
+```js
+if (this._programmaticFilterRefresh && this.componentHasFocus) {
+  this._programmaticFilterRefresh = false;
+}
+```
+
+When the user is genuinely interacting (`componentHasFocus` is true), any leftover `_programmaticFilterRefresh` from a mount-time value sync is immediately cleared so `_userTyped` can be set on the first keystroke.
+
+### `components/input/src/auro-input.js`
+
+**Null-safe slot query** — early return when slot element isn't available:
+
+```js
+const slot = this.shadowRoot?.querySelector('slot[name="displayValue"]');
+if (!slot) {
+  return;
+}
+```
+
+## Accompanying Test Changes
+
+Three new tests added to `components/combobox/test/auro-combobox.test.js`:
+
+1. **`programmatic value sync via syncInputValuesAcrossTriggerAndBib does not set _userTyped`** — Verifies that setting `el.value = 'Apples'` programmatically keeps `_userTyped` false (guarded by `_syncingDisplayValue` / `_programmaticFilterRefresh`), preventing the bib from auto-opening on framework bindings.
+
+2. **`does not move focus to clear button on selection when combobox lacks focus`** — Verifies that a programmatic `el.value = 'Apples'` (which routes through `setMenuValue` → `_pendingMenuValueSync`) does not invoke `setClearBtnFocus`, because the `isEcho` guard catches it.
+
+3. **`focusin from a child element does not call this.focus()`** — Verifies that a `focusin` event with `event.target !== this` (e.g. from an internal input) does not trigger the host's `focus()` method.
+
+## What the Plan Got Right
+
+- The `else if (this.value)` fallback is removed by the existing `displayValueInTrigger.remove()` cleanup at the top of `updateTriggerTextDisplay`, so it doesn't accumulate stale synthetic spans.
+- The focusin change preserves the `this.touched = true` write for all focusin events (accessibility/validation still works), while only scoping the delegation call.
+- The input null-safety fix is a pure defensive guard with no behavioral change for normally-timed calls.
+
+## What the Plan Missed
+
+- **Initial investigation considered an `isProgrammatic` guard on `_userTyped`** — adding `!event.isProgrammatic` to suppress programmatic input events from opening the bib. This was abandoned because auro-input's `notifyValueChanged()` marks ALL re-dispatched input events (including user-typed ones) as `isProgrammatic = true`. The existing `_syncingDisplayValue` / `_syncingBibValue` / `_programmaticFilterRefresh` flags already handle suppression correctly.
+- **Initial investigation considered a `componentHasFocus` guard on `setClearBtnFocus`** — to prevent focus theft on programmatic selections. This was abandoned because in fullscreen mode, `componentHasFocus` returns false during the dialog-to-trigger focus transition (a timing race), breaking the user-click-option → focus-clear-button path. The existing `isEcho` guard (`_pendingMenuValueSync`) correctly handles the programmatic case without the timing fragility.
+
+## Lessons
+
+1. **One-shot flags need a clear-on-interaction fallback.** `_programmaticFilterRefresh` was designed to be cleared at the end of `handleTriggerInputValueChange`, but early-return paths bypass that cleanup. Any flag that suppresses user behavior must also have a clear path tied to user interaction (e.g. `componentHasFocus`).
+2. **auro-input marks ALL re-dispatched events as `isProgrammatic`.** Both `notifyValueChanged()` and the patched native value setter dispatch input events with `isProgrammatic = true`. This flag cannot distinguish user typing from programmatic syncs at the combobox level — the existing `_syncingDisplayValue` / `_syncingBibValue` flags are the correct mechanism.
+3. **`:focus-within` is unreliable during dialog close transitions.** In fullscreen mode, closing the `showModal()` dialog transitions focus asynchronously. Guards based on `componentHasFocus` (which uses `:focus` / `:focus-within`) will see false during this window.
+4. **Shadow DOM event retargeting means `event.target === this` for all shadow-originated `focusin` events.** Only light-DOM children preserve their target through the host boundary. For a combobox where all focusable elements are in shadow DOM, the focusin target is always retargeted to the host — making `event.target === this` equivalent to the old unconditional call for the combobox's own children. The behavioral change is solely for external focus management scenarios.
+5. **Methods called outside their original lifecycle context need null guards.** `checkDisplayValueSlotChange` was safe when only called from `slotchange` (post-render). Reusing it in `updateTriggerTextDisplay` (which can fire from `syncValuesAndStates` during mount) exposed the null slot reference.
+
+## Receipts
+
+- **Files changed:** `components/combobox/src/auro-combobox.js` (+36/−10), `components/input/src/auro-input.js` (+4/−1), `components/combobox/test/auro-combobox.test.js` (+87/−0).
+- **Test result:** 484 passing, 0 failed (combobox suite).
+- **Related investigation surface:** `components/input/src/base-input.js` lines 731, 985-992 (`isProgrammatic` flag origin).

--- a/docs/post-mortem/1598671.md
+++ b/docs/post-mortem/1598671.md
@@ -1,7 +1,7 @@
 # Post-Mortem: Flight-Search DisplayValue & Focus Regressions
 
 **Branch:** `jbaker/comboboxDisplayValueFixForFlightSearch` → `dev`
-**Scope:** Four behavioral fixes in auro-combobox and one defensive guard in auro-input, all surfaced by the flight-search planbook integration.
+**Scope:** Five behavioral fixes across auro-combobox and auro-dropdown, plus one defensive guard in auro-input, all surfaced by the flight-search planbook integration.
 
 ## Symptoms → Lesson
 
@@ -12,6 +12,8 @@
 | `checkDisplayValueSlotChange` throws in auro-input during early lifecycle (before shadow root renders) | `this.shadowRoot.querySelector(...)` can fail if called before `firstUpdated`. Added optional chaining (`?.`) and a light-DOM fallback so `hasDisplayValueContent` reflects slotted content even before the shadow slot exists. |
 | `setClearBtnFocus` stealing focus during programmatic value syncs | The `isEcho` guard (from `_pendingMenuValueSync`) already prevented this for setMenuValue-driven selections — no additional `componentHasFocus` gate was needed. |
 | Bib doesn't open on the first character typed after page load (but opens on the second) | Stale `_programmaticFilterRefresh` flag from mount-time `updated('value')` suppresses `_userTyped` on the first keystroke. Clear the flag at the top of `handleTriggerInputValueChange` when `componentHasFocus` is true. |
+| Page scrolls to / focuses combobox on initial render when it has a preset value | The bib input had a static `autofocus` attribute rendered on every cycle — including initial mount when the bib is closed. Combined with `delegatesFocus: true` on BaseInput, the browser focused the native `<input autofocus>` inside the bib on element upgrade. Fix: make `autofocus` conditional on `dropdownOpen && isBibFullscreen`. Additionally, `delegatesFocus` was removed from `AuroDropdown` as a defensive measure against focus cascading during lifecycle DOM manipulation. |
+| Focus stays on `document.body` after click-selecting a menu option (clear button not focused) | After the bib dialog closes on click selection, focus falls to `document.body`. `clearBtn.focus()` inside the shadow DOM silently fails when focus isn't already inside the shadow root's focus chain. Fix: call `this.input.focus()` first (which `delegatesFocus` on BaseInput routes to the native input, establishing the chain), then `clearBtn.focus()`. Also suppress the dropdown's competing `focusTrigger()` call when `noHideOnThisFocusLoss` is true. |
 
 ## The Bugs
 
@@ -56,6 +58,12 @@ When the flight-search planbook first loads, typing a character into the combobo
 
 4. **Stale `_programmaticFilterRefresh` flag:** `updated('value')` sets the flag unconditionally (when `!_userTyped`), but the clear-point at the end of `handleTriggerInputValueChange` is unreachable when the early return `if (this.value === this.input.value) return` fires. The flag survives into the next user interaction, suppressing `_userTyped` on the first keystroke.
 
+5. **Static `autofocus` on the bib input + `delegatesFocus` on BaseInput:** The bib input's template had a static `autofocus` attribute rendered on every Lit cycle. When the custom element upgrades and first renders, `BaseInput`'s `delegatesFocus: true` causes the browser to focus the native `<input autofocus>` inside the bib's shadow DOM — even though the bib is closed and invisible. This is enforced at the browser platform level. `delegatesFocus: true` on `AuroDropdown` amplified the cascade (any transient focus touch on the dropdown host during lifecycle operations would also route to the bib input), though the primary cause was the unconditional `autofocus` attribute.
+
+6. **`clearBtn.focus()` silently fails when focus is on `document.body`:** On click selection (vs Enter key), the bib dialog closes before `setClearBtnFocus` fires, sending focus to `document.body`. Calling `.focus()` on an element deep inside nested shadow DOMs requires the shadow root's focus chain to be established first. With `delegatesFocus: true` on BaseInput, calling `this.input.focus()` first routes focus to the native `<input>` (establishing the chain), after which `clearBtn.focus()` succeeds. Without this priming step, the browser silently ignores the focus call.
+
+7. **Dropdown's generic focus restoration races with the combobox's `setClearBtnFocus`:** After the bib closes, the dropdown's `handleDropdownToggle` schedules a `setTimeout(() => focusTrigger())` to restore focus to the trigger. When `noHideOnThisFocusLoss` is true (set by the combobox), the consumer is managing focus explicitly — the dropdown's generic restoration must be suppressed to avoid overriding `setClearBtnFocus`.
+
 ## The Fixes
 
 ### `components/combobox/src/auro-combobox.js`
@@ -96,6 +104,95 @@ if (this._programmaticFilterRefresh && this.componentHasFocus) {
 
 When the user is genuinely interacting (`componentHasFocus` is true), any leftover `_programmaticFilterRefresh` from a mount-time value sync is immediately cleared so `_userTyped` can be set on the first keystroke.
 
+**Conditional `autofocus` on bib input** — only set when the fullscreen bib is actually opening:
+
+```js
+autofocus="${this.dropdownOpen && this.dropdown?.isBibFullscreen}"
+```
+
+This ensures the native `<input autofocus>` in the bib's shadow DOM only requests focus when the fullscreen dialog is opening (where it's needed to keep the mobile keyboard visible), not during initial mount.
+
+**`setClearBtnFocus` focus-chain priming** — establish the shadow DOM focus chain before moving focus to the clear button:
+
+```js
+setClearBtnFocus() {
+  doubleRaf(() => {
+    this.input.focus();
+    const clearBtn = this.input.shadowRoot.querySelector('.clearBtn');
+    if (clearBtn) {
+      clearBtn.focus();
+    }
+  });
+}
+```
+
+On click selection, focus is on `document.body` when this fires (the bib dialog closed and the clicked option is gone). `clearBtn.focus()` silently fails unless the shadow root's focus chain is active. `this.input.focus()` primes it via `delegatesFocus` on BaseInput, then `clearBtn.focus()` succeeds.
+
+**Guarded open-handler `setInputFocus`** — the dropdown-open handler's `doubleRaf(() => setInputFocus())` now checks `this.dropdownOpen` before executing, preventing it from overriding `setClearBtnFocus` when the bib closed before the deferred callback fired:
+
+```js
+doubleRaf(() => {
+  if (this.dropdownOpen) {
+    this.setInputFocus();
+  }
+  ...
+});
+```
+
+**Guarded strategy-change `setInputFocus`** — only focus the input when the dropdown is actually open, preventing focus theft during hot reload/re-initialization:
+
+```js
+this._scheduleTimer(() => {
+  if (this.dropdown.isPopoverVisible) {
+    this.setInputFocus();
+  }
+}, 0);
+```
+
+### `components/dropdown/src/auro-dropdown.js`
+
+**Removed `delegatesFocus: true`** (defensive) — the combobox has explicit focus routing via `focus()`, `setInputFocus()`, and the keyboard strategy. The dropdown's `delegatesFocus` was redundant and amplified focus cascading during lifecycle DOM manipulation:
+
+```js
+static get shadowRootOptions() {
+  return {
+    ...AuroElement.shadowRootOptions,
+  };
+}
+```
+
+**Added `focusTrigger()` helper** — replaces direct `this.trigger.focus()` calls (which silently fail when the trigger div has no `tabindex`). Queries `slot.assignedElements()` directly since `getFocusableElements()` can't traverse slot projections:
+
+```js
+focusTrigger() {
+  if (this.trigger.hasAttribute('tabindex')) {
+    this.trigger.focus();
+  } else {
+    const slot = this.trigger.querySelector('slot[name="trigger"]');
+    if (slot) {
+      const assigned = slot.assignedElements();
+      const focusable = assigned.find((el) => !el.hasAttribute('disabled'));
+      if (focusable) {
+        focusable.focus();
+        return;
+      }
+    }
+    const focusables = getFocusableElements(this.trigger);
+    if (focusables.length > 0) {
+      focusables[0].focus();
+    }
+  }
+}
+```
+
+**Suppressed generic focus restoration when consumer manages focus** — when `noHideOnThisFocusLoss` is true (set by the combobox), skip the dropdown's `focusTrigger()` call on close to avoid racing with `setClearBtnFocus`:
+
+```js
+if (!this.isPopoverVisible && eventType !== "focusloss" && !this.noHideOnThisFocusLoss) {
+  setTimeout(() => { this.focusTrigger(); });
+}
+```
+
 ### `components/input/src/auro-input.js`
 
 **Null-safe slot query with light-DOM fallback** — when the shadow slot isn't available yet, check light-DOM children so `hasDisplayValueContent` isn't stuck `false`:
@@ -125,22 +222,175 @@ Three new tests added to `components/combobox/test/auro-combobox.test.js`:
 - The `else if (this.value)` fallback is removed by the existing `displayValueInTrigger.remove()` cleanup at the top of `updateTriggerTextDisplay`, so it doesn't accumulate stale synthetic spans.
 - The focusin change preserves the `this.touched = true` write for all focusin events (accessibility/validation still works), while only scoping the delegation call.
 - The input null-safety fix includes a light-DOM fallback (`querySelector('[slot="displayValue"]:not(slot)')`) so `hasDisplayValueContent` is correctly set even when called before the shadow root renders, preventing the displayValue wrapper from staying hidden after mount.
+- The two focus-theft fixes (conditional `autofocus` + `delegatesFocus` removal from dropdown) address complementary scenarios and are both retained:
+
+| Fix | Prevents |
+|---|---|
+| Remove `delegatesFocus` from `AuroDropdown` | Focus theft during swap / programmatic prop changes (Lit lifecycle DOM manipulation transiently touches the dropdown host) |
+| Conditional `autofocus` on bib input | Focus theft on initial mount (browser honors `<input autofocus>` during custom element upgrade even when the bib is closed) |
+
+- `delegatesFocus` on `BaseInput` was intentionally **retained** — removing it was tested but broke `clearBtn.focus()` (the browser requires the shadow root focus chain to be active for `.focus()` to reach elements inside nested shadow DOMs). The `setClearBtnFocus` priming pattern (`input.focus()` then `clearBtn.focus()`) depends on it.
 
 ## What the Plan Missed
 
 - **Initial investigation considered an `isProgrammatic` guard on `_userTyped`** — adding `!event.isProgrammatic` to suppress programmatic input events from opening the bib. This was abandoned because auro-input's `notifyValueChanged()` marks ALL re-dispatched input events (including user-typed ones) as `isProgrammatic = true`. The existing `_syncingDisplayValue` / `_syncingBibValue` / `_programmaticFilterRefresh` flags already handle suppression correctly.
-- **Initial investigation considered a `componentHasFocus` guard on `setClearBtnFocus`** — to prevent focus theft on programmatic selections. This was abandoned because in fullscreen mode, `componentHasFocus` returns false during the dialog-to-trigger focus transition (a timing race), breaking the user-click-option → focus-clear-button path. The existing `isEcho` guard (`_pendingMenuValueSync`) correctly handles the programmatic case without the timing fragility.
+- **Initial investigation considered a `componentHasFocus` guard on `setClearBtnFocus`** — to prevent focus theft on programmatic selections. This was abandoned because (a) in fullscreen mode, `componentHasFocus` returns false during the dialog-to-trigger focus transition (a timing race), and (b) without `delegatesFocus` on the dropdown, `:focus-within` doesn't propagate from bib content to the combobox host on desktop click selections. The existing `isEcho` guard (`_pendingMenuValueSync`) correctly handles the programmatic case without the timing fragility.
+- **Removing `delegatesFocus` from `BaseInput` was tested and reverted.** Without it, `.focus()` on elements inside the auro-input shadow DOM (like the clear button) silently fails when focus starts on `document.body`. The browser requires the shadow root's `delegatesFocus` chain to be active for programmatic focus routing into nested shadow DOMs. The initial-load focus theft was caused by the static `autofocus` attribute, not by `delegatesFocus` on BaseInput.
 
 ## Lessons
 
 1. **One-shot flags need a clear-on-interaction fallback.** `_programmaticFilterRefresh` was designed to be cleared at the end of `handleTriggerInputValueChange`, but early-return paths bypass that cleanup. Any flag that suppresses user behavior must also have a clear path tied to user interaction (e.g. `componentHasFocus`).
+
+   **The problem pattern:**
+   ```js
+   // updated() sets the flag on mount
+   updated(changedProperties) {
+     if (changedProperties.has('value')) {
+       if (!this._userTyped) {
+         this._programmaticFilterRefresh = true;  // ← set here
+       }
+     }
+   }
+
+   handleTriggerInputValueChange(event) {
+     // Flag suppresses _userTyped
+     if (!this._syncingDisplayValue && !this._programmaticFilterRefresh) {
+       this._userTyped = true;  // ← never reached on first keystroke!
+     }
+
+     // ... early return before the clear point:
+     if (this.value === this.input.value) {
+       return;  // ← exits here on mount-time echo, flag stays true
+     }
+
+     // Clear point only reached on full path through:
+     if (this._programmaticFilterRefresh) {
+       this._programmaticFilterRefresh = false;  // ← never reached!
+     }
+   }
+   ```
+
+   **The fix pattern — clear on interaction:**
+   ```js
+   handleTriggerInputValueChange(event) {
+     // Clear stale flag when user is genuinely interacting
+     if (this._programmaticFilterRefresh && this.componentHasFocus) {
+       this._programmaticFilterRefresh = false;
+     }
+
+     // Now _userTyped can be set on the first keystroke
+     if (!this._syncingDisplayValue && !this._programmaticFilterRefresh) {
+       this._userTyped = true;  // ← works on first keystroke!
+     }
+     // ...
+   }
+   ```
+
+   **Rule:** If a flag suppresses user-facing behavior, its clear path must not depend solely on code paths that can be bypassed by early returns. Add a secondary clear at the top of the interaction handler, gated on proof of user presence (`componentHasFocus`, `document.hasFocus()`, etc.).
 2. **auro-input marks ALL re-dispatched events as `isProgrammatic`.** Both `notifyValueChanged()` and the patched native value setter dispatch input events with `isProgrammatic = true`. This flag cannot distinguish user typing from programmatic syncs at the combobox level — the existing `_syncingDisplayValue` / `_syncingBibValue` flags are the correct mechanism.
+
+   **How auro-input dispatches events — both paths set `isProgrammatic`:**
+   ```js
+   // Path 1: notifyValueChanged() — called from updated() after ANY value change
+   // (user typing OR programmatic set — both go through Lit's reactive cycle)
+   notifyValueChanged() {
+     const inputEvent = new Event('input', { bubbles: true, composed: true });
+     inputEvent.isProgrammatic = true;  // ← ALWAYS true
+     this.dispatchEvent(inputEvent);
+   }
+
+   // Path 2: patched native input value setter — fires when input.value is
+   // set programmatically AND the input does NOT have focus
+   set value(val) {
+     nativeDescriptor.set.call(this, val);
+     if (this.matches(":focus")) return;  // ← user typing? skip (native event handles it)
+     const inputEvent = new InputEvent('input', { bubbles: true, composed: true });
+     inputEvent.isProgrammatic = true;  // ← ALWAYS true
+     this.dispatchEvent(inputEvent);
+   }
+   ```
+
+   **Why `!event.isProgrammatic` doesn't work as a guard:**
+   ```js
+   // ❌ BROKEN: blocks ALL events because notifyValueChanged always sets it
+   handleTriggerInputValueChange(event) {
+     if (!event.isProgrammatic) {  // ← NEVER true for events reaching the combobox
+       this._userTyped = true;
+     }
+   }
+
+   // ✅ CORRECT: use combobox-level sync flags that are only set during
+   // explicit programmatic value writes (not during user typing)
+   handleTriggerInputValueChange(event) {
+     if (!this._syncingDisplayValue && !this._syncingBibValue && !this._programmaticFilterRefresh) {
+       this._userTyped = true;  // ← works for user typing
+     }
+   }
+   ```
+
+   **Rule:** Don't rely on event-level flags set by child components to distinguish user vs programmatic interactions at the parent level. Use parent-owned sync flags that bracket the specific programmatic operations you want to suppress.
 3. **`:focus-within` is unreliable during dialog close transitions.** In fullscreen mode, closing the `showModal()` dialog transitions focus asynchronously. Guards based on `componentHasFocus` (which uses `:focus` / `:focus-within`) will see false during this window.
 4. **Shadow DOM event retargeting means `event.target` is always the host for shadow-originated events.** Use `event.composedPath()[0]` to identify the actual focus origin. `event.target` is retargeted at the shadow boundary, making it useless for distinguishing host-originated focus from child-originated focus.
 5. **Early-return guards on non-reactive properties must still set a reasonable default.** `checkDisplayValueSlotChange` returns early when the shadow slot doesn't exist, but `hasDisplayValueContent` is non-reactive — a bare `return` leaves it stuck `false`, hiding the displayValue wrapper even after the shadow root renders. A light-DOM fallback (`querySelector`) before the return ensures the first render reflects slotted content.
+6. **`autofocus` on hidden elements is still honored by the browser.** A static `autofocus` attribute inside a closed `<dialog>` or invisible bib is still processed during custom element upgrade. Always make `autofocus` conditional on the containing context being visible/open.
+7. **`delegatesFocus` is a platform-level behavior no JS guard can override.** It fires during ANY focus touch on the host — including transient Lit lifecycle operations. If your component has explicit focus routing, `delegatesFocus` on intermediate wrapper components is redundant and causes unwanted cascading.
+
+   **The cascade that causes focus theft on mount:**
+   ```
+   Combobox mounts with preset value
+     → updated() runs → updateTriggerTextDisplay() → input.requestUpdate()
+     → Lit re-renders auro-input → DOM manipulation transiently touches
+       the AuroDropdown host (e.g. slotchange, attribute write)
+     → delegatesFocus on AuroDropdown fires (browser platform level)
+     → browser auto-focuses first focusable descendant in dropdown's shadow root
+     → auro-input (trigger) has delegatesFocus → cascades to native <input>
+     → page scrolls to combobox, keyboard pops on mobile
+   ```
+
+   **Why JavaScript guards can't prevent it:**
+   ```js
+   // ❌ These guards run AFTER delegatesFocus has already moved focus:
+   this.addEventListener('focusin', (event) => {
+     if (event.composedPath()[0] === this) {
+       this.focus();  // ← this guard is irrelevant; focus already moved
+     }
+   });
+
+   // ❌ componentHasFocus checks are also too late:
+   focus() {
+     if (!this.componentHasFocus) {  // ← already true because delegatesFocus fired
+       this.input.focus();
+     }
+   }
+   ```
+
+   **The fix — remove `delegatesFocus` from the intermediate host:**
+   ```js
+   // AuroDropdown — BEFORE (causes cascade):
+   static get shadowRootOptions() {
+     return { ...AuroElement.shadowRootOptions, delegatesFocus: true };
+   }
+
+   // AuroDropdown — AFTER (explicit routing only):
+   static get shadowRootOptions() {
+     return { ...AuroElement.shadowRootOptions };
+   }
+
+   // Focus routing is handled explicitly by the combobox:
+   // - focus() → this.input.focus()
+   // - setInputFocus() → nativeInput.focus()
+   // - setClearBtnFocus() → this.input.focus() then clearBtn.focus()
+   // - focusTrigger() on the dropdown → slot.assignedElements()[0].focus()
+   ```
+
+   **Rule:** `delegatesFocus` is appropriate on leaf components (like auro-input, where clicking the wrapper should focus the native input). On intermediate wrapper components (like a dropdown that hosts other focusable components), it causes unwanted cascading during any lifecycle operation that transiently touches the host. Remove it and use explicit focus routing instead.
+8. **`getFocusableElements` can't see slot-projected content.** The utility walks DOM tree children; slotted elements are in the host's light DOM, not the slot element's children. Use `slot.assignedElements()` to find projected focusable content.
+9. **`delegatesFocus` on BaseInput is load-bearing for `.focus()` routing.** Removing it from the input prevents programmatic `.focus()` from reaching elements inside the shadow DOM when focus starts on `document.body`. The fix for initial-load focus theft is conditional `autofocus`, not removing `delegatesFocus`.
+10. **Priming the focus chain before moving to a sibling shadow element.** When focus is on `document.body`, `clearBtn.focus()` inside a nested shadow DOM silently fails. Calling `this.input.focus()` first (which `delegatesFocus` routes to the native input) establishes the chain, then `clearBtn.focus()` succeeds.
+11. **Generic focus restoration must respect consumer ownership.** The dropdown's `handleDropdownToggle` generically restores focus to the trigger on close. When `noHideOnThisFocusLoss` is true, the consumer (combobox) is managing focus explicitly — the dropdown must skip its restoration to avoid racing.
 
 ## Receipts
 
-- **Files changed:** `components/combobox/src/auro-combobox.js` (+36/−10), `components/input/src/auro-input.js` (+7/−1), `components/combobox/test/auro-combobox.test.js` (+87/−0).
-- **Test result:** 484 passing, 0 failed (combobox suite).
-- **Related investigation surface:** `components/input/src/base-input.js` lines 731, 985-992 (`isProgrammatic` flag origin).
+- **Files changed:** `components/combobox/src/auro-combobox.js`, `components/dropdown/src/auro-dropdown.js`, `components/input/src/auro-input.js`, `components/input/src/base-input.js` (comment only), `components/input/test/auro-input.test.js`, `components/combobox/test/auro-combobox.test.js`.
+- **Test result:** 484 passing, 0 failed (combobox suite); 354 passing, 0 failed (dropdown suite); 563 passing, 0 failed (input suite).
+- **Related investigation surface:** `components/input/src/base-input.js` lines 30-34 (`delegatesFocus` — retained), lines 731, 985-992 (`isProgrammatic` flag origin); `node_modules/@aurodesignsystem/auro-library/scripts/runtime/Focusables/Focusables.mjs` (`getFocusableElements` slot limitation).

--- a/docs/post-mortem/1598671.md
+++ b/docs/post-mortem/1598671.md
@@ -11,7 +11,7 @@
 | `focusin` handler on the combobox was calling `this.focus()` on every child-element focus, causing focus-redirect loops in certain frameworks | The old unconditional `this.focus()` call in the `focusin` listener conflicted with framework focus management. Now only fires when `event.composedPath()[0] === this` (the host itself is the focus origin, not a shadow DOM child). |
 | `checkDisplayValueSlotChange` throws in auro-input during early lifecycle (before shadow root renders) | `this.shadowRoot.querySelector(...)` can fail if called before `firstUpdated`. Added optional chaining (`?.`) and a light-DOM fallback so `hasDisplayValueContent` reflects slotted content even before the shadow slot exists. |
 | `setClearBtnFocus` stealing focus during programmatic value syncs | The `isEcho` guard (from `_pendingMenuValueSync`) already prevented this for setMenuValue-driven selections — no additional `componentHasFocus` gate was needed. |
-| Bib doesn't open on the first character typed after page load (but opens on the second) | Stale `_programmaticFilterRefresh` flag from mount-time `updated('value')` suppresses `_userTyped` on the first keystroke. Clear the flag at the top of `handleTriggerInputValueChange` when `componentHasFocus` is true. |
+| Bib doesn't open on the first character typed after page load (but opens on the second) | Stale `_programmaticFilterRefresh` flag from mount-time `updated('value')` suppresses `_userTyped` on the first keystroke. Fix: make the flag self-clearing via `this.updateComplete.then(...)` right after it's set, so it can never survive into the next user interaction. |
 | Page scrolls to / focuses combobox on initial render when it has a preset value | The bib input had a static `autofocus` attribute rendered on every cycle — including initial mount when the bib is closed. Combined with `delegatesFocus: true` on BaseInput, the browser focused the native `<input autofocus>` inside the bib on element upgrade. Fix: make `autofocus` conditional on `dropdownOpen && isBibFullscreen`. Additionally, `delegatesFocus` was removed from `AuroDropdown` as a defensive measure against focus cascading during lifecycle DOM manipulation. |
 | Focus stays on `document.body` after click-selecting a menu option (clear button not focused) | After the bib dialog closes on click selection, focus falls to `document.body`. `clearBtn.focus()` inside the shadow DOM silently fails when focus isn't already inside the shadow root's focus chain. Fix: call `this.input.focus()` first (which `delegatesFocus` on BaseInput routes to the native input, establishing the chain), then `clearBtn.focus()`. Also suppress the dropdown's competing `focusTrigger()` call when `noHideOnThisFocusLoss` is true. |
 
@@ -94,20 +94,24 @@ this.addEventListener('focusin', (event) => {
 });
 ```
 
-**Stale `_programmaticFilterRefresh` clear** — at the top of `handleTriggerInputValueChange`, before evaluating `_userTyped`:
+**Self-clearing `_programmaticFilterRefresh`** — the flag is cleared via `updateComplete.then(...)` immediately after it's set, so it can never survive past the update cycle it's meant to guard:
 
 ```js
-if (this._programmaticFilterRefresh && this.componentHasFocus) {
-  this._programmaticFilterRefresh = false;
+// In updated('value'):
+if (!this._userTyped) {
+  this._programmaticFilterRefresh = true;
+  this.updateComplete.then(() => {
+    this._programmaticFilterRefresh = false;
+  });
 }
 ```
 
-When the user is genuinely interacting (`componentHasFocus` is true), any leftover `_programmaticFilterRefresh` from a mount-time value sync is immediately cleared so `_userTyped` can be set on the first keystroke.
+This collapses the previous scattered clear-points (end of `handleTriggerInputValueChange`, end of the `availableOptions` handler, and the `componentHasFocus` interaction guard) into a single co-located self-clear.
 
 **Conditional `autofocus` on bib input** — only set when the fullscreen bib is actually opening:
 
 ```js
-autofocus="${this.dropdownOpen && this.dropdown?.isBibFullscreen}"
+?autofocus="${this.dropdownOpen && this.dropdown?.isBibFullscreen}"
 ```
 
 This ensures the native `<input autofocus>` in the bib's shadow DOM only requests focus when the fullscreen dialog is opening (where it's needed to keep the mobile keyboard visible), not during initial mount.
@@ -239,7 +243,7 @@ Three new tests added to `components/combobox/test/auro-combobox.test.js`:
 
 ## Lessons
 
-1. **One-shot flags need a clear-on-interaction fallback.** `_programmaticFilterRefresh` was designed to be cleared at the end of `handleTriggerInputValueChange`, but early-return paths bypass that cleanup. Any flag that suppresses user behavior must also have a clear path tied to user interaction (e.g. `componentHasFocus`).
+1. **One-shot flags should be self-clearing.** `_programmaticFilterRefresh` was originally designed to be cleared at the end of `handleTriggerInputValueChange`, but early-return paths bypass that cleanup. Making the flag self-clearing via `this.updateComplete.then(...)` right after it's set eliminates the entire class of "flag survives into the next interaction" bugs.
 
    **The problem pattern:**
    ```js
@@ -270,23 +274,31 @@ Three new tests added to `components/combobox/test/auro-combobox.test.js`:
    }
    ```
 
-   **The fix pattern — clear on interaction:**
+   **The fix pattern — self-clearing flag:**
    ```js
-   handleTriggerInputValueChange(event) {
-     // Clear stale flag when user is genuinely interacting
-     if (this._programmaticFilterRefresh && this.componentHasFocus) {
-       this._programmaticFilterRefresh = false;
+   updated(changedProperties) {
+     if (changedProperties.has('value')) {
+       if (!this._userTyped) {
+         this._programmaticFilterRefresh = true;
+         // Self-clear after this update cycle completes —
+         // can never survive into the next user interaction.
+         this.updateComplete.then(() => {
+           this._programmaticFilterRefresh = false;
+         });
+       }
      }
+   }
 
-     // Now _userTyped can be set on the first keystroke
+   handleTriggerInputValueChange(event) {
+     // No scattered clear-points needed — flag is already
+     // guaranteed to be false by the next interaction.
      if (!this._syncingDisplayValue && !this._programmaticFilterRefresh) {
        this._userTyped = true;  // ← works on first keystroke!
      }
-     // ...
    }
    ```
 
-   **Rule:** If a flag suppresses user-facing behavior, its clear path must not depend solely on code paths that can be bypassed by early returns. Add a secondary clear at the top of the interaction handler, gated on proof of user presence (`componentHasFocus`, `document.hasFocus()`, etc.).
+   **Rule:** If a one-shot flag suppresses user-facing behavior, co-locate its clear with its set-point via `updateComplete.then(...)`. Don't scatter clear-points across handler end-paths or interaction guards — they're fragile and multiply with each new code path.
 2. **auro-input marks ALL re-dispatched events as `isProgrammatic`.** Both `notifyValueChanged()` and the patched native value setter dispatch input events with `isProgrammatic = true`. This flag cannot distinguish user typing from programmatic syncs at the combobox level — the existing `_syncingDisplayValue` / `_syncingBibValue` flags are the correct mechanism.
 
    **How auro-input dispatches events — both paths set `isProgrammatic`:**

--- a/docs/post-mortem/1598671.md
+++ b/docs/post-mortem/1598671.md
@@ -8,8 +8,8 @@
 | If you see... | This doc says... |
 |---|---|
 | Combobox's displayValue overlay is blank after a programmatic `value` set when options haven't loaded yet | `updateTriggerTextDisplay` only cloned from `optionSelected`; if `optionSelected` is null (e.g. on remount before slot population) no visual was rendered. The new `else if (this.value)` branch synthesizes a temporary `<span slot="displayValue">` from the raw value. |
-| `focusin` handler on the combobox was calling `this.focus()` on every child-element focus, causing focus-redirect loops in certain frameworks | The old unconditional `this.focus()` call in the `focusin` listener conflicted with framework focus management. Now only fires when `event.target === this` (the host itself receives focus, not a shadow DOM child). |
-| `checkDisplayValueSlotChange` throws in auro-input during early lifecycle (before shadow root renders) | `this.shadowRoot.querySelector(...)` can fail if called before `firstUpdated`. Added optional chaining (`?.`) and early return. |
+| `focusin` handler on the combobox was calling `this.focus()` on every child-element focus, causing focus-redirect loops in certain frameworks | The old unconditional `this.focus()` call in the `focusin` listener conflicted with framework focus management. Now only fires when `event.composedPath()[0] === this` (the host itself is the focus origin, not a shadow DOM child). |
+| `checkDisplayValueSlotChange` throws in auro-input during early lifecycle (before shadow root renders) | `this.shadowRoot.querySelector(...)` can fail if called before `firstUpdated`. Added optional chaining (`?.`) and a light-DOM fallback so `hasDisplayValueContent` reflects slotted content even before the shadow slot exists. |
 | `setClearBtnFocus` stealing focus during programmatic value syncs | The `isEcho` guard (from `_pendingMenuValueSync`) already prevented this for setMenuValue-driven selections — no additional `componentHasFocus` gate was needed. |
 | Bib doesn't open on the first character typed after page load (but opens on the second) | Stale `_programmaticFilterRefresh` flag from mount-time `updated('value')` suppresses `_userTyped` on the first keystroke. Clear the flag at the top of `handleTriggerInputValueChange` when `componentHasFocus` is true. |
 
@@ -75,12 +75,12 @@ When the flight-search planbook first loads, typing a character into the combobo
 }
 ```
 
-**focusin handler** — scoped the `this.focus()` delegation to the host-is-target case:
+**focusin handler** — scoped the `this.focus()` delegation to the host-is-origin case:
 
 ```js
 this.addEventListener('focusin', (event) => {
   this.touched = true;
-  if (event.target === this) {
+  if (event.composedPath()[0] === this) {
     this.focus();
   }
 });
@@ -98,11 +98,14 @@ When the user is genuinely interacting (`componentHasFocus` is true), any leftov
 
 ### `components/input/src/auro-input.js`
 
-**Null-safe slot query** — early return when slot element isn't available:
+**Null-safe slot query with light-DOM fallback** — when the shadow slot isn't available yet, check light-DOM children so `hasDisplayValueContent` isn't stuck `false`:
 
 ```js
 const slot = this.shadowRoot?.querySelector('slot[name="displayValue"]');
 if (!slot) {
+  this.hasDisplayValueContent = Boolean(
+    this.querySelector('[slot="displayValue"]:not(slot)')
+  );
   return;
 }
 ```
@@ -115,13 +118,13 @@ Three new tests added to `components/combobox/test/auro-combobox.test.js`:
 
 2. **`does not move focus to clear button on selection when combobox lacks focus`** — Verifies that a programmatic `el.value = 'Apples'` (which routes through `setMenuValue` → `_pendingMenuValueSync`) does not invoke `setClearBtnFocus`, because the `isEcho` guard catches it.
 
-3. **`focusin from a child element does not call this.focus()`** — Verifies that a `focusin` event with `event.target !== this` (e.g. from an internal input) does not trigger the host's `focus()` method.
+3. **`focusin from a shadow-DOM child does not call this.focus()`** — Focuses the native input inside the shadow DOM and verifies that the composed focusin (with `composedPath()[0]` pointing at the native input, not the host) does not trigger the host's `focus()` method.
 
 ## What the Plan Got Right
 
 - The `else if (this.value)` fallback is removed by the existing `displayValueInTrigger.remove()` cleanup at the top of `updateTriggerTextDisplay`, so it doesn't accumulate stale synthetic spans.
 - The focusin change preserves the `this.touched = true` write for all focusin events (accessibility/validation still works), while only scoping the delegation call.
-- The input null-safety fix is a pure defensive guard with no behavioral change for normally-timed calls.
+- The input null-safety fix includes a light-DOM fallback (`querySelector('[slot="displayValue"]:not(slot)')`) so `hasDisplayValueContent` is correctly set even when called before the shadow root renders, preventing the displayValue wrapper from staying hidden after mount.
 
 ## What the Plan Missed
 
@@ -133,11 +136,11 @@ Three new tests added to `components/combobox/test/auro-combobox.test.js`:
 1. **One-shot flags need a clear-on-interaction fallback.** `_programmaticFilterRefresh` was designed to be cleared at the end of `handleTriggerInputValueChange`, but early-return paths bypass that cleanup. Any flag that suppresses user behavior must also have a clear path tied to user interaction (e.g. `componentHasFocus`).
 2. **auro-input marks ALL re-dispatched events as `isProgrammatic`.** Both `notifyValueChanged()` and the patched native value setter dispatch input events with `isProgrammatic = true`. This flag cannot distinguish user typing from programmatic syncs at the combobox level — the existing `_syncingDisplayValue` / `_syncingBibValue` flags are the correct mechanism.
 3. **`:focus-within` is unreliable during dialog close transitions.** In fullscreen mode, closing the `showModal()` dialog transitions focus asynchronously. Guards based on `componentHasFocus` (which uses `:focus` / `:focus-within`) will see false during this window.
-4. **Shadow DOM event retargeting means `event.target === this` for all shadow-originated `focusin` events.** Only light-DOM children preserve their target through the host boundary. For a combobox where all focusable elements are in shadow DOM, the focusin target is always retargeted to the host — making `event.target === this` equivalent to the old unconditional call for the combobox's own children. The behavioral change is solely for external focus management scenarios.
-5. **Methods called outside their original lifecycle context need null guards.** `checkDisplayValueSlotChange` was safe when only called from `slotchange` (post-render). Reusing it in `updateTriggerTextDisplay` (which can fire from `syncValuesAndStates` during mount) exposed the null slot reference.
+4. **Shadow DOM event retargeting means `event.target` is always the host for shadow-originated events.** Use `event.composedPath()[0]` to identify the actual focus origin. `event.target` is retargeted at the shadow boundary, making it useless for distinguishing host-originated focus from child-originated focus.
+5. **Early-return guards on non-reactive properties must still set a reasonable default.** `checkDisplayValueSlotChange` returns early when the shadow slot doesn't exist, but `hasDisplayValueContent` is non-reactive — a bare `return` leaves it stuck `false`, hiding the displayValue wrapper even after the shadow root renders. A light-DOM fallback (`querySelector`) before the return ensures the first render reflects slotted content.
 
 ## Receipts
 
-- **Files changed:** `components/combobox/src/auro-combobox.js` (+36/−10), `components/input/src/auro-input.js` (+4/−1), `components/combobox/test/auro-combobox.test.js` (+87/−0).
+- **Files changed:** `components/combobox/src/auro-combobox.js` (+36/−10), `components/input/src/auro-input.js` (+7/−1), `components/combobox/test/auro-combobox.test.js` (+87/−0).
 - **Test result:** 484 passing, 0 failed (combobox suite).
 - **Related investigation surface:** `components/input/src/base-input.js` lines 731, 985-992 (`isProgrammatic` flag origin).


### PR DESCRIPTION
# Alaska Airlines Pull Request

Release candidate pull request. See issue #1557 for details.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details open>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve combobox, dropdown, and input displayValue and focus behavior for preset values and framework integrations, and document the flight-search regressions and fixes.

Enhancements:
- Add synthetic displayValue rendering when a combobox has a value but no selected option, ensuring preselected values are visible before options load.
- Refine combobox focus management, including guarded focusin handling, conditional bib autofocus, and clearer focus routing to the input and clear button.
- Make the dropdown manage trigger focus more robustly via a dedicated focusTrigger helper and a noFocusRestoreOnClose flag so consumers can own focus restoration.
- Harden auro-input’s displayValue slot detection with null-safe checks and a light-DOM fallback so displayValue content is recognized earlier in the lifecycle.
- Ensure the _programmaticFilterRefresh flag in the combobox is self-clearing after an update cycle to avoid suppressing the first user keystroke.

Documentation:
- Add a detailed post-mortem documenting the displayValue and focus regressions seen in flight-search and the corresponding fixes across combobox, dropdown, and input.

Tests:
- Extend combobox, dropdown, and input test suites to cover the new displayValue synthesis, focus routing behaviors, and slot-change handling.