### PR TITLE
fix(select): restore trigger ellipsis truncation AB#1594470

### DIFF
--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -63,8 +63,12 @@
   justify-content: center;
 }
 
-.valueContainer [slot="displayValue"] {
-  display: none;
+.valueContainer {
+  max-width: 100%;
+
+  [slot="displayValue"] {
+    display: none;
+  }
 }
 
 .accents {
@@ -93,6 +97,7 @@
 .triggerContent {
   display: flex;
   width: 100%;
+  box-sizing: border-box;
   align-items: center;
   justify-content: center;
 }
@@ -132,7 +137,10 @@
   }
 
   .value {
+    overflow: hidden;
     height: auto;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 

--- a/components/select/src/styles/style.scss
+++ b/components/select/src/styles/style.scss
@@ -65,10 +65,6 @@
 
 .valueContainer {
   max-width: 100%;
-
-  [slot="displayValue"] {
-    display: none;
-  }
 }
 
 .accents {

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -3,6 +3,7 @@
 import { Meta, StoryObj } from '@storybook/web-components-vite';
 import { expect, userEvent } from 'storybook/test';
 import { html } from 'lit-html';
+import type { AuroSelect } from '../src/index';
 import '../../menu/src/registered';
 
 import '../src/registered';
@@ -75,8 +76,8 @@ export const SelectLongValueEllipsis: Story = {
     const value = el.shadowRoot?.querySelector('#value') as HTMLDivElement | null;
     const dropdown = el.shadowRoot?.querySelector('[auro-dropdown]') as HTMLElement | null;
     const triggerContent = dropdown?.querySelector('#triggerFocus') as HTMLDivElement | null;
-    const wrapper = dropdown?.shadowRoot?.querySelector('.triggerContentWrapper') as HTMLDivElement | null;
-    const chevron = dropdown?.shadowRoot?.querySelector('.chevron') as HTMLDivElement | null;
+    const wrapper = dropdown?.shadowRoot?.querySelector('#triggerLabel') as HTMLDivElement | null;
+    const chevron = dropdown?.shadowRoot?.querySelector('#showStateIcon') as HTMLDivElement | null;
 
     if (!value || !dropdown || !triggerContent || !wrapper || !chevron) {
       throw new Error('Failed to find select trigger elements for the truncation assertion.');
@@ -86,7 +87,13 @@ export const SelectLongValueEllipsis: Story = {
     const triggerContentRect = triggerContent.getBoundingClientRect();
     const wrapperRect = wrapper.getBoundingClientRect();
     const chevronRect = chevron.getBoundingClientRect();
+    const valueStyles = getComputedStyle(value);
+    const wrapperStyles = getComputedStyle(wrapper);
 
+    await expect(valueStyles.textOverflow).toBe('ellipsis');
+    await expect(valueStyles.whiteSpace).toBe('nowrap');
+    await expect(wrapperStyles.overflowX === 'hidden' || wrapperStyles.overflow === 'hidden').toBe(true);
+    await expect(value.scrollWidth).toBeGreaterThan(value.clientWidth);
     await expect(triggerContentRect.right).toBeLessThanOrEqual(wrapperRect.right + 0.5);
     await expect(valueRect.right).toBeLessThanOrEqual(chevronRect.left + 0.5);
   },

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -51,6 +51,47 @@ export const SelectDefault: Story = {
   `,
 };
 
+// ─── Long selected value truncates before chevron ─────────────────────────────
+export const SelectLongValueEllipsis: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select style="width: 230px" value="long label">
+  <span slot="label">Select Example</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="long label">Verify the trigger truncates with ellipsis in classic layout without clipping the chevron area</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as AuroSelect;
+    const menu = el.querySelector('auro-menu') as HTMLElement & { updateComplete?: Promise<void> };
+
+    await el.updateComplete;
+    await menu.updateComplete;
+    await el.dropdown.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+    const value = el.shadowRoot?.querySelector('#value') as HTMLDivElement | null;
+    const dropdown = el.shadowRoot?.querySelector('[auro-dropdown]') as HTMLElement | null;
+    const triggerContent = dropdown?.querySelector('#triggerFocus') as HTMLDivElement | null;
+    const wrapper = dropdown?.shadowRoot?.querySelector('.triggerContentWrapper') as HTMLDivElement | null;
+    const chevron = dropdown?.shadowRoot?.querySelector('.chevron') as HTMLDivElement | null;
+
+    if (!value || !dropdown || !triggerContent || !wrapper || !chevron) {
+      throw new Error('Failed to find select trigger elements for the truncation assertion.');
+    }
+
+    const valueRect = value.getBoundingClientRect();
+    const triggerContentRect = triggerContent.getBoundingClientRect();
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const chevronRect = chevron.getBoundingClientRect();
+
+    await expect(triggerContentRect.right).toBeLessThanOrEqual(wrapperRect.right + 0.5);
+    await expect(valueRect.right).toBeLessThanOrEqual(chevronRect.left + 0.5);
+  },
+};
+
 // ─── §2.1.1  Open dropdown and select an option (P0) ────────────────────────
 export const SelectOpenAndSelectOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
@@ -785,4 +826,3 @@ export const SelectInverseError: Story = {
 </div>
   `,
 };
-

--- a/docs/post-mortem/1594470.md
+++ b/docs/post-mortem/1594470.md
@@ -1,0 +1,127 @@
+# Post-Mortem: Select trigger ellipsis not working (AB#1594470)
+
+**Branch:** `rmenner/select/ellipsis-long-label`
+
+**Scope:** Two SCSS changes in `auro-select`'s selected-value path, plus one Storybook regression story.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| A long selected value does **not** show an ellipsis at all | Check the selected-value element for the core truncation trio: `overflow: hidden`, `white-space: nowrap`, and `text-overflow: ellipsis`. |
+| A long selected value truncates, but the ellipsis or trailing characters disappear under the select chevron | Check the trigger sizing. Here `.triggerContent` had `width: 100%` plus padding under `content-box`, so the text region ran into the chevron area. |
+
+## The Bug
+
+The ticket started as a plain ellipsis failure. In a constrained-width classic select, a long selected value did not truncate at all.
+
+Once the value had ellipsis styles, the second issue showed up. The text area still ran under the chevron. So this was one truncation bug with two parts:
+
+1. The selected value needed the core truncation styles
+2. The trigger content needed to fit inside the visible trigger width, padding included
+
+Both had to be fixed before the select behaved correctly.
+
+## Root Causes
+
+There were two defects in the same path.
+
+### 1. The selected value was missing the full truncation setup
+
+In `components/select/src/styles/style.scss`, the classic-layout `.value` rule needed the core truncation trio:
+
+- `overflow: hidden`
+- `white-space: nowrap`
+- `text-overflow: ellipsis`
+
+That path also needed a width boundary. `.valueContainer` now uses `max-width: 100%`.
+
+### 2. The trigger box was wider than the visible text region
+
+Once the value could ellipsize, the layout issue was easy to see.
+
+The trigger markup inside `components/select/src/auro-select.js` renders:
+
+```html
+<div slot="trigger" id="triggerFocus" class="triggerContent">
+  <div class="accents left">...</div>
+  <div class="mainContent">...</div>
+  <div class="accents right"></div>
+</div>
+```
+
+In `components/select/src/styles/style.scss`, `.triggerContent` was styled with:
+
+```scss
+.triggerContent {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+At the same time, the classic layout added horizontal padding:
+
+```scss
+:host([layout*='classic']) {
+  .triggerContent {
+    padding: 0 var(--ds-size-100, vac.$ds-size-100);
+  }
+}
+```
+
+Because `box-sizing` was still `content-box`, the padding sat on top of the declared width. That made the trigger content wider than the visible text region, so the selected value could slide under the chevron from `auro-dropdown`.
+
+## The Fix
+
+The fix had two parts:
+
+### 1. Make the selected value ellipsize
+
+In `components/select/src/styles/style.scss`:
+
+```scss
+.valueContainer {
+  max-width: 100%;
+}
+
+.value {
+  height: auto;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+```
+
+This gave the selected value a real truncation path.
+
+### 2. Make the trigger width include its padding
+
+In the same file:
+
+```scss
+.triggerContent {
+  display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+With `border-box`, the trigger width includes its padding. The text stays out of the chevron.
+
+## Storybook Regression Coverage
+
+The regression story lives in `components/select/stories/component.stories.ts` as:
+
+- `SelectLongValueEllipsis`
+
+It renders the narrow selected state directly:
+
+- fixed width (`230px`)
+- pre-selected value (`value="long label"`)
+- long selected option label
+
+That keeps the story simple and gives Chromatic a stable target.


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request addresses a long-standing issue where long selected values in the `auro-select` component would not properly truncate with an ellipsis, and in some cases, the text would run under the chevron. The fix includes SCSS changes to ensure correct ellipsis behavior and trigger sizing, as well as a new Storybook regression test to prevent future regressions.

**SCSS fixes for truncation and layout:**

* Ensured the selected value truncates with an ellipsis by adding `overflow: hidden`, `white-space: nowrap`, and `text-overflow: ellipsis` to the `.value` class, and set `.valueContainer` to `max-width: 100%` (`components/select/src/styles/style.scss`) [[1]](diffhunk://#diff-90e3edfb9da105ab1eee353937c4eddfc5e1a0f64eb71a231850697456a08728L66-R72) [[2]](diffhunk://#diff-90e3edfb9da105ab1eee353937c4eddfc5e1a0f64eb71a231850697456a08728R140-R143).
* Updated `.triggerContent` to use `box-sizing: border-box` so its width includes padding, preventing the selected value from sliding under the chevron (`components/select/src/styles/style.scss`).

**Regression test coverage:**

* Added a new Storybook story, `SelectLongValueEllipsis`, which verifies that long selected values are truncated with an ellipsis and do not overlap the chevron (`components/select/stories/component.stories.ts`).

**Documentation:**

* Added a detailed post-mortem explaining the root causes, fixes, and lessons learned from this bug (`docs/post-mortem/1594470.md`).

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix auro-select trigger layout so long selected values truncate with an ellipsis without overlapping the chevron, and add regression coverage and documentation for the issue.

New Features:
- Add a Storybook story that demonstrates and validates ellipsis truncation for long selected values in auro-select.

Enhancements:
- Adjust auro-select trigger and selected-value styling to enforce proper truncation and constrain content width within the trigger.

Documentation:
- Add a post-mortem document detailing the root causes, fixes, and lessons learned from the select trigger ellipsis bug.

Tests:
- Add a Storybook regression test that asserts the selected value and trigger content remain within the visible trigger area and do not clip under the chevron.