### PR TITLE
fix(bibtemplate): adjust mobile header padding AB#1364921

### DIFF
--- a/components/bibtemplate/src/styles/style.scss
+++ b/components/bibtemplate/src/styles/style.scss
@@ -19,12 +19,12 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    padding-bottom: var(--ds-size-200, #{vac.$ds-size-200});
     gap: var(--ds-size-100, #{vac.$ds-size-100});
   }
 
   .header {
     max-width: calc(100vw - var(--ds-size-900, #{vac.$ds-size-900}));
-    padding-top: var(--ds-size-200, #{vac.$ds-size-200});
   }
 
   .subheader {

--- a/docs/post-mortem/1364921.md
+++ b/docs/post-mortem/1364921.md
@@ -1,0 +1,44 @@
+# AB#1364921 — Auro Bug: bibtemplate mobile padding
+
+**Branch:** `rmenner/bib/mobile-heading-padding`
+**Scope:** One small SCSS adjustment in `auro-bibtemplate` to correct mobile header spacing in the fullscreen bib layout.
+
+---
+
+## The Problem
+
+On mobile, the fullscreen bib header spacing was applied to the `.header` element instead of the full title row. That made the vertical rhythm uneven: the title text received extra top padding, but the close-button row itself did not own the spacing.
+
+---
+
+## Root Cause
+
+The spacing rule was attached too low in the DOM structure:
+
+- The committed CSS put `padding-top` on `.header`.
+- The mobile layout actually needs the spacing on `.titleRow`, which contains both the title content and the close button.
+
+Because the padding lived on the inner text container, the overall row spacing was off in fullscreen mobile presentation.
+
+---
+
+## The Fix
+
+The SCSS in `components/bibtemplate/src/styles/style.scss` was adjusted to move the spacing responsibility to the row container:
+
+- Added `padding-bottom` to `.titleRow`
+- Removed `padding-top` from `.header`
+
+This keeps the title row responsible for its own layout spacing and avoids pushing only the text block.
+
+---
+
+## Why This Works
+
+`.titleRow` is the layout container for the mobile header. Putting the spacing there keeps the title and close button aligned as a single unit, which is the level where the fullscreen bib header is actually composed.
+
+---
+
+## Outcome
+
+The mobile bib header now uses cleaner container-level spacing, and the fullscreen heading/close-button area renders with the intended padding behavior.


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request addresses a mobile layout issue with the fullscreen bib header spacing in the `auro-bibtemplate` component. The main change is a small SCSS adjustment that moves the header padding from the `.header` element to the `.titleRow` container, ensuring consistent vertical spacing for both the title and the close button. The update also includes a post-mortem document explaining the problem, root cause, and solution.

Styling adjustments:

* [`components/bibtemplate/src/styles/style.scss`](diffhunk://#diff-82c9c1af5254dc6f7ba2627c9d4f541d91b253b8ffce59a5ba33d0153d3ce6baR22-L27): Added `padding-bottom` to `.titleRow` and removed `padding-top` from `.header` to ensure the title row, including the close button, receives the correct spacing on mobile.

Documentation:

* [`docs/post-mortem/1364921.md`](diffhunk://#diff-6e6442e888f4206a5f982b1df3c4c109bb52dc262c3718bffbe7cf2c16d3c21cR1-R44): Added a post-mortem detailing the issue, its root cause, the fix, and the resulting improvement in mobile header layout.

Before:
<img width="502" height="261" alt="Screenshot 2026-07-17 at 9 37 21 PM" src="https://github.com/user-attachments/assets/695e59d4-6e57-4bec-b24b-6ea93850a25c" />

After:
<img width="501" height="272" alt="Screenshot 2026-07-17 at 9 30 39 PM" src="https://github.com/user-attachments/assets/28b9523d-4f54-4bb6-85e7-9e3a2cece5c8" />

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adjust mobile fullscreen bib header spacing in auro-bibtemplate and document the issue with a post-mortem.

Bug Fixes:
- Fix uneven mobile fullscreen bib header spacing by ensuring the title row container owns the vertical padding.

Documentation:
- Add a post-mortem document describing the mobile bib header spacing issue, its root cause, and the applied fix.