### PR TITLE
fix(counter): apply inverse color token to counters in group AB#1450397

### DIFF
--- a/components/counter/apiExamples/appearance-inverse-group-custom.html
+++ b/components/counter/apiExamples/appearance-inverse-group-custom.html
@@ -1,0 +1,11 @@
+<custom-counter-group appearance="inverse">
+  <custom-counter>
+    Short label
+  </custom-counter>
+  <custom-counter>
+    Another short label
+  </custom-counter>
+  <custom-counter>
+    This is an example of the wrapping behavior for a long label
+  </custom-counter>
+</custom-counter-group>

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -10,6 +10,7 @@ import { html } from "lit/static-html.js";
 
 import tokens from "./styles/tokens-css.js";
 import counterGroupStyles from "./styles/counter-group-css.js";
+import colorCss from "./styles/counter-group-color-css.js";
 import shapeSizeCss from "./styles/shapeSize-css.js";
 
 import AuroLibraryRuntimeUtils from "@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs";
@@ -127,6 +128,7 @@ export class AuroCounterGroup extends AuroElement {
   static get styles() {
     return [
       tokens,
+      colorCss,
       counterGroupStyles,
       shapeSizeCss
     ];

--- a/components/counter/src/auro-counter-wrapper.js
+++ b/components/counter/src/auro-counter-wrapper.js
@@ -7,7 +7,6 @@ import { html } from "lit/static-html.js";
 import { LitElement } from "lit";
 
 import styleCss from "./styles/counter-wrapper-css.js";
-import colorCss from "./styles/counter-wrapper-color-css.js";
 import tokensCss from "./styles/tokens-css.js";
 
 import AuroLibraryRuntimeUtils from "@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs";
@@ -21,7 +20,6 @@ export class AuroCounterWrapper extends LitElement {
 
   static get styles() {
     return [
-      colorCss,
       styleCss,
       tokensCss
     ];

--- a/components/counter/src/styles/counter-group-color.scss
+++ b/components/counter/src/styles/counter-group-color.scss
@@ -5,8 +5,8 @@
 
 /* stylelint-disable no-descending-specificity, selector-max-attribute */
 
-:host {
-  ::slotted(*:not(:first-child)) {
-    border-color: var(--ds-auro-counter-divider-color);
+.counters {
+  ::slotted(auro-counter:not(:first-of-type)), ::slotted([auro-counter]:not(:first-of-type)) {
+    border-top-color: var(--ds-auro-counter-divider-color);
   }
 }

--- a/components/counter/src/styles/counter-group.scss
+++ b/components/counter/src/styles/counter-group.scss
@@ -102,7 +102,7 @@ label {
   flex-direction: column;
   gap: var(--ds-size-300, vac.$ds-size-300);
 
-  ::slotted(auro-counter:not(:first-of-type)) {
+  ::slotted(auro-counter:not(:first-of-type)), ::slotted([auro-counter]:not(:first-of-type)) {
     padding-top: var(--ds-size-300, vac.$ds-size-300);
     border-top-width: 1px;
     border-top-style: solid;

--- a/components/counter/stories/component.stories.ts
+++ b/components/counter/stories/component.stories.ts
@@ -352,7 +352,7 @@ export const CounterInverseDisabled: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <div style="background: var(--ds-color-background-darkest, #07244a); padding: 2rem;">
-  <auro-counter-group>
+  <auro-counter-group appearance="inverse">
     <auro-counter appearance="inverse" disabled>Short label</auro-counter>
     <auro-counter appearance="inverse" disabled>
       Long label example

--- a/components/counter/stories/individual-api-examples.stories.ts
+++ b/components/counter/stories/individual-api-examples.stories.ts
@@ -52,6 +52,12 @@ const specialConfigs = {
     },
     tags: ['!autodocs'],
   },
+  'appearance-inverse-group-custom': {
+    globals: {
+      backgrounds: { value: 'dark' },
+    },
+    tags: ['!autodocs'],
+  },
   'appearance-inverse-helptext': {
     globals: {
       backgrounds: { value: 'dark' },
@@ -95,6 +101,7 @@ export const AppearanceInverseDisabled = stories.AppearanceInverseDisabled;
 export const AppearanceInverseDropdown = stories.AppearanceInverseDropdown;
 export const AppearanceInverseError = stories.AppearanceInverseError;
 export const AppearanceInverseGroup = stories.AppearanceInverseGroup;
+export const AppearanceInverseGroupCustom = stories.AppearanceInverseGroupCustom;
 export const AppearanceInverseHelptext = stories.AppearanceInverseHelptext;
 export const AppearanceInverseSnowflake = stories.AppearanceInverseSnowflake;
 export const Basic = stories.Basic;

--- a/docs/post-mortem/1450397.md
+++ b/docs/post-mortem/1450397.md
@@ -1,0 +1,31 @@
+# Post-Mortem: Counter group inverse color token not applied
+
+**Issue:** AB#1450397
+
+## Summary
+
+Counters inside an inverse `auro-counter-group` were not getting the divider color token.
+
+The divider line still rendered, but it did not pick up the inverse color we expected.
+
+## What broke
+
+The group spacing and divider styles were there, but the divider color was not coming through for counters inside the group.
+
+That meant the inverse group could render with the wrong divider color.
+
+## Root cause
+
+The divider color rule was attached to the counter wrapper styles.
+
+But the divider border is defined by the counter group slotted selector, not the wrapper. The color token was living in the wrong place. (likely a result of a refactor)
+
+## Fix
+
+We moved the divider color rule into the counter group color styles so it lives next to the selector that draws the divider.
+
+We also updated the selector to match the grouped counter shapes this component supports.
+
+## Check
+
+We added a new inverse group API example and exposed it in Storybook so the grouped counter colors are easy to verify by hand.


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request addresses an issue where inverse `auro-counter-group` components were not applying the correct divider color token to their counters. The main fix involves moving the divider color rule from the counter wrapper styles to the counter group color styles, updating selectors for better compatibility, and adding a new example and story for easier verification. A post-mortem document was also added to explain the root cause and resolution.

**Bug fix and style correction:**

* Moved the divider color rule from `counter-wrapper-color.scss` to `counter-group-color.scss`, renamed the file accordingly, and updated the selector to target grouped counters correctly. This ensures the inverse divider color is applied as expected.
* Updated the `AuroCounterGroup` component to import and apply the new `counter-group-color-css.js` styles. [[1]](diffhunk://#diff-fa2f020cecf8d39fea26460b90c0db3cd5f20784b2ad0fdd6eb03e6cbdc05f22R13) [[2]](diffhunk://#diff-fa2f020cecf8d39fea26460b90c0db3cd5f20784b2ad0fdd6eb03e6cbdc05f22R131)
* Removed the now-unnecessary `counter-wrapper-color-css.js` import and usage from the `AuroCounterWrapper` component. [[1]](diffhunk://#diff-3e9a3fb183b979e3962905a096cf72ec91b832721f868d992c0924f3a5803fc8L10) [[2]](diffhunk://#diff-3e9a3fb183b979e3962905a096cf72ec91b832721f868d992c0924f3a5803fc8L24)
* Improved the selector in `counter-group.scss` to better match grouped counter shapes, ensuring consistent styling.

**Testing and documentation:**

* Added a new API example (`appearance-inverse-group-custom.html`) and corresponding Storybook story for inverse counter groups, making it easier to verify correct divider color application. [[1]](diffhunk://#diff-5ba7aa4751f600d0fc43b225a6d49766e77449d51851960a74150cf2d1d23370R1-R11) [[2]](diffhunk://#diff-068fc23813fc0d50b0f306ce7cddf4ef3d9279fd5bfd639303661ff8d36902deR55-R60) [[3]](diffhunk://#diff-068fc23813fc0d50b0f306ce7cddf4ef3d9279fd5bfd639303661ff8d36902deR104)
* Added a post-mortem document explaining the issue, root cause, and the fix.
## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix inverse counter group divider colors and add documentation and examples for verification.

Bug Fixes:
- Ensure counters within inverse counter groups use the correct divider color token by moving the color styling from the wrapper to the group and wiring it into the group component styles.
- Align grouped counter spacing and divider behavior across supported counter shapes via updated slot selectors.

Enhancements:
- Refine counter group styling selectors to support both native and attribute-based grouped counters while keeping divider and layout rules centralized in the group component.

Documentation:
- Add a post-mortem document describing the inverse counter group color issue, its root cause, and the implemented fix.
- Add a new inverse counter group API example and Storybook story to demonstrate and manually verify correct divider colors.