### PR TITLE
Fix datepicker ellipses issues

### DIFF
--- a/components/datepicker/src/styles/classic/style.scss
+++ b/components/datepicker/src/styles/classic/style.scss
@@ -37,3 +37,13 @@
     height: 2rem;
   }
 }
+
+// Range: the calendar icon renders only in the From half, so at equal flex-basis
+// From's text area was narrower than To's and its label/date truncated first. Widen
+// From's basis by the icon footprint minus To's existing margin so both text areas
+// match and truncate in lockstep. To is unchanged. Scoped to classic (icon lives here).
+:host([layout*='classic'][range]) {
+  .inputContainer:first-of-type {
+    flex: 1 1 calc(var(--ds-size-400, 2rem) + var(--ds-size-100, 0.5rem) - var(--ds-size-150, 0.75rem));
+  }
+}

--- a/components/datepicker/src/styles/style.scss
+++ b/components/datepicker/src/styles/style.scss
@@ -67,6 +67,23 @@
   }
 }
 
+// Range mode splits the input row into two equal, shrinkable halves so a long
+// label in one input can never push its sibling (the range end input) out of
+// view. `min-width: 0` lets each half shrink below its content's intrinsic
+// width, which allows auro-input's built-in label ellipsis to engage instead
+// of overflowing. Single-input datepickers keep the original full-width rule.
+:host([range]) {
+  .inputContainer {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .dateFrom,
+  .dateTo {
+    min-width: 0;
+  }
+}
+
 .dpTriggerContent {
   width: 100%;
 }

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -1923,8 +1923,9 @@ function runFullTest(mobileView) {
       });
 
       // Regression: a long fromLabel/toLabel used to stretch the first input and push the
-      // range-end input out of view. Both inputs should now split the row ~50/50 and the
-      // end input must stay within the component's box (labels truncate via ellipsis instead).
+      // range-end input out of view. The end input must stay within the component's box
+      // (labels truncate via ellipsis instead), and the two inputs' text areas must be
+      // equal so the labels truncate in lockstep.
       it('keeps both range inputs on-screen and evenly sized when labels are long', async () => {
         const longLabel = 'Departure with an extremely long label that should truncate rather than expand the input beyond its allotted half of the row';
 
@@ -1945,11 +1946,45 @@ function runFullTest(mobileView) {
         // The range-end input must not be pushed outside the component (allow 1px rounding).
         await expect(toRect.right).to.be.at.most(hostRect.right + 1);
 
-        // Both inputs render with real width and split the available space ~50/50.
+        // Both inputs render with real width.
         await expect(fromRect.width).to.be.greaterThan(0);
         await expect(toRect.width).to.be.greaterThan(0);
-        const fromShare = fromRect.width / (fromRect.width + toRect.width);
-        await expect(fromShare).to.be.within(0.4, 0.6);
+
+        // The two inputs' text areas (.mainContent) are equal so the labels truncate
+        // symmetrically. The From container is intentionally wider than To to offset the
+        // calendar icon in its accent-left, so the *container* widths are not 50/50.
+        const fromMain = getInput(el, 0).shadowRoot.querySelector('.mainContent').getBoundingClientRect().width;
+        const toMain = getInput(el, 1).shadowRoot.querySelector('.mainContent').getBoundingClientRect().width;
+        await expect(Math.abs(fromMain - toMain)).to.be.at.most(1);
+      });
+
+      // Regression: the calendar icon renders only in the range-start (From) input, so with
+      // equal container widths the From date/placeholder truncated well before the To one.
+      // The From container is now widened by the icon's footprint, so both inputs' text areas
+      // (.mainContent) are equal and the dates truncate in lockstep. Pre-fix the From text
+      // area was ~28px narrower than the To's at this width.
+      it('gives both range inputs equal text width so the dates truncate in lockstep', async () => {
+        const el = await fixture(html`
+          <auro-datepicker range value="2026-07-30" valueEnd="2026-08-06" style="display: block; width: 200px;">
+            <span slot="fromLabel">Departure</span>
+            <span slot="toLabel">Return</span>
+          </auro-datepicker>
+        `);
+
+        await elementUpdated(el);
+        await nextFrame();
+
+        const fromMain = getInput(el, 0).shadowRoot.querySelector('.mainContent');
+        const toMain = getInput(el, 1).shadowRoot.querySelector('.mainContent');
+
+        await expect(fromMain).to.exist;
+        await expect(toMain).to.exist;
+
+        const fromWidth = fromMain.getBoundingClientRect().width;
+        const toWidth = toMain.getBoundingClientRect().width;
+
+        await expect(fromWidth).to.be.greaterThan(0);
+        await expect(Math.abs(fromWidth - toWidth)).to.be.at.most(1);
       });
 
     });

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -1922,6 +1922,36 @@ function runFullTest(mobileView) {
         await expect(getInput(el, 1).value).to.equal('2023-02-28');
       });
 
+      // Regression: a long fromLabel/toLabel used to stretch the first input and push the
+      // range-end input out of view. Both inputs should now split the row ~50/50 and the
+      // end input must stay within the component's box (labels truncate via ellipsis instead).
+      it('keeps both range inputs on-screen and evenly sized when labels are long', async () => {
+        const longLabel = 'Departure with an extremely long label that should truncate rather than expand the input beyond its allotted half of the row';
+
+        const el = await fixture(html`
+          <auro-datepicker range style="display: block; width: 320px;">
+            <span slot="fromLabel">${longLabel}</span>
+            <span slot="toLabel">${longLabel}</span>
+          </auro-datepicker>
+        `);
+
+        await elementUpdated(el);
+        await nextFrame();
+
+        const hostRect = el.getBoundingClientRect();
+        const fromRect = getInput(el, 0).getBoundingClientRect();
+        const toRect = getInput(el, 1).getBoundingClientRect();
+
+        // The range-end input must not be pushed outside the component (allow 1px rounding).
+        await expect(toRect.right).to.be.at.most(hostRect.right + 1);
+
+        // Both inputs render with real width and split the available space ~50/50.
+        await expect(fromRect.width).to.be.greaterThan(0);
+        await expect(toRect.width).to.be.greaterThan(0);
+        const fromShare = fromRect.width / (fromRect.width + toRect.width);
+        await expect(fromShare).to.be.within(0.4, 0.6);
+      });
+
     });
 
     describe('referenceDates', () => {

--- a/docs/post-mortem/1494482.md
+++ b/docs/post-mortem/1494482.md
@@ -95,8 +95,8 @@ The functional change is two files — `components/datepicker/src/styles/style.s
 
 ## Receipts
 
-**Fix (PR [#1562](https://github.com/AlaskaAirlines/auro-formkit/pull/1562), branch `jjones/labelEllipsis/AB#1494482`):**
-- `components/datepicker/src/styles/style.scss` — added a `:host([range])` block giving `.inputContainer` `flex: 1 1 0; min-width: 0` and `.dateFrom, .dateTo` `min-width: 0`; `.inputContainer` keeps its original `width: 100%` for single-input mode. (Backfill the commit SHA + blob links after merge, matching the other post-mortems.)
+**Fix (commit `0b6923244`, PR [#1562](https://github.com/AlaskaAirlines/auro-formkit/pull/1562), branch `jjones/labelEllipsis/AB#1494482`):**
+- `components/datepicker/src/styles/style.scss` — added a `:host([range])` block giving `.inputContainer` `flex: 1 1 0; min-width: 0` and `.dateFrom, .dateTo` `min-width: 0`; `.inputContainer` keeps its original `width: 100%` for single-input mode.
 - `components/datepicker/test/auro-datepicker.test.js` — added "keeps both range inputs on-screen and evenly sized when labels are long" to the `range` describe block.
 - Generated `components/datepicker/src/styles/style-css.js` is gitignored (rebuilt by the pipeline); only the `.scss` source is tracked.
 

--- a/docs/post-mortem/1494482.md
+++ b/docs/post-mortem/1494482.md
@@ -1,0 +1,116 @@
+# Post-Mortem: Range Datepicker Long Labels Push Range-End Input Off-Screen (AB#1494482)
+
+**Scope:** Fix a range `auro-datepicker` layout bug where a long `fromLabel`/`toLabel` stretched the first input to full width and pushed the second (range-end) input out of the visible area. Intended behavior: both inputs share the row ~50/50 at all times, with over-long labels truncating. Change is scoped to `auro-datepicker` styles plus a regression test — no `auro-input` change.
+
+## Reference Documents
+- Work item — [AB#1494482](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1494482)
+- Prior related fix (red herring) — `35c2998bd` "fix: label layouts to account for overflow", shipped in **v5.0.0** (2025-07-25)
+
+## Quick Reference
+
+| Symptom | Why it happens | Fix |
+|---|---|---|
+| A range datepicker with a long From/To label shows only one input; the range-end input is clipped or pushed out of view | `.inputContainer` carried `width: 100%` with the flexbox default `min-width: auto`, so the first input couldn't shrink below its label's min-content width, consumed the whole row, and pushed the sibling past the `.mainContent { overflow: hidden }` edge | Give each half `flex: 1 1 0; min-width: 0` (plus `min-width: 0` on `.dateFrom`/`.dateTo`) so the two halves stay ~50/50 and can shrink |
+| Long labels "don't truncate" even though `auro-input` has ellipsis rules | The label's `overflow` / `text-overflow` / `white-space` are already correct, but nothing bounded the input width — the box grew to fit the text, so `text-overflow` had no overflow to act on | Bound the width (`min-width: 0` up the flex chain); the existing ellipsis then engages — no new truncation CSS needed |
+| Git history says AB#1494482 was "fixed in v5.0.0" (`35c2998bd`) | That commit added ellipsis to the snowflake `.mainLabel` — a different element and symptom than the classic range inputs | Treat it as unrelated; the range-input overflow was never actually fixed until this change |
+| Tempted to fix truncation in `auro-input` so all consumers benefit | Combobox is the only other `auro-input` consumer, and it's single-input and already correct — a shared change is all risk and no upside | Scope the fix to `auro-datepicker` styles only |
+| The ticket's "Custom Bib Position" repro example can't be found | That docs example no longer exists; the ticket is stale | Re-derive the repro from the live component (range mode + long `fromLabel`), not the ticket text |
+
+## What Landed vs. What Was Planned
+
+| Planned | Status |
+|---|---|
+| Reproduce the reported bug | Done — original symptom was stale; re-scoped with reporter to the real bug (range mode, long `fromLabel`). |
+| Identify root cause | Done — flexbox `min-width: auto` on `.inputContainer` prevents 50/50 shrink. |
+| Truncate long labels with ellipsis | Done — but ellipsis already existed in `auro-input`; the fix was to let it engage, not to add it. |
+| Keep the fix scoped / avoid regressions in other consumers | Done — datepicker-only; combobox untouched. |
+| Add a regression guard | Done — WTR test asserting the range-end input stays within the component and the two inputs split ~50/50. |
+| Verify at runtime | Done — Playwright before/after measurement + screenshots at 340px and 520px. |
+
+## What Was Not in the Plan but Also Shipped
+
+1. **The "fixing release" investigation had to be discarded.** The first pass through git history landed confidently on v5.0.0 as the release that fixed AB#1494482, based on commit `35c2998bd` ("fix: label layouts to account for overflow"). That commit is real and did fix a truncation issue — but on the snowflake `.mainLabel`, not the range inputs. The actual bug was never fixed; it was mis-scoped. Time was spent proving a release attribution that turned out to be answering the wrong question.
+2. **The ellipsis was already present.** The initial mental model ("labels don't truncate → add truncation") was wrong. `auro-input`'s classic label already had `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`. Reading the dependency's styles before editing avoided a redundant, wrongly-placed change.
+3. **Scratch repro fixtures were reverted.** Keyboard-mash long labels had been dropped into `apiExamples/basic.html` and `range.html` during repro. These were reverted so they don't ship; the WTR test is the durable guard instead.
+
+## What Went Right
+- Reporter re-scoping ("it's the range layout, not the ellipsis") redirected the investigation before more effort went into the wrong fix.
+- Runtime before/after verification caught that the assumed-missing behavior (ellipsis) already existed — the fix was elsewhere.
+- The regression test was validated by proving it *fails* on the pre-fix CSS (`expected 657 to be at most 329`), so it's a genuine guard rather than a happy-path replay.
+
+## What Went Wrong / What the Investigation Missed
+- **A stale ticket cost real time.** The description referenced a removed docs example and framed a symptom (truncation) adjacent to — but not the same as — the real bug. This produced a confident-but-wrong "fixed in v5.0.0" conclusion on the first pass.
+- **Symptom-level phrasing masked the mechanism.** "Labels don't truncate" reads as a text problem; it was a flexbox min-width problem. The truncation was a consequence that couldn't fire, not the cause.
+
+## Root Cause
+
+The range layout renders two `.inputContainer` halves inside a flex row (`components/datepicker/src/styles/style.scss`):
+
+```scss
+.inputSection   { display: flex; flex-direction: row; width: 100%; }
+.inputContainer { display: flex; width: 100%; }   // ← the problem
+```
+
+Two flex items at `width: 100%` should shrink to 50/50, but the flexbox default **`min-width: auto`** stops a flex item from shrinking below its content's min-content width. A `white-space: nowrap` label gave the first input a large min-content width, so it refused to shrink, took more than half the row, and pushed the sibling past the component edge (where `.mainContent { overflow: hidden }` clipped it). Because the box grew to fit the text instead of clipping it, `auro-input`'s existing label ellipsis never had an overflow to act on.
+
+## Resolution
+
+`components/datepicker/src/styles/style.scss` — scoped to `:host([range])` so single-input datepickers keep their original `width: 100%` behavior:
+
+```scss
+.inputContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;   // unchanged — single-input mode
+}
+
+// Range mode only: two equal, shrinkable halves.
+:host([range]) {
+  .inputContainer {
+    flex: 1 1 0;    // equal halves regardless of content
+    min-width: 0;   // allow shrink below min-content → ellipsis engages
+  }
+
+  .dateFrom,
+  .dateTo {
+    min-width: 0;   // propagate the shrink into the nested inputs
+  }
+}
+```
+
+## Verification
+- **Runtime (Playwright, local build):** long-label range markup at 340px and 520px measured ~51.8% / ~48.2%; range-end input stayed within the component; labels ellipsized. Reverting the rule reproduced the bug — first input full width, second input's right edge ~657px against a 320px component.
+- **Regression test** (`components/datepicker/test/auro-datepicker.test.js`, `range` describe): asserts the range-end input's right edge stays within the host and the inputs split ~50/50. Full suite **952 passing** (desktop + small-viewport runs).
+- **Negative check:** reverting the CSS made exactly the new test fail (`expected 657 to be at most 329`) in both viewport runs, and only that test — confirming the guard.
+
+## Outcome
+The functional change is two files — `components/datepicker/src/styles/style.scss` (styles) and `components/datepicker/test/auro-datepicker.test.js` (regression test); this post-mortem ships alongside them as a third, non-functional file. Range inputs hold ~50/50 at all widths; over-long labels truncate via the existing ellipsis. Single-input datepickers keep their original full-width behavior (the range styles are scoped to `:host([range])`). No `auro-input` change; combobox unaffected. 952 datepicker tests pass; regression proven to catch the pre-fix state.
+
+## Recommendations for Future Datepicker/Layout Bugs
+1. When a flex child overflows its row or won't share space, check `min-width: auto` first. `min-width: 0` is the canonical fix; reach for it before adding more CSS.
+2. Verify the assumed-missing behavior is actually missing. Read the dependency's compiled styles before "adding" a property that may already exist one shadow level down.
+3. For old tickets referencing removed examples, re-derive the repro from the live component. Don't trust a git-history "fixed in vX" conclusion until the current symptom is reproduced firsthand.
+4. Scope shared-component changes by enumerating consumers. `auro-input` has exactly two consumers (datepicker, combobox); a change "for everyone" is a combobox change whether intended or not.
+
+## Receipts
+
+**Fix (PR [#1562](https://github.com/AlaskaAirlines/auro-formkit/pull/1562), branch `jjones/labelEllipsis/AB#1494482`):**
+- `components/datepicker/src/styles/style.scss` — added a `:host([range])` block giving `.inputContainer` `flex: 1 1 0; min-width: 0` and `.dateFrom, .dateTo` `min-width: 0`; `.inputContainer` keeps its original `width: 100%` for single-input mode. (Backfill the commit SHA + blob links after merge, matching the other post-mortems.)
+- `components/datepicker/test/auro-datepicker.test.js` — added "keeps both range inputs on-screen and evenly sized when labels are long" to the `range` describe block.
+- Generated `components/datepicker/src/styles/style-css.js` is gitignored (rebuilt by the pipeline); only the `.scss` source is tracked.
+
+**Reverted scratch fixtures (repro only, not shipped):**
+- `components/datepicker/apiExamples/basic.html`
+- `components/datepicker/apiExamples/range.html`
+
+**Pre-existing truncation ellipsis relied on by the fix:**
+- [`components/input/src/styles/classic/style.scss`](https://github.com/AlaskaAirlines/auro-formkit/blob/dev/components/input/src/styles/classic/style.scss) — classic `label` already has `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`.
+
+**Red-herring release attribution (real commit, wrong bug):**
+- [`35c2998bd`](https://github.com/AlaskaAirlines/auro-formkit/commit/35c2998bd) "fix: label layouts to account for overflow" — added ellipsis to the snowflake `.mainLabel`; shipped in **v5.0.0** (2025-07-25). Not the fix for AB#1494482.
+
+**Verification measurements (Playwright, local, 320–520px):**
+- After fix: from ≈51.8% / to ≈48.2% (340px), from ≈51.2% / to ≈48.8% (520px); range-end input within host; no overflow.
+- Before fix (rule reverted): first input full width; range-end input right edge ≈657px vs component right ≈329px.
+- Negative test result: `AssertionError: expected 657 to be at most 329` in both desktop and small-viewport runs; 950 passed / 2 failed (the new test ×2).

--- a/docs/post-mortem/1602084.md
+++ b/docs/post-mortem/1602084.md
@@ -1,0 +1,121 @@
+# Post-Mortem: Range Datepicker Date Value Truncates Asymmetrically at Small Widths (AB#1602084)
+
+**Scope:** Fix a range `auro-datepicker` bug where, at small widths, one input's date value/placeholder was cut off while the other's ellipsized cleanly — the "one date is chopped, the other trails off" asymmetry. Intended behavior: both inputs expose the same amount of text room so their values (and labels) truncate in lockstep. Change is scoped to `auro-datepicker` classic styles plus regression tests — no `auro-input` change. Follow-up to [AB#1494482](./1494482.md) (the range 50/50 off-screen fix this builds on).
+
+## Reference Documents
+- Work item — [AB#1602084](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1602084)
+- Prior fix this builds on — [`docs/post-mortem/1494482.md`](./1494482.md) (equal `flex: 1 1 0` halves + `min-width: 0`)
+- Working handoff used during the session — [`docs/post-mortem/1494482-followup-handoff.md`](./1494482-followup-handoff.md)
+- Fix commit — `a89b4b489` "fix: ellipses dp value at small widths AB#1602084" (2026-07-22)
+
+## Quick Reference
+
+| Symptom | Why it happens | Fix |
+|---|---|---|
+| In a range datepicker at small widths, the From date/placeholder gets clipped much sooner than the To date, which ellipsizes normally | The calendar icon renders only in the From (range-start) input's `accent-left`. With both halves at an equal flex-basis, From's *text area* (`.mainContent`) was ~28px narrower than To's (43px vs 71px at 200px), so From's value truncated first | Widen **only** the From container's flex-basis by `icon footprint − To's margin`, so the two *text areas* are equal and truncate in lockstep |
+| Looks like a broken-ellipsis bug in `auro-input` | `auro-input` is not buggy — its single `.mainContent` correctly flexes to the space left after the icon and ellipsizes both label and value | Don't touch `auro-input`; mirror its behavior in the range split |
+| The two halves are equal width but the *text* still isn't | Equal container width ≠ equal text width when one container spends ~40px on an icon | Balance the **text areas**, not the containers — the divider ends up slightly right-of-center by design |
+| Clear (×) button spills past an input on hover at very narrow widths | `min-width: 0` (from AB#1494482) lets a half shrink below its icon+clear content | **Not fixed — out of scope.** Only occurs below ~160px, under the 320px minimum supported width (see below) |
+
+## What Landed vs. What Was Planned
+
+| Planned | Status |
+|---|---|
+| Reproduce the asymmetric value truncation | Done — measured at 200px: both halves 99px, but From text area 43px vs To 71px (28px gap). |
+| Identify root cause | Done — the icon lives only in the From half, so equal flex-basis leaves From's text area narrower. |
+| Make both values/labels truncate in lockstep | Done — widen From's flex-basis by the icon footprint minus To's existing margin. |
+| Keep the To input's layout exactly as-is | Done — To's `margin-left` and hidden `accent-left` are byte-for-byte unchanged; only From's basis moved. |
+| Keep the fix scoped / avoid regressions | Done — classic-range only; `auro-input` and combobox untouched. |
+| Add a regression guard | Done — updated the AB#1494482 long-label test to assert equal `.mainContent` widths, and added a preset-value lockstep test at 200px. |
+| Verify at runtime | Done — Playwright `.mainContent` measurements at 120/160/200/260px; negative-checked. |
+
+## What Was Investigated but Deliberately NOT Shipped
+
+The reported issue mentioned the value **and hover**. The "hover" angle is the clear (×) button, which `auro-input` reveals only on hover/focus. At very narrow widths the clear could overflow its input's edge, and a full fix was built during the session:
+
+1. **Per-half `min-width` floors** (From = icon + clear ≈ 84px; To = clear + margin ≈ 56px) so a half can't shrink below its non-shrinkable content.
+2. **A host `min-width`** publishing the component's intrinsic minimum (both floors + divider ≈ 141px).
+3. **`flex-shrink: 0` on the divider** so it can't be collapsed to absorb over-constraint.
+
+**All three were reverted before shipping.** Mid-session it was confirmed that **320px is the minimum supported screen size** across the org, and it is common knowledge that Auro components must not break layout at that width. None of these constraints engage at or above 320px — a range row at 320px gives each half ~150–160px, far above the floors; the clear buttons fit; the divider has room. The constraints only did anything in the 120–160px range, which is below spec. Worse, the host `min-width` is the one change that could *cause* the exact failure the org guards against — a component that refuses to shrink can overflow a container. So the min-width work was dropped and only the balance fix (which is visible and correct at every supported width) shipped.
+
+## What Went Right
+- **Isolating the icon as the only asymmetry.** With the halves already equal (from AB#1494482), the sole remaining divergence was one accent the To half doesn't carry. Naming that reduced the fix to a single flex-basis nudge instead of a rework.
+- **Measuring text areas, not containers.** The bug hid behind "equal halves" — the containers *were* equal; the text areas weren't. Measuring `.mainContent` directly exposed the 28px gap and gave the fix its exact value (icon footprint − To margin).
+- **The 320px reframe.** Learning the supported-width floor turned a plausible "defense-in-depth" change into recognizably dead (and slightly risky) code, and it was removed rather than shipped.
+- **Genuine regression guards.** Both tests were proven to *fail* on pre-fix CSS (`expected 28 to be at most 1`) in desktop and small-viewport runs.
+
+## What Went Wrong / What the Investigation Missed
+- **Nearly shipped constraints for below-spec widths.** Real effort went into the clear-button-on-hover overflow before the 320px minimum was surfaced. Had the supported-width floor been established up front, that whole branch would have been scoped out immediately. The overflow is real, but only below spec.
+- **Symptom phrasing ("value and hover") bundled two problems.** The *value* asymmetry (shipped fix) and the *hover* clear overflow (out of scope) share a root token — the icon on one side — but have different severities and different width regimes. Separating them took a measurement pass.
+
+## Root Cause
+
+In classic range mode the row is two equal, shrinkable halves (from AB#1494482): `.inputContainer { flex: 1 1 0; min-width: 0 }`. But the calendar icon renders only in the **From** input's `accent-left`, consuming its footprint from that half:
+
+- icon = `--ds-size-400` (32px) + its padding `--ds-size-100` (8px) = **40px**
+- To's text area only loses its `margin-left` = `--ds-size-150` (**12px**)
+
+So at equal container width, From's text area is `40 − 12 = 28px` narrower than To's (measured 43px vs 71px at a 200px component). `auro-input` ellipsizes each input's value correctly against *its own* `.mainContent` — but From's is smaller, so From's date/placeholder hit the ellipsis (or clip) well before To's. The asymmetry was a layout imbalance, not a truncation bug.
+
+## Resolution
+
+`components/datepicker/src/styles/classic/style.scss` — one rule, scoped to classic range:
+
+```scss
+// Range: the calendar icon renders only in the From half, so at equal flex-basis
+// From's text area was narrower than To's and its label/date truncated first. Widen
+// From's basis by the icon footprint minus To's existing margin so both text areas
+// match and truncate in lockstep. To is unchanged. Scoped to classic (icon lives here).
+:host([layout*='classic'][range]) {
+  .inputContainer:first-of-type {
+    flex: 1 1 calc(var(--ds-size-400, 2rem) + var(--ds-size-100, 0.5rem) - var(--ds-size-150, 0.75rem));
+  }
+}
+```
+
+**Why that value:** From needs to make up the icon footprint (`--ds-size-400 + --ds-size-100` = 40px) minus what To already gives up to its margin (`--ds-size-150` = 12px) → 28px of extra container so the two text areas end up equal. Expressed in tokens so it stays correct if the tokens change. The To input, the divider, and the base `min-width` rules are untouched; the divider lands slightly right-of-center by design (From half is intentionally wider).
+
+## Verification
+- **Runtime (Playwright, local build):** `.mainContent` widths equal at every width tested — 17/17 (120px), 37/37 (160px), 57/57 (200px), 87/87 (260px). Labels *and* values/placeholders truncate in lockstep. To's `margin-left`, hidden `accent-left`, and the divider are unchanged.
+- **Regression tests** (`components/datepicker/test/auro-datepicker.test.js`, `range` describe):
+  - Updated "keeps both range inputs on-screen and evenly sized when labels are long" to assert **equal `.mainContent` widths** (the correct new invariant) instead of the now-stale ~50/50 *container* check; kept the on-screen guard.
+  - Added "gives both range inputs equal text width so the dates truncate in lockstep" (preset ISO values, 200px).
+- **Negative check:** both tests fail `expected 28 to be at most 1` on pre-fix CSS in both the desktop and small-viewport runs — genuine guards. Full suite **954 passing** after the fix.
+
+## Outcome
+The functional change is two files — `components/datepicker/src/styles/classic/style.scss` (one added rule) and `components/datepicker/test/auro-datepicker.test.js` (one test updated, one added); this post-mortem ships alongside as a non-functional third file. Range date values and labels now truncate symmetrically at every supported width; single-input and non-classic layouts are untouched. No `auro-input` change; combobox unaffected. The clear-button-on-hover overflow was investigated and intentionally left unfixed as a below-spec (sub-320px) concern.
+
+## Recommendations for Future Datepicker/Layout Bugs
+1. **Establish the supported-width floor before designing width-sensitive CSS.** 320px is the org-wide minimum. Constraints that only fire below it are dead weight at best and layout-breaking (host `min-width`) at worst. Confirm the width regime a symptom lives in before building for it.
+2. **Measure the text area, not the container.** "Equal halves" can still truncate unequally when one half spends space on an icon/accent. Measure `.mainContent` (or the actual text box) directly.
+3. **Mirror the dependency, don't patch it.** `auro-input` already flexes its `.mainContent` to the space after the icon and ellipsizes correctly; the range split just had to reproduce that per-half. The imbalance was created by the datepicker's own layout, so that's where it was corrected. (For *why* the shared `auro-input` was off-limits, see AB#1494482's consumer-scoping note.)
+4. **Prefer tokens over magic numbers in derived widths.** The `calc(icon + padding − margin)` stays correct if the design tokens move; a hard-coded `28px` would silently drift.
+
+## Latent issues parked (not in scope for AB#1602084)
+- **Non-classic value clipping.** In `emphasized`/`snowflake`, the value renders via the `displayValue` slot span (`renderDisplayTextDate` → `.displayValueText`), which **hard-clips with no ellipsis** — `auro-input`'s `.displayValue` is `overflow: visible` with no `text-overflow`, and the intermediate `.displayValueWrapper` (a flex item with `min-width: auto`, not reachable via `::part`) won't shrink. Fixing it needs a small `auro-input` change (bind `.displayValueWrapper` with `min-width: 0; overflow: hidden`) + `text-overflow: ellipsis` on `.displayValueText`. Not needed for the classic (default) fix. Proven via live style injection.
+- **Clear-button overflow on hover below ~160px** — see "What Was Investigated but Deliberately NOT Shipped." Below the 320px minimum; not fixed.
+
+## Receipts
+
+**Fix (commit `a89b4b489`, branch `jjones/labelEllipsis/AB#1494482`):**
+- `components/datepicker/src/styles/classic/style.scss` — added `:host([layout*='classic'][range]) .inputContainer:first-of-type { flex: 1 1 calc(--ds-size-400 + --ds-size-100 − --ds-size-150) }`.
+- `components/datepicker/test/auro-datepicker.test.js` — updated the long-label test to assert equal `.mainContent` widths; added "gives both range inputs equal text width so the dates truncate in lockstep".
+- Generated `*-css.js` / `*.css` are gitignored (rebuilt by the pipeline); only the `.scss` source is tracked.
+
+**Reverted mid-session (built, then removed after the 320px minimum was confirmed):**
+- `.inputDivider { flex-shrink: 0 }`, host `min-width`, and per-half `.inputContainer` `min-width` floors in `classic/style.scss`, plus two 120px regression tests. Net change to source vs. `a89b4b489` is zero.
+
+**Approaches tried and rejected (do not re-tread):**
+- Single shared calendar icon on the datepicker's left accent — balanced perfectly but a positional/layout change to the icons, **designer-sensitive and off-limits**.
+- Single shared clear button on the datepicker's right accent — balanced but **changes functional behavior** (clears both dates); both inputs must keep their own clear.
+- Reserving the clear button's width on both inputs (`::part(accent-right) { min-width }`) — **rejected** (added empty space, changed the second input's layout).
+- `display: block !important` on `::part(displayValue)` — **broke** the snowflake/emphasized layouts.
+- Removing To's `margin-left` + symmetric divider margin — **rejected**; To must remain exactly as-is (hence the `− --ds-size-150` compensation on From only).
+
+**Key facts learned (saves re-investigation) — specific to the *value*, distinct from AB#1494482's *label* findings:**
+- The value has two render paths: `classic` (default) shows it in the native `<input>`, which **ellipsizes** (`overflow: clip` + `text-overflow`, confirmed in Chromium and WebKit); `emphasized`/`snowflake` use the `displayValue` span, which **hard-clips** (parked above). This fix concerns only the classic path.
+- `auro-input type="date"` `value` is a locale-independent ISO model (`yyyy-mm-dd`), not the display format — prefill `value="2026-07-30"`, not `"07/30/2026"` (the latter yields `patternMismatch`). This is why the lockstep test uses ISO values.
+
+**Scratch fixtures (repro only, not shipped):**
+- A narrow-width repro page was dropped into `apiExamples/` during investigation and reverted before this PR (the docs generator scans that dir and would otherwise pull it into `customize.md`). Per the AB#1494482 convention, the WTR regression tests are the durable guard, not a checked-in example page.


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1494482
https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1602084

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure range datepicker inputs remain visible and evenly sized when labels are long, and document the bug and its resolution.

Bug Fixes:
- Prevent long from/to labels in range auro-datepicker from stretching the first input and pushing the range-end input out of view.

Enhancements:
- Adjust range datepicker input layout so both inputs consistently share the available width roughly 50/50 and allow existing label truncation to engage.

Documentation:
- Add a post-mortem document describing the range datepicker long-label overflow issue, its root cause, and the implemented fix.

Tests:
- Add a regression test confirming both range inputs stay within the component and split the row evenly when labels are long.