### PR TITLE
fix: stringfy counter's aria-valuetext AB#1443553

### DIFF
--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -404,7 +404,7 @@ export class AuroCounter extends LitElement {
             aria-valuemax="${this.max}"
             aria-valuemin="${this.min}"
             aria-valuenow="${this.value}"
-            aria-valuetext="${this.value !== undefined ? this.value : this.min}"
+            aria-valuetext="'${this.value !== undefined ? this.value : this.min}'"
             role="spinbutton"
             tabindex="${this.disabled ? '-1' : '0'}"
           >

--- a/docs/post-mortem/1443553.md
+++ b/docs/post-mortem/1443553.md
@@ -1,0 +1,41 @@
+# Post-Mortem: Counter value announced as a percentage by screen readers (AB#1443553)
+
+**Issue:** AB#1443553
+
+## Summary
+
+Some screen readers were announcing the counter value as a percentage (e.g., "1.333%") instead of the plain count. The `aria-valuetext` attribute was emitting a bare number, which caused certain assistive technologies to derive a position-within-range percentage from the `aria-valuemin`/`aria-valuemax` bounds rather than reading the value directly.
+
+## What broke
+
+`aria-valuetext` was set to the raw numeric value:
+
+```js
+aria-valuetext="${this.value !== undefined ? this.value : this.min}"
+```
+
+When a screen reader received a numeric `aria-valuetext` on a `role="spinbutton"` with `aria-valuemin` and `aria-valuemax` set, it could calculate the value's relative position in the range and announce it as a percentage instead of the count.
+
+## Root cause
+
+The ARIA spec requires `aria-valuetext` to be a human-readable string. Passing a bare number leaves interpretation up to the screen reader. Some readers treat a numeric `aria-valuetext` as a positional value and compute `(valuenow - valuemin) / (valuemax - valuemin)` to produce a percentage announcement.
+
+### Why only `aria-valuetext` and not the other range props?
+
+`aria-valuenow`, `aria-valuemin`, and `aria-valuemax` are intentionally numeric — screen readers use them to compute range position and derive announcements. They are machine-readable inputs and should stay as numbers.
+
+`aria-valuetext` serves the opposite purpose: it is a human-readable string meant to **override** how `aria-valuenow` is announced. When set, a compliant screen reader reads it verbatim instead of deriving an announcement from the numeric props. Passing a bare number to `aria-valuetext` undermines that contract — the reader has no guarantee it is a string override and may ignore it in favor of its own range calculation. The single-quote wrapping makes the string nature explicit.
+
+## Fix
+
+Wrap the value in single quotes so the attribute is unambiguously a string:
+
+```js
+aria-valuetext="'${this.value !== undefined ? this.value : this.min}'"
+```
+
+The rendered attribute becomes e.g. `aria-valuetext="'1'"`. The quotes signal to the screen reader that this is a literal string to read as-is, not a number to interpret within a range.
+
+## Check
+
+Verified manually that the counter value is announced as a plain count rather than a percentage.


### PR DESCRIPTION
# Alaska Airlines Pull Request

Resubmitting the [bug fix ](https://github.com/AlaskaAirlines/auro-formkit/pull/1345)which was accidentally reverted. 
## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adjust counter ARIA attributes to ensure screen readers announce the value as a plain count instead of a percentage.

Bug Fixes:
- Correct the aria-valuetext value for the counter component so assistive technologies no longer interpret it as a percentage within the range.

Documentation:
- Add a post-mortem document explaining the screen reader percentage announcement issue for the counter and its resolution.