### PR TITLE
fix(dropdown): close dropdown when disabled to prevent it from remaining open AB#1594444

### DIFF
--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -656,11 +656,9 @@ export class AuroDropdown extends AuroElement {
     this.floater.handleUpdate(changedProperties);
 
     // Close the dropdown if the disabled property is set to true
-    if (changedProperties.has('disabled')) {
-      if (this.disabled && this.isPopoverVisible) {
-        this.hide();
-        this.isPopoverVisible = false;
-      }
+    if (changedProperties.has('disabled') && this.disabled && this.isPopoverVisible) {
+      this.hide();
+      this.isPopoverVisible = false;
     }
 
     // Note: `disabled` is not a breakpoint (it is not a screen size),

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -650,9 +650,18 @@ export class AuroDropdown extends AuroElement {
     this.clearTriggerFocusEventBinding();
   }
 
+  // eslint-disable-next-line complexity
   updated(changedProperties) {
     super.updated(changedProperties);
     this.floater.handleUpdate(changedProperties);
+
+    // Close the dropdown if the disabled property is set to true
+    if (changedProperties.has('disabled')) {
+      if (this.disabled && this.isPopoverVisible) {
+        this.hide();
+        this.isPopoverVisible = false;
+      }
+    }
 
     // Note: `disabled` is not a breakpoint (it is not a screen size),
     // so it looks like we never consume this - however, dropdownBib handles this in the setter as "undefined"

--- a/components/dropdown/stories/playground/dropdown.stories.ts
+++ b/components/dropdown/stories/playground/dropdown.stories.ts
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/web-components-vite';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+import { html } from 'lit-html';
 
 import { AuroDropdown } from '../../src/index';
 
@@ -26,9 +27,13 @@ export default meta;
 
 type Story = StoryObj<AuroDropdown & typeof args>;
 
-export const Combobox: Story = {
-  render: (args) => template(args),
-  // args: {
-  //   'default-slot': 'Label',
-  // },
+export const Dropdown: Story = {
+  render: (args) =>
+    template(
+      args,
+      html`
+        <div slot="trigger">Trigger</div>
+        <div>Dropdown content</div>
+      `,
+    ),
 };

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -453,9 +453,10 @@ function runFullTest(mobileView) {
 
         trigger.click();
         await elementUpdated(el);
+        await expectPopoverShown(el);
         el.disabled = true;
         await elementUpdated(el);
-        expectPopoverHidden(el);
+        await expectPopoverHidden(el);
       });
 
       it('disabled dropdown has aria-disabled="true" on trigger', async () => {

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -447,6 +447,17 @@ function runFullTest(mobileView) {
         expectPopoverHidden(el);
       });
 
+      it('should close the bib when disabled while open', async () => {
+        const el = await fixture(html`<auro-dropdown><div slot="trigger">Trigger</div></auro-dropdown>`);
+        const trigger = el.shadowRoot.querySelector("#trigger");
+
+        trigger.click();
+        await elementUpdated(el);
+        el.disabled = true;
+        await elementUpdated(el);
+        expectPopoverHidden(el);
+      });
+
       it('disabled dropdown has aria-disabled="true" on trigger', async () => {
         const el = await fixture(html`
           <auro-dropdown disabled>

--- a/docs/post-mortem/1594444.md
+++ b/docs/post-mortem/1594444.md
@@ -1,0 +1,35 @@
+# Post-Mortem: Dropdown stays open when disabled
+
+**Issue:** AB#1594444
+
+## Summary
+
+This was a small state cleanup bug.
+
+If `auro-dropdown` was open and then became disabled, it stayed open. The component stopped taking input, but it did not close the popover that was already on screen.
+
+## What broke
+
+The disabled logic stopped new interaction, but it did not clean up what was already open.
+
+That left the dropdown open on screen even though it was disabled.
+
+## Root cause
+
+We did not close the dropdown when `disabled` changed to `true`.
+
+If it was already open, it stayed open.
+
+## Fix
+
+We added that check in the dropdown update cycle. If `disabled` becomes `true` while the popover is visible, the component now hides the dropdown and clears the visible state.
+
+## Check
+
+We added a regression test in `components/dropdown/test/auro-dropdown.test.js` that opens the dropdown, sets `disabled = true`, and verifies the popover is hidden.
+
+We also fixed the broken dropdown playground story.
+
+## Takeaway
+
+If a component can become disabled after it is already active, disabled handling needs to clean up the active UI too. Blocking the next interaction is not enough.


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request addresses a bug where the `auro-dropdown` component stayed open when it was disabled after being opened. The main changes include fixing the dropdown's state management so it closes when disabled, adding a regression test, updating the Storybook playground story, and documenting the issue with a post-mortem.

**Bug fix: Dropdown closes when disabled**
- [`auro-dropdown.js`](diffhunk://#diff-8f14c621eaf6cffb65e93778a1e71d1ab4fde24b2d03bcc3fe3261f40448754fR653-R665): Updated the `updated` lifecycle method to close the dropdown if `disabled` becomes `true` while the popover is visible.

**Testing improvements**
- [`auro-dropdown.test.js`](diffhunk://#diff-603498a1302d86f27894b99eeecb702bef6d247b0620d4045bddc80459c7b25cR450-R460): Added a regression test to verify that the dropdown closes when it is disabled while open.

**Storybook and documentation updates**
- [`dropdown.stories.ts`](diffhunk://#diff-42d1af9b54f13898aa2db1bf566aecc9e8f4b649519233bb05ed8b2eca91feffL29-R38): Fixed the playground story to use the correct slot and content for the dropdown. [[1]](diffhunk://#diff-42d1af9b54f13898aa2db1bf566aecc9e8f4b649519233bb05ed8b2eca91feffL29-R38) [[2]](diffhunk://#diff-42d1af9b54f13898aa2db1bf566aecc9e8f4b649519233bb05ed8b2eca91feffR3)
- [`docs/post-mortem/1594444.md`](diffhunk://#diff-77825e660ea4901566ade54bca17cf2fc11a79b1c30ed8a56bba3c9398d509f5R1-R35): Added a post-mortem documenting the bug, root cause, fix, and lessons learned.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure auro-dropdown closes its popover when the component becomes disabled and improve coverage and documentation around this behavior.

Bug Fixes:
- Close an open auro-dropdown popover when the component is disabled while active to prevent a stuck open state.

Enhancements:
- Correct the dropdown Storybook playground story to use an explicit trigger slot and sample content.

Documentation:
- Add a post-mortem documenting the dropdown disabled-state bug, root cause, fix, and lessons learned.

Tests:
- Add a regression test verifying that an open auro-dropdown closes when it is disabled.