### PR TITLE
fix(menu): distinguish menu options that share a value AB#1602086

### DIFF
--- a/components/combobox/apiExamples/duplicate-values.html
+++ b/components/combobox/apiExamples/duplicate-values.html
@@ -1,0 +1,13 @@
+<auro-combobox>
+  <span slot="ariaLabel.bib.close">Close combobox</span>
+  <span slot="ariaLabel.input.clear">Clear All</span>
+  <span slot="bib.fullscreen.headline">Choose an airport</span>
+  <span slot="label">Departure airport</span>
+  <auro-menu>
+    <auro-menuoption value="seattle" suggest="seattle sea seatac tacoma">Seattle&ndash;Tacoma International (SEA)</auro-menuoption>
+    <auro-menuoption value="seattle" suggest="seattle pae paine field everett">Seattle Paine Field (PAE)</auro-menuoption>
+    <auro-menuoption value="portland" suggest="portland pdx oregon">Portland International (PDX)</auro-menuoption>
+    <auro-menuoption value="spokane" suggest="spokane geg washington">Spokane International (GEG)</auro-menuoption>
+    <auro-menuoption static nomatch>No matching airport</auro-menuoption>
+  </auro-menu>
+</auro-combobox>

--- a/components/combobox/demo/index.html
+++ b/components/combobox/demo/index.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/legacy/auro-classic/CSSCustomProperties.css"/>
 
     <!-- Design Token Alaska Theme -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/themes/alaska/CSSCustomProperties--alaska.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/web/alaska.min.css"/>
 
     <!-- Webcore Stylesheet Alaska Theme -->
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/webcorestylesheets@latest/dist/bundled/themes/alaska.global.min.css" />

--- a/components/combobox/docs/pages/customize.md
+++ b/components/combobox/docs/pages/customize.md
@@ -29,6 +29,7 @@
       <auro-anchorlink fluid href="#noValidate" class="level2 body-xs">No Validation</auro-anchorlink>
       <auro-anchorlink fluid href="#dynamicMenu" class="level2 body-xs">Dynamic Menu</auro-anchorlink>
       <auro-anchorlink fluid href="#loading" class="level2 body-xs">Loading</auro-anchorlink>
+      <auro-anchorlink fluid href="#nonUniqueValues" class="level2 body-xs">Non-Unique Option Values</auro-anchorlink>
     </auro-nav>
   </nav>
   <div class="mainContent">
@@ -328,6 +329,17 @@
         <auro-accordion alignRight>
           <span slot="trigger">See code</span>
           <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/loading.html) -->
+          <!-- AURO-GENERATED-CONTENT:END -->
+        </auro-accordion>
+        <auro-header level="3" id="nonUniqueValues">Non-Unique Option Values</auro-header>
+        <p>Two or more <code>auro-menuoption</code> elements may share the same <code>value</code>. This is common when the <code>value</code> represents a coarser grouping than the option label &mdash; for example, several airports that all serve the same city. When the user filters the list and selects one of several options that share a <code>value</code>, the combobox resolves to the exact option chosen, so the correct label is displayed even though the underlying <code>value</code> is duplicated.</p>
+        <div class="exampleWrapper">
+          <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/duplicate-values.html) -->
+          <!-- AURO-GENERATED-CONTENT:END -->
+        </div>
+        <auro-accordion alignRight>
+          <span slot="trigger">See code</span>
+          <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/duplicate-values.html) -->
           <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
       </section>

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1779,6 +1779,9 @@ export class AuroCombobox extends AuroElement {
         // does NOT match the new value.
         const menuSelectionMatchesValue =
           this.menu.optionSelected &&
+          // optionSelected is a single element here (scalar `.value`). A multiselect
+          // menu exposes it as an ARRAY, which has no scalar `.value` to compare, so
+          // that shape can't be a single-option match — fall through to the clear path.
           !Array.isArray(this.menu.optionSelected) &&
           this.menu.optionSelected.value === this.value;
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1493,7 +1493,17 @@ export class AuroCombobox extends AuroElement {
       return;
     }
 
-    this.value = this.input.value;
+    // Skip this write during a display-value sync: that path sets the input to
+    // the selected option's LABEL, which is not its machine value. When an
+    // option's label differs from its value (and especially when several
+    // options share a value but render distinct labels — AB#1602086), writing
+    // the label back into this.value clobbers the machine value the selection
+    // listener just set (this.value = optionSelected.value), collapsing the
+    // selection. _syncingBibValue still tracks (that mirrors user-typed text
+    // from the fullscreen bib, where value should follow the input).
+    if (!this._syncingDisplayValue) {
+      this.value = this.input.value;
+    }
 
     // Ignore re-entrant input events caused by programmatic value sets.
     if (this._syncingBibValue || this._syncingDisplayValue) {
@@ -1757,33 +1767,50 @@ export class AuroCombobox extends AuroElement {
       }
 
       if (this.input.value !== this.value) {
-        // Clear menu.value AND menu.optionSelected together. Clearing only
-        // menu.value leaves the previously-selected option element pinned
-        // as menu.optionSelected; a later auroMenu-selectedOption event
-        // would then write its stale .value back into combobox.value
-        // (e.g. Tab-after-Backspace re-selecting the prior option).
-        if (this.menu.value || this.menu.optionSelected) {
-          this.menu.clearSelection();
-        }
+        // A fresh user selection leaves the input showing the option's LABEL
+        // while this.value holds its machine value, so input.value !== this.value
+        // is expected whenever label ≠ value. In that case the menu's current
+        // selection is authoritative — and when several options share a value it
+        // is the ONLY thing that records WHICH same-value option the user picked
+        // (the menu tracks it by element identity via `_selectedKey`). Clearing
+        // it here drops that key; the ensuing value-only re-resolution then
+        // collapses the selection onto the first same-value option (AB#1602086).
+        // So only treat the divergence as a stale menu when the selected option
+        // does NOT match the new value.
+        const menuSelectionMatchesValue =
+          this.menu.optionSelected &&
+          !Array.isArray(this.menu.optionSelected) &&
+          this.menu.optionSelected.value === this.value;
 
-        if (!this.persistInput) {
-          this.syncInputValuesAcrossTriggerAndBib(this.value || '');
-        }
+        if (!menuSelectionMatchesValue) {
+          // Clear menu.value AND menu.optionSelected together. Clearing only
+          // menu.value leaves the previously-selected option element pinned
+          // as menu.optionSelected; a later auroMenu-selectedOption event
+          // would then write its stale .value back into combobox.value
+          // (e.g. Tab-after-Backspace re-selecting the prior option).
+          if (this.menu.value || this.menu.optionSelected) {
+            this.menu.clearSelection();
+          }
 
-        // Programmatic value with no matching option: updateFilter will close
-        // the bib silently (see line 648 — no noMatchOption + 0 results
-        // hides). Announce so screen-reader users hear the request was
-        // dropped. Gated on `input.value !== this.value` so this never fires
-        // for user typing — that path always reconciles input.value to
-        // this.value before updated() runs.
-        if (
-          this.value &&
-          this.menu &&
-          this.menu.options &&
-          this.menu.options.length > 0 &&
-          !this.menu.options.some((opt) => opt.value === this.value)
-        ) {
-          announceToScreenReader(this._getAnnouncementRoot(), `No matching option for ${this.value}`);
+          if (!this.persistInput) {
+            this.syncInputValuesAcrossTriggerAndBib(this.value || '');
+          }
+
+          // Programmatic value with no matching option: updateFilter will close
+          // the bib silently (see line 648 — no noMatchOption + 0 results
+          // hides). Announce so screen-reader users hear the request was
+          // dropped. Gated on `input.value !== this.value` so this never fires
+          // for user typing — that path always reconciles input.value to
+          // this.value before updated() runs.
+          if (
+            this.value &&
+            this.menu &&
+            this.menu.options &&
+            this.menu.options.length > 0 &&
+            !this.menu.options.some((opt) => opt.value === this.value)
+          ) {
+            announceToScreenReader(this._getAnnouncementRoot(), `No matching option for ${this.value}`);
+          }
         }
       }
 

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -800,6 +800,27 @@ function runFullTest(mobileView) {
       await expect(el.optionSelected).to.equal(opts[1]);
       await expect(el.menu.optionSelected).to.equal(opts[1]);
       await expect(el.input.value).to.equal('Seattle Paine Field (PAE)');
+
+      // ...and a subsequent PROGRAMMATIC value reconcile to that same shared
+      // value must NOT collapse the selection onto the FIRST match. This is the
+      // divergence from auro-menu.selectByValue('SEA') (which always snaps to
+      // the first same-value option): combobox.updated() guards it via
+      // `menuSelectionMatchesValue` — when the menu's selected option already
+      // carries the incoming value, the menu selection is left intact rather
+      // than cleared-and-value-re-resolved, so the exact element the user chose
+      // survives. A plain `el.value = 'SEA'` is a Lit no-op here (value is
+      // already 'SEA') and never re-enters updated(), so force the value-change
+      // reconcile cycle to run — the cycle a framework drives when it re-writes
+      // `value` on re-render. Without the guard, updated() clears the menu and
+      // value-only resolution collapses onto opts[0].
+      el.value = 'SEA';
+      el.requestUpdate('value', 'PDX');
+      await elementUpdated(el);
+
+      await expect(el.value).to.equal('SEA');
+      await expect(el.optionSelected).to.equal(opts[1]);
+      await expect(el.menu.optionSelected).to.equal(opts[1]);
+      await expect(el.input.value).to.equal('Seattle Paine Field (PAE)');
     });
 
     // Regression: with persistInput + framework re-mount (Svelte `{#key}`),

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -8,6 +8,7 @@ import {
   shiftTabFixture,
   shiftTabDisabledFirstFixture,
   defaultFixture,
+  duplicateValueFixture,
   disabledOptionFixture,
   presetDisabledValueFixture,
   nestedMenuFixture,
@@ -766,6 +767,39 @@ function runFullTest(mobileView) {
       await expect(right.value).to.equal('a');
       await expect(left.input.value).to.equal('b');
       await expect(right.input.value).to.equal('a');
+    });
+
+    // Regression (AB#1602086): two options share a value but render distinct
+    // labels. Selecting the SECOND must keep ITS identity through combobox's
+    // value↔menu sync — previously combobox.updated() cleared the menu
+    // selection (input shows the label, this.value the machine value), and the
+    // value-only re-resolution collapsed onto the FIRST same-value option.
+    it('keeps the exact option selected when two options share a value', async () => {
+      const el = await duplicateValueFixture(mobileView);
+      await elementUpdated(el);
+
+      // Type "Seattle" so both duplicate options stay visible, open, then
+      // click the second — the true duplicate-disambiguation path.
+      el.focus();
+      await elementUpdated(el);
+      await sendKeys({ type: 'Seattle' });
+      el.input.click();
+      await elementUpdated(el);
+      await waitUntil(() => el.dropdown.isPopoverVisible);
+
+      const menu = el.querySelector('auro-menu');
+      const opts = menu.querySelectorAll('auro-menuoption');
+
+      opts[1].click();
+      await elementUpdated(opts[1]);
+      await elementUpdated(menu);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await elementUpdated(el);
+
+      await expect(el.value).to.equal('SEA');
+      await expect(el.optionSelected).to.equal(opts[1]);
+      await expect(el.menu.optionSelected).to.equal(opts[1]);
+      await expect(el.input.value).to.equal('Seattle Paine Field (PAE)');
     });
 
     // Regression: with persistInput + framework re-mount (Svelte `{#key}`),

--- a/components/combobox/test/testFixtures.js
+++ b/components/combobox/test/testFixtures.js
@@ -123,6 +123,35 @@ export async function defaultFixture(mobileView) {
 }
 
 /**
+ * Testing fixture whose first two options share a value but render distinct labels.
+ * @param {boolean} mobileView - Whether to render the fixture in mobile viewport.
+ * @returns {Promise<HTMLElement>} The auro-combobox element with duplicate-value options.
+ */
+export async function duplicateValueFixture(mobileView) {
+  if (mobileView) {
+    await setViewport({
+      width: 500,
+      height: 800
+    });
+  } else {
+    await setViewport({
+      width: 800,
+      height: 800
+    });
+  }
+  return fixture(html`
+  <auro-combobox>
+    <span slot="label">Airport</span>
+    <auro-menu>
+      <auro-menuoption value="SEA" id="dup-option-0">Seattle-Tacoma (SEA)</auro-menuoption>
+      <auro-menuoption value="SEA" id="dup-option-1">Seattle Paine Field (PAE)</auro-menuoption>
+      <auro-menuoption value="PDX" id="dup-option-2">Portland (PDX)</auro-menuoption>
+    </auro-menu>
+  </auro-combobox>
+  `);
+}
+
+/**
  * Testing fixture whose second option is disabled, for programmatic value rejection.
  * @param {boolean} mobileView - Whether to render the fixture in mobile viewport.
  * @returns {Promise<HTMLElement>} The auro-combobox element with a disabled option.

--- a/components/menu/apiExamples/duplicate-values-multiselect.html
+++ b/components/menu/apiExamples/duplicate-values-multiselect.html
@@ -1,0 +1,6 @@
+<auro-menu multiselect>
+  <auro-menuoption value="seattle">Seattle&ndash;Tacoma International (SEA)</auro-menuoption>
+  <auro-menuoption value="seattle">Seattle Paine Field (PAE)</auro-menuoption>
+  <auro-menuoption value="portland">Portland International (PDX)</auro-menuoption>
+  <auro-menuoption value="spokane">Spokane International (GEG)</auro-menuoption>
+</auro-menu>

--- a/components/menu/apiExamples/duplicate-values.html
+++ b/components/menu/apiExamples/duplicate-values.html
@@ -1,0 +1,6 @@
+<auro-menu>
+  <auro-menuoption value="seattle">Seattle&ndash;Tacoma International (SEA)</auro-menuoption>
+  <auro-menuoption value="seattle">Seattle Paine Field (PAE)</auro-menuoption>
+  <auro-menuoption value="portland">Portland International (PDX)</auro-menuoption>
+  <auro-menuoption value="spokane">Spokane International (GEG)</auro-menuoption>
+</auro-menu>

--- a/components/menu/docs/pages/customize.md
+++ b/components/menu/docs/pages/customize.md
@@ -23,6 +23,7 @@
       <auro-anchorlink fluid href="#multiselect" class="level2 body-xs">Multi-Select</auro-anchorlink>
       <auro-anchorlink fluid href="#presetValue" class="level2 body-xs">Preset Value</auro-anchorlink>
       <auro-anchorlink fluid href="#presetValueMultiselect" class="level2 body-xs">Preset Value (Multi)</auro-anchorlink>
+      <auro-anchorlink fluid href="#nonUniqueValues" class="level2 body-xs">Non-Unique Option Values</auro-anchorlink>
     </auro-nav>
   </nav>
   <div class="mainContent">
@@ -219,6 +220,27 @@
         <auro-accordion alignRight>
         <span slot="trigger">See code</span>
         <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/preset-value-multiselect.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </auro-accordion>
+        <auro-header level="3" id="nonUniqueValues">Non-Unique Option Values</auro-header>
+        <p>Two or more <code>auro-menuoption</code> elements may share the same <code>value</code>. This is common when the <code>value</code> represents a coarser grouping than the option label &mdash; for example, several airports that all serve the same city. The menu tracks the specific option a user selects rather than resolving by <code>value</code> alone, so selecting one of several options that share a <code>value</code> highlights exactly the option that was chosen.</p>
+        <div class="exampleWrapper">
+        <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/duplicate-values.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </div>
+        <auro-accordion alignRight>
+        <span slot="trigger">See code</span>
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/duplicate-values.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </auro-accordion>
+        <p>In <code>multiselect</code> mode, options that share a <code>value</code> are tracked independently, so each can be selected and removed on its own. Selections are stored in DOM order regardless of the order in which they were chosen.</p>
+        <div class="exampleWrapper">
+        <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/duplicate-values-multiselect.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </div>
+        <auro-accordion alignRight>
+        <span slot="trigger">See code</span>
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/duplicate-values-multiselect.html) -->
         <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
       </section>

--- a/components/menu/src/auro-menu-utils.js
+++ b/components/menu/src/auro-menu-utils.js
@@ -108,6 +108,107 @@ export function isSelectableByValue(option) {
          !option.hasAttribute('static');
 }
 
+/* eslint-disable no-underscore-dangle */
+/**
+ * Resolves the single selected option for a given `value`, preferring the
+ * option tracked by `selectedKey` (a user-initiated selection) over a
+ * first-by-value match. When multiple options share the same `value`, matching
+ * by `value` alone cannot distinguish which one the user picked; the key
+ * disambiguates it.
+ *
+ * The key is trusted only when it still resolves to an option whose `value`
+ * matches the requested `value`. If the key is stale (option removed) or the
+ * value was changed programmatically, resolution falls back to value matching —
+ * preserving backward-compatible behavior for preselection and `selectByValue`.
+ * @private
+ * @param {Array<HTMLElement>} items - The menu's flat option list.
+ * @param {string} value - The value to resolve.
+ * @param {string|undefined} selectedKey - The `_optionKey` of the user-selected option, if any.
+ * @returns {HTMLElement|undefined} The resolved option, or undefined when none match.
+ */
+export function resolveSelectedOption(items, value, selectedKey) {
+  if (!items) {
+    return undefined;
+  }
+
+  if (selectedKey !== undefined) {
+    const keyed = items.find((item) => item._optionKey === selectedKey);
+    if (keyed && isSelectableByValue(keyed) && keyed.value === value) {
+      return keyed;
+    }
+    // Key exists but the option is gone or its value no longer matches — fall
+    // through to value-based matching.
+  }
+
+  return items.find((item) => isSelectableByValue(item) && item.value === value);
+}
+
+/**
+ * Resolves the selected options for a multi-select `value` array, preferring
+ * options tracked by `selectedKeys` (user-initiated selections) and falling
+ * back to value matching for any values not resolved by key. The result is
+ * always sorted into DOM order regardless of selection sequence.
+ * @private
+ * @param {Array<HTMLElement>} items - The menu's flat option list.
+ * @param {Array<string>} valueArray - The selected values.
+ * @param {Array<string>|undefined} selectedKeys - The `_optionKey`s of the user-selected options, if any.
+ * @returns {Array<HTMLElement>} The resolved options in DOM order.
+ */
+export function resolveSelectedOptions(items, valueArray, selectedKeys) {
+  if (!items) {
+    return [];
+  }
+
+  const resolved = [];
+
+  // Track how many of each value are still available to resolve. A value that
+  // appears N times in `valueArray` may be satisfied at most N times total across
+  // the key pass and the value fallback below — matching by count, not presence,
+  // on BOTH passes. This stops a duplicate value from being over-resolved: e.g.
+  // two keyed options that both carry `SEA` cannot both match a single requested
+  // `SEA` (which happens when `value` is set directly without clearing
+  // `_selectedKey`, so more keys survive than the value set now asks for).
+  const remaining = new Map();
+  valueArray.forEach((val) => remaining.set(val, (remaining.get(val) || 0) + 1));
+
+  // Resolve by key first: trust a key only when its option is still selectable
+  // and there is still an unmatched occurrence of its value in the request set.
+  if (Array.isArray(selectedKeys)) {
+    selectedKeys.forEach((key) => {
+      const keyed = items.find((item) => item._optionKey === key);
+      if (keyed && isSelectableByValue(keyed) && (remaining.get(keyed.value) || 0) > 0 && !resolved.includes(keyed)) {
+        resolved.push(keyed);
+        remaining.set(keyed.value, remaining.get(keyed.value) - 1);
+      }
+    });
+  }
+
+  // Fall back to value matching for the occurrences not resolved by key. Iterate
+  // the leftover per-value counts so a value that appears twice but was only
+  // resolved once by key still matches its remaining occurrence(s).
+  remaining.forEach((count, val) => {
+    for (let occurrence = 0; occurrence < count; occurrence += 1) {
+      const option = items.find((item) => isSelectableByValue(item) && item.value === val && !resolved.includes(item));
+      if (option) {
+        resolved.push(option);
+      }
+    }
+  });
+
+  // Always return in DOM order so display is consistent regardless of the order
+  // keys/values were selected. Every resolved option came from `items`, so an
+  // O(1) index lookup mirrors `_sortSelectedByDomOrder` and avoids the O(n)
+  // `items.indexOf` per comparison for large combobox option sets.
+  const indexMap = new Map(items.map((item, index) => [
+    item,
+    index
+  ]));
+  resolved.sort((optionA, optionB) => indexMap.get(optionA) - indexMap.get(optionB));
+
+  return resolved;
+}
+/* eslint-enable no-underscore-dangle */
+
 /**
  * Helper method to dispatch custom events.
  * @param {HTMLElement} element - Element to dispatch event from.

--- a/components/menu/src/auro-menu-utils.js
+++ b/components/menu/src/auro-menu-utils.js
@@ -160,6 +160,10 @@ export function resolveSelectedOptions(items, valueArray, selectedKeys) {
   }
 
   const resolved = [];
+  // Mirror `resolved` as a Set for O(1) membership checks below, matching the
+  // indexMap optimization used for the sort rather than scanning `resolved`
+  // on every candidate.
+  const resolvedSet = new Set();
 
   // Track how many of each value are still available to resolve. A value that
   // appears N times in `valueArray` may be satisfied at most N times total across
@@ -176,8 +180,9 @@ export function resolveSelectedOptions(items, valueArray, selectedKeys) {
   if (Array.isArray(selectedKeys)) {
     selectedKeys.forEach((key) => {
       const keyed = items.find((item) => item._optionKey === key);
-      if (keyed && isSelectableByValue(keyed) && (remaining.get(keyed.value) || 0) > 0 && !resolved.includes(keyed)) {
+      if (keyed && isSelectableByValue(keyed) && (remaining.get(keyed.value) || 0) > 0 && !resolvedSet.has(keyed)) {
         resolved.push(keyed);
+        resolvedSet.add(keyed);
         remaining.set(keyed.value, remaining.get(keyed.value) - 1);
       }
     });
@@ -188,9 +193,10 @@ export function resolveSelectedOptions(items, valueArray, selectedKeys) {
   // resolved once by key still matches its remaining occurrence(s).
   remaining.forEach((count, val) => {
     for (let occurrence = 0; occurrence < count; occurrence += 1) {
-      const option = items.find((item) => isSelectableByValue(item) && item.value === val && !resolved.includes(item));
+      const option = items.find((item) => isSelectableByValue(item) && item.value === val && !resolvedSet.has(item));
       if (option) {
         resolved.push(option);
+        resolvedSet.add(option);
       }
     }
   });
@@ -198,12 +204,15 @@ export function resolveSelectedOptions(items, valueArray, selectedKeys) {
   // Always return in DOM order so display is consistent regardless of the order
   // keys/values were selected. Every resolved option came from `items`, so an
   // O(1) index lookup mirrors `_sortSelectedByDomOrder` and avoids the O(n)
-  // `items.indexOf` per comparison for large combobox option sets.
+  // `items.indexOf` per comparison for large combobox option sets. Any element
+  // not in `items` (a stale snapshot from a future caller) sorts to the END via
+  // `?? items.length`, matching `_sortSelectedByDomOrder` and avoiding NaN
+  // comparisons.
   const indexMap = new Map(items.map((item, index) => [
     item,
     index
   ]));
-  resolved.sort((optionA, optionB) => indexMap.get(optionA) - indexMap.get(optionB));
+  resolved.sort((optionA, optionB) => (indexMap.get(optionA) ?? items.length) - (indexMap.get(optionB) ?? items.length));
 
   return resolved;
 }

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -17,9 +17,19 @@ import {
   isOptionInteractive,
   isSelectableByValue,
   dispatchMenuEvent,
-  serializeMultiSelectValue
+  serializeMultiSelectValue,
+  resolveSelectedOption,
+  resolveSelectedOptions
 } from './auro-menu-utils.js';
 import { classMap } from "lit/directives/class-map.js";
+
+/**
+ * Monotonically increasing counter used to give each menu instance a unique
+ * `_menuInstanceId` prefix. Auto-generating the id (rather than using a random
+ * string) keeps option keys deterministic and collision-free across menus.
+ * @private
+ */
+let menuInstanceIdCounter = 0;
 
 
 /**
@@ -92,9 +102,8 @@ export class AuroMenu extends AuroElement {
 
     // Instance properties (non-reactive)
 
-    /**
-     * @private
-     */
+    menuInstanceIdCounter += 1;
+
     Object.assign(this, {
       // Root-level menu (true) or a nested submenu (false)
       rootMenu: true,
@@ -104,6 +113,21 @@ export class AuroMenu extends AuroElement {
       nestingSpacer: '<span class="nestingSpacer"></span>',
       // Loading indicator for slot elements
       loadingSlots: null,
+      // Unique id for this menu instance; prefixes every auto-generated option
+      // key so keys never collide across menus in the same document.
+      _menuInstanceId: `menu-${menuInstanceIdCounter}`,
+      // Monotonically increasing counter for option key generation. Never
+      // resets, so a key is never reused within this instance's lifetime.
+      _optionKeyCounter: 0,
+      // Key(s) of the option(s) the user has actively selected. A single string
+      // in single-select, an array in multi-select, undefined when nothing is
+      // user-selected. Used to disambiguate options that share a `value`.
+      _selectedKey: undefined,
+      // True only for the one updated() cycle following a user selection, so
+      // reconciliation trusts `_selectedKey`. A `value` change from a consumer's
+      // direct property assignment leaves this false, dropping the stale key so
+      // reconciliation falls back to first-by-value (see updated()).
+      _valueChangeFromSelection: false,
     });
   }
 
@@ -323,6 +347,13 @@ export class AuroMenu extends AuroElement {
       return;
     }
 
+    // A programmatic value set carries no positional intent, so drop any
+    // `_selectedKey` left over from a prior user click. This makes reconciliation
+    // in updated() fall back to first-by-value (single) / value-in-DOM-order
+    // (multi), matching the documented contract for programmatic selection even
+    // when a stale key would still resolve to a duplicate-value option.
+    this._selectedKey = undefined;
+
     // `value` is a String property; stringify arrays so attribute reflection and `formattedValue` parsing stay correct.
     this.value = Array.isArray(value) ? JSON.stringify(value) : value;
   }
@@ -370,6 +401,17 @@ export class AuroMenu extends AuroElement {
   updated(changedProperties) {
     super.updated(changedProperties);
 
+    // Consume the selection-driven flag for THIS cycle up front. Clearing it
+    // unconditionally — not only inside the `value` branch below — prevents it
+    // from lingering `true` when a selection produces a serialized `value`
+    // byte-identical to the current one, in which case Lit schedules no
+    // `value`-change cycle to consume it. A lingering flag would misclassify a
+    // later consumer's programmatic `value` set as selection-driven and keep a
+    // stale `_selectedKey`. The reconcile path below re-sets the instance flag
+    // after this point, so its intentional cross-cycle hand-off still works.
+    const valueChangeFromSelection = this._valueChangeFromSelection;
+    this._valueChangeFromSelection = false;
+
     // Single source of truth for 'auroMenu-selectedOption'. Selection handlers
     // mutate optionSelected and let Lit's update cycle dispatch here; the prior
     // .value comparison missed multi-select array changes and combined with the
@@ -393,6 +435,17 @@ export class AuroMenu extends AuroElement {
         this.initItems();
       }
 
+      // Distinguish a selection-driven `value` change (a user click, which set
+      // the flag in handleSelectState / _sortSelectedByDomOrder) from a
+      // programmatic assignment by a consumer. A programmatic set carries no
+      // positional intent, so drop any leftover `_selectedKey` and let
+      // reconciliation fall back to first-by-value (single) / value-in-DOM-order
+      // (multi) — the same contract selectByValue() guarantees, even when a
+      // stale key would otherwise still resolve to a duplicate-value option.
+      if (!valueChangeFromSelection) {
+        this._selectedKey = undefined;
+      }
+
       // Set when reconciliation reassigns `value` below. That reassignment schedules a
       // second updated() cycle, so the `event`-attribute dispatch is deferred to that
       // cycle to avoid firing option custom events twice on the same selection.
@@ -410,19 +463,55 @@ export class AuroMenu extends AuroElement {
           // Defensive default: `formattedValue` can be undefined for unexpected value types,
           // and calling `.includes` on undefined would throw during reconciliation.
           const valueArray = this.formattedValue || [];
-          const matchingOptions = this.items ? this.items.filter((item) => isSelectableByValue(item) && valueArray.includes(item.value)) : [];
+          // Resolve by key first (the user's exact picks), then fall back to
+          // value matching for any values not resolved by key — so pre-selection
+          // and programmatic value sets keep working. Result is DOM-ordered.
+          const matchingOptions = resolveSelectedOptions(this.items, valueArray, this._selectedKey);
           newSelected = matchingOptions.length > 0 ? matchingOptions : undefined;
 
-          // Reconcile `value` with the selectable set. Drop only entries whose option is
-          // loaded but non-selectable (disabled/static) — leaving them would desync `value`
-          // from `optionSelected`, and the toggle handlers rebuild `value` from `formattedValue`,
-          // so the rejected entry would resurface on the next select/deselect. Entries with no
-          // matching item yet are preserved so async preselection still works once options render.
-          const rejectedValues = this.items
-            ? this.items.filter((item) => !isSelectableByValue(item) && valueArray.includes(item.value)).map((item) => item.value)
-            : [];
-          if (rejectedValues.length > 0) {
-            const reconciled = valueArray.filter((val) => !rejectedValues.includes(val));
+          // Reconcile `value` with the selectable set. An occurrence is dropped
+          // only when it is loaded but no selectable option can satisfy it —
+          // every loaded item sharing that value is non-selectable, or the value
+          // recurs more often than it has selectable options (a duplicate value
+          // whose extra siblings are disabled/static). This is count-based, not
+          // presence-based, so an enabled option is kept even when a disabled
+          // sibling shares its value — mirroring how `resolveSelectedOptions`
+          // resolves the same set. Entries with no matching item yet are
+          // preserved so async preselection still works, and the toggle handlers
+          // rebuild `value` from `formattedValue`, so a rejected entry cannot
+          // resurface on the next select/deselect.
+          const selectableByValue = new Map();
+          const loadedValues = new Set();
+          if (this.items) {
+            this.items.forEach((item) => {
+              loadedValues.add(item.value);
+              if (isSelectableByValue(item)) {
+                selectableByValue.set(item.value, (selectableByValue.get(item.value) || 0) + 1);
+              }
+            });
+          }
+
+          const reconciled = valueArray.filter((val) => {
+            // Not loaded yet (async preselection) — keep for a later cycle.
+            if (!loadedValues.has(val)) {
+              return true;
+            }
+            // Consume one selectable option per occurrence; drop once exhausted.
+            const remaining = selectableByValue.get(val) || 0;
+            if (remaining > 0) {
+              selectableByValue.set(val, remaining - 1);
+              return true;
+            }
+            return false;
+          });
+
+          if (reconciled.length !== valueArray.length) {
+            // This is an internal correction, not a consumer's programmatic set,
+            // so preserve the selection-driven flag through the re-entrant
+            // updated() cycle it schedules. Otherwise that cycle would treat the
+            // reassignment as programmatic and drop `_selectedKey` mid-cascade,
+            // flipping resolution and looping.
+            this._valueChangeFromSelection = true;
             this.value = serializeMultiSelectValue(reconciled);
             valueReconciled = true;
           }
@@ -434,7 +523,11 @@ export class AuroMenu extends AuroElement {
           // `hidden` is intentionally NOT excluded: the combobox toggles
           // `hidden` as its type-ahead filter, so a filtered-out option is
           // still a valid programmatic selection.
-          const matchingOption = this.items ? this.items.find((item) => isSelectableByValue(item) && item.value === this.value) : undefined;
+          // Prefer the option the user actually selected (tracked by
+          // `_selectedKey`) so a click on the second of two options sharing a
+          // `value` resolves back to that exact element instead of the first
+          // value match. Falls back to first-by-value for programmatic sets.
+          const matchingOption = resolveSelectedOption(this.items, this.value, this._selectedKey);
 
           if (matchingOption) {
             newSelected = matchingOption;
@@ -662,6 +755,14 @@ export class AuroMenu extends AuroElement {
       }
     });
 
+    // Assign private keys once items are populated. Only the root menu assigns
+    // keys: its `items` is a deep query that already includes nested submenu
+    // options, so a single pass keys the entire tree. Nested menus skip this
+    // and inherit keys from the root.
+    if (this.rootMenu) {
+      this._assignOptionKeys();
+    }
+
     if (this.noCheckmark) {
       this.updateItemsState(new Map([
         [
@@ -678,6 +779,31 @@ export class AuroMenu extends AuroElement {
     }));
   }
 
+  /**
+   * Assigns a private, auto-generated unique key (`_optionKey`) to each menu
+   * option that does not already have one. Keys are internal state on the
+   * element instance — never reflected as an attribute or exposed publicly —
+   * and let selection tracking distinguish options that share the same `value`.
+   *
+   * The `_optionKey === undefined` guard makes this idempotent: options keep the
+   * key they were first assigned across re-renders and slot changes, and if a
+   * nested menu's lifecycle runs a pass before the root, options simply wait for
+   * the root to key them (or keep whatever key they already hold).
+   * @private
+   */
+  _assignOptionKeys() {
+    if (!this.items) {
+      return;
+    }
+
+    this.items.forEach((option) => {
+      if (option._optionKey === undefined) {
+        this._optionKeyCounter += 1;
+        option._optionKey = `${this._menuInstanceId}-${this._optionKeyCounter}`;
+      }
+    });
+  }
+
   // Logic Methods
 
   /**
@@ -687,24 +813,28 @@ export class AuroMenu extends AuroElement {
    */
   handleSelectState(option) {
     if (this.multiSelect) {
-      const currentValue = this.formattedValue || [];
       const currentSelected = this.optionSelected || [];
 
-      if (!currentValue.includes(option.value)) {
-        this.value = serializeMultiSelectValue([
-          ...currentValue,
-          option.value
-        ]);
-      }
       if (!currentSelected.includes(option)) {
         this.optionSelected = [
           ...currentSelected,
           option
         ];
       }
+
+      // Re-sort by DOM order and rebuild `_selectedKey`/`value` from the
+      // selected set so display order stays consistent with the menu, not with
+      // click order.
+      this._sortSelectedByDomOrder();
     } else {
       this.value = option.value;
       this.optionSelected = option;
+      // Track the specific option the user selected so the value→option
+      // reconciliation in updated() resolves back to this exact element even
+      // when another option shares the same `value`.
+      this._selectedKey = option._optionKey;
+      // Mark this `value` change as selection-driven so updated() trusts the key.
+      this._valueChangeFromSelection = true;
     }
 
     this._index = this.items.indexOf(option);
@@ -717,18 +847,22 @@ export class AuroMenu extends AuroElement {
    */
   handleDeselectState(option) {
     if (this.multiSelect) {
-      // Remove this option from array; an empty result collapses `value` to undefined.
-      const newFormattedValue = (this.formattedValue || []).filter((val) => val !== option.value);
-      this.value = serializeMultiSelectValue(newFormattedValue);
-
-      this.optionSelected = this.optionSelected.filter((val) => val !== option);
+      // Remove this exact element from the selection (identity, not value — two
+      // options can share a `value`), then rebuild `value`/`_selectedKey` from
+      // the remaining set in DOM order. An empty result collapses to undefined.
+      this.optionSelected = this.optionSelected.filter((selected) => selected !== option);
       if (this.optionSelected.length === 0) {
         this.optionSelected = undefined;
+        this._selectedKey = undefined;
+        this.value = undefined;
+      } else {
+        this._sortSelectedByDomOrder();
       }
     } else {
       // For single-select: Back to undefined when deselected
       this.value = undefined;
       this.optionSelected = undefined;
+      this._selectedKey = undefined;
     }
 
     // Update the index tracking
@@ -752,7 +886,36 @@ export class AuroMenu extends AuroElement {
   clearSelection() {
     this.optionSelected = undefined;
     this.value = undefined;
+    this._selectedKey = undefined;
     this._index = -1;
+  }
+
+  /**
+   * Re-sorts the multi-select selection into DOM order and rebuilds the derived
+   * `_selectedKey` and `value` from `optionSelected`. Selection is always stored
+   * and serialized in the order options appear in the menu, never in click
+   * order — so selecting C then A yields `[A, C]`.
+   * @private
+   */
+  _sortSelectedByDomOrder() {
+    if (!this.multiSelect || !Array.isArray(this.optionSelected) || !this.items) {
+      return;
+    }
+
+    const indexMap = new Map(this.items.map((item, index) => [
+      item,
+      index
+    ]));
+
+    // Sort any element no longer in `items` (a stale selection left over from a
+    // dynamic rebuild that the consumer has not cleared) to the END rather than
+    // the front, so it never displaces a live option to the head of the
+    // serialized order. Value reconciliation drops it on the next updated() cycle.
+    this.optionSelected.sort((optionA, optionB) => (indexMap.get(optionA) ?? this.items.length) - (indexMap.get(optionB) ?? this.items.length));
+    this._selectedKey = this.optionSelected.map((option) => option._optionKey);
+    this.value = serializeMultiSelectValue(this.optionSelected.map((option) => option.value));
+    // Mark this `value` change as selection-driven so updated() trusts the keys.
+    this._valueChangeFromSelection = true;
   }
 
   /**
@@ -764,6 +927,7 @@ export class AuroMenu extends AuroElement {
     // Reset to undefined - initial state
     this.value = undefined;
     this.optionSelected = undefined;
+    this._selectedKey = undefined;
     this._index = -1;
 
     // Clear active option state so a follow-up open/navigation starts fresh

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -989,6 +989,19 @@ export class AuroMenu extends AuroElement {
       this.initItems();
     }
 
+    // Recover `_index` from the highlighted option when it has been reset to -1.
+    // In multi-select, deselecting the last remaining option collapses the value
+    // to undefined, and the updated() reconciliation resets `_index = -1` even
+    // though `optionActive` still points at the highlighted option. Without this,
+    // reading `items[-1]` returns undefined and the re-select no-ops until the
+    // highlight is moved away and back. Mirrors auro-combobox's reconcileMenuIndex.
+    if (this._index < 0 && this.optionActive && this.items) {
+      const activeIndex = this.items.indexOf(this.optionActive);
+      if (activeIndex >= 0) {
+        this._index = activeIndex;
+      }
+    }
+
     // Get currently selected menu option based on index
     const option = this.items ? this.items[this._index] : undefined;
 

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -907,6 +907,14 @@ export class AuroMenu extends AuroElement {
       index
     ]));
 
+    // Sorting in place mutates `optionSelected` without a new array reference,
+    // which Lit's `===` change-detection cannot see on its own — but that is
+    // intentional and safe: both callers (handleSelectState / handleDeselectState)
+    // assign a fresh `optionSelected` array immediately before calling, so Lit
+    // already has a changed reference to react to, and the `value` write below
+    // schedules the updated() cycle that re-derives `optionSelected` in DOM order
+    // via resolveSelectedOptions. Do not "fix" this into a new-array assignment.
+    //
     // Sort any element no longer in `items` (a stale selection left over from a
     // dynamic rebuild that the consumer has not cleared) to the END rather than
     // the front, so it never displaces a live option to the head of the
@@ -990,11 +998,13 @@ export class AuroMenu extends AuroElement {
     }
 
     // Recover `_index` from the highlighted option when it has been reset to -1.
-    // In multi-select, deselecting the last remaining option collapses the value
-    // to undefined, and the updated() reconciliation resets `_index = -1` even
-    // though `optionActive` still points at the highlighted option. Without this,
-    // reading `items[-1]` returns undefined and the re-select no-ops until the
-    // highlight is moved away and back. Mirrors auro-combobox's reconcileMenuIndex.
+    // The updated() reconciliation resets `_index = -1` whenever the value
+    // collapses to undefined while `optionActive` still points at the highlighted
+    // option — e.g. deselecting the last remaining option in multi-select, or a
+    // programmatic clearSelection() in single-select while keyboard focus is on an
+    // option. Without this, reading `items[-1]` returns undefined and the re-select
+    // no-ops until the highlight is moved away and back. Mirrors auro-combobox's
+    // reconcileMenuIndex.
     if (this._index < 0 && this.optionActive && this.items) {
       const activeIndex = this.items.indexOf(this.optionActive);
       if (activeIndex >= 0) {

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -6,7 +6,7 @@ import designTokens from '@aurodesignsystem/design-tokens/dist/legacy/auro-class
 import '../src/registered.js';
 
 const mobileBreakpointWidth = parseInt(designTokens['ds-grid-breakpoint-sm'], 10) - 1;
-import { arrayConverter, arraysAreEqual, isOptionInteractive, isSelectableByValue } from '../src/auro-menu-utils.js';
+import { arrayConverter, arraysAreEqual, isOptionInteractive, isSelectableByValue, resolveSelectedOption, resolveSelectedOptions } from '../src/auro-menu-utils.js';
 import {
   defaultFixture,
   noninteractiveOptionsFixture,
@@ -14,6 +14,10 @@ import {
   customEventFixture,
   emptyItemsFixture,
   multiSelectFixture,
+  duplicateValueFixture,
+  multiSelectDuplicateValueFixture,
+  multiSelectDisabledDuplicateValueFixture,
+  nestedDuplicateValueFixture,
 } from './testFixtures.js';
 import { getOptions } from './testFunctions.js';
 
@@ -3026,6 +3030,558 @@ function runFullTest(mobileView) {
       // firstUpdated should have fallen back to 'sm' and 'box' with null parent
       expect(option.size).to.equal('sm');
       expect(option.shape).to.equal('box');
+    });
+  });
+
+  describe('unique option keys (duplicate values)', () => {
+    it('assigns a unique _optionKey to every option', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      const keys = options.map((option) => option._optionKey);
+      keys.forEach((key) => expect(key).to.be.a('string'));
+      expect(new Set(keys).size).to.equal(keys.length);
+    });
+
+    it('tracks the exact option clicked when values are duplicated (single-select)', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Click the SECOND option that shares value "SEA".
+      options[1].click();
+      await elementUpdated(menu);
+
+      // Resolution must land on the exact element clicked, not the first value match.
+      expect(menu.optionSelected).to.equal(options[1]);
+      expect(menu.optionSelected).to.not.equal(options[0]);
+      expect(menu.value).to.equal('SEA');
+      expect(menu._selectedKey).to.equal(options[1]._optionKey);
+    });
+
+    it('keeps tracking the correct option after a subsequent updated() cycle', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      options[1].click();
+      await elementUpdated(menu);
+
+      // Force another reactive cycle without re-flagging `value`; a re-render
+      // that does not change `value` must preserve the selection-driven key so
+      // the pick still resolves to options[1]. (A cycle that *does* re-flag
+      // `value` is a programmatic set and intentionally drops the key — covered
+      // by the 'direct value assignment' test.)
+      menu.requestUpdate();
+      await elementUpdated(menu);
+
+      expect(menu.optionSelected === options[1], 'selection-driven key survives a re-render').to.be.true;
+    });
+
+    it('falls back to first-by-value for programmatic selectByValue with duplicates', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      menu.selectByValue('SEA');
+      await elementUpdated(menu);
+
+      // No positional intent in a programmatic set → first match by DOM order.
+      expect(menu.optionSelected).to.equal(options[0]);
+    });
+
+    it('programmatic selectByValue clears a stale key and resolves first-by-value', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // User clicks the SECOND SEA, so _selectedKey points at options[1].
+      options[1].click();
+      await elementUpdated(menu);
+      expect(menu.optionSelected).to.equal(options[1]);
+
+      // Clearing the key happens synchronously in selectByValue, regardless of
+      // whether the value ends up changing.
+      menu.selectByValue('SEA');
+      expect(menu._selectedKey).to.be.undefined;
+
+      // Move away and back programmatically: with the stale key gone, the return
+      // to 'SEA' carries no positional intent and resolves first-by-value rather
+      // than snapping back to the previously-clicked duplicate.
+      menu.selectByValue('PDX');
+      await elementUpdated(menu);
+      expect(menu.optionSelected).to.equal(options[2]);
+
+      menu.selectByValue('SEA');
+      await elementUpdated(menu);
+      expect(menu.optionSelected).to.equal(options[0]);
+    });
+
+    it('direct value assignment drops a stale key and resolves first-by-value', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // User clicks the SECOND SEA, so _selectedKey points at options[1].
+      // Compare by identity as a boolean: a failing `.to.equal(domElement)`
+      // makes chai serialize the LitElement for its diff, which hangs.
+      options[1].click();
+      await elementUpdated(menu);
+      expect(menu.optionSelected === options[1], 'click tracks the second SEA').to.be.true;
+
+      // A consumer's direct `value` property assignment carries no positional
+      // intent, so the leftover key must be dropped and resolution fall back to
+      // first-by-value — a prior click on a duplicate must not bias it.
+      menu.value = 'PDX';
+      await elementUpdated(menu);
+      expect(menu.optionSelected === options[2], 'PDX resolves to the only PDX').to.be.true;
+
+      menu.value = 'SEA';
+      await elementUpdated(menu);
+      expect(menu.optionSelected === options[0], 'programmatic SEA resolves first-by-value').to.be.true;
+    });
+
+    it('honors the user pick across a re-render when value does not change', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Click the second duplicate, then force a re-render without changing
+      // `value`. The selection-driven key must survive so the user's pick is not
+      // reset to the first-by-value option.
+      options[1].click();
+      await elementUpdated(menu);
+      menu.requestUpdate();
+      await elementUpdated(menu);
+      expect(menu.optionSelected === options[1], 'user pick survives a value-preserving re-render').to.be.true;
+    });
+
+    it('tracks duplicate-value options independently in multi-select', async () => {
+      const el = await multiSelectDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      options[0].click();
+      await elementUpdated(menu);
+      options[1].click();
+      await elementUpdated(menu);
+
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(2);
+      expect(menu.optionSelected).to.include(options[0]);
+      expect(menu.optionSelected).to.include(options[1]);
+      expect(JSON.parse(menu.value)).to.eql([
+        'SEA',
+        'SEA'
+      ]);
+    });
+
+    it('deselects one of two duplicate-value options by identity', async () => {
+      const el = await multiSelectDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Select both SEA options, then deselect the FIRST one. The survivor must be
+      // the second SEA — removal is by element identity (selected !== option), not
+      // by value, and `_sortSelectedByDomOrder()` rebuilds `value`/`_selectedKey`
+      // from that survivor. A value-vs-identity regression would drop the wrong SEA.
+      options[0].click();
+      await elementUpdated(menu);
+      options[1].click();
+      await elementUpdated(menu);
+      options[0].click();
+      await elementUpdated(menu);
+
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(1);
+      expect(menu.optionSelected[0] === options[1], 'the surviving SEA is the second element').to.be.true;
+      expect(menu._selectedKey).to.eql([options[1]._optionKey]);
+      expect(JSON.parse(menu.value)).to.eql(['SEA']);
+    });
+
+    it('stores multi-select selections in DOM order, not click order', async () => {
+      const el = await multiSelectDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Select PDX (index 2) first, then the first SEA (index 0).
+      options[2].click();
+      await elementUpdated(menu);
+      options[0].click();
+      await elementUpdated(menu);
+
+      // Stored order must be DOM order [SEA(0), PDX(2)], not click order [PDX, SEA].
+      expect(menu.optionSelected[0]).to.equal(options[0]);
+      expect(menu.optionSelected[1]).to.equal(options[2]);
+      expect(menu._selectedKey).to.eql([
+        options[0]._optionKey,
+        options[2]._optionKey
+      ]);
+      expect(JSON.parse(menu.value)).to.eql([
+        'SEA',
+        'PDX'
+      ]);
+    });
+
+    it('reconciles a rejected disabled value out of a multi-select selection without looping', async () => {
+      const el = await multiSelectFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Pair a selectable value with a disabled one (option4 is disabled). The
+      // reconcile branch drops the non-selectable entry and reassigns `value`,
+      // scheduling a re-entrant updated() cycle. That cycle preserves the
+      // selection-driven flag so it does not re-drop `_selectedKey` and loop —
+      // it must settle on just the selectable option.
+      menu.value = JSON.stringify([
+        'option1',
+        'option4'
+      ]);
+      await elementUpdated(menu);
+
+      expect(JSON.parse(menu.value)).to.eql(['option1']);
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(1);
+      expect(menu.optionSelected[0] === options[0], 'only the selectable option survives').to.be.true;
+    });
+
+    it('keeps an enabled selection when a disabled sibling shares its value', async () => {
+      const el = await multiSelectDisabledDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Click the ENABLED "SEA" (index 0). A disabled "SEA" sibling (index 1)
+      // shares its value. The value-level reconcile must not treat "SEA" as a
+      // rejected value wholesale and collapse the selection — it must keep the
+      // enabled option resolved. A presence-based reject would drop 'SEA'
+      // entirely and reverse the click.
+      options[0].click();
+      await elementUpdated(menu);
+
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(1);
+      expect(menu.optionSelected[0] === options[0], 'the enabled SEA survives reconcile').to.be.true;
+      expect(JSON.parse(menu.value)).to.eql(['SEA']);
+    });
+
+    it('drops a duplicate occurrence with no selectable option left but keeps the enabled one', async () => {
+      const el = await multiSelectDisabledDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Request "SEA" twice: only one selectable "SEA" exists (the other is
+      // disabled). Count-based reconcile keeps a single occurrence resolved to
+      // the enabled option and drops the surplus, rather than keeping both or
+      // dropping all.
+      menu.value = JSON.stringify([
+        'SEA',
+        'SEA'
+      ]);
+      await elementUpdated(menu);
+
+      expect(JSON.parse(menu.value)).to.eql(['SEA']);
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(1);
+      expect(menu.optionSelected[0] === options[0], 'the enabled SEA is the survivor').to.be.true;
+    });
+
+    it('preserves a live _selectedKey through a reconcile re-entrant cycle without looping', async () => {
+      const el = await multiSelectDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Select both SEA duplicates and PDX. `_selectedKey` now holds live keys
+      // for the exact clicked elements, including the SECOND SEA (options[1]).
+      options[0].click();
+      await elementUpdated(menu);
+      options[1].click();
+      await elementUpdated(menu);
+      options[2].click();
+      await elementUpdated(menu);
+
+      // Disable the FIRST SEA out from under the live selection. It stays in
+      // optionSelected/value until the next reconcile makes it unsatisfiable.
+      options[0].setAttribute('disabled', '');
+      await elementUpdated(options[0]);
+
+      // Deselecting PDX is selection-driven: it re-serializes `value` with the
+      // flag set and `_selectedKey` still live. updated() now finds one 'SEA'
+      // occurrence unsatisfiable (options[0] is disabled) and reconciles it out,
+      // scheduling a re-entrant updated() cycle. That reconcile must PRESERVE the
+      // selection-driven flag so the re-entrant cycle keeps `_selectedKey` and
+      // resolves through the live keys — if it dropped the flag mid-cascade,
+      // resolution would flip and loop (this await would time out).
+      options[2].click();
+      await elementUpdated(menu);
+
+      // Settles (no loop) on the still-selectable second SEA, by identity.
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(1);
+      expect(menu.optionSelected[0] === options[1], 'the live-keyed second SEA survives reconcile').to.be.true;
+      expect(JSON.parse(menu.value)).to.eql(['SEA']);
+    });
+
+    it('tracks the exact duplicate option selected via keyboard Enter (single-select)', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Move the active index to the SECOND option sharing value "SEA".
+      menu.navigateOptions('down');
+      await elementUpdated(menu);
+      menu.navigateOptions('down');
+      await elementUpdated(menu);
+
+      // Enter routes through handleKeyDown → makeSelection → handleSelectState —
+      // the same identity path as a click — so the exact active element is
+      // tracked, not the first value match.
+      menu.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true
+      }));
+      await elementUpdated(menu);
+
+      expect(menu.optionSelected === options[1], 'Enter selects the exact active duplicate').to.be.true;
+      expect(menu.value).to.equal('SEA');
+      expect(menu._selectedKey).to.equal(options[1]._optionKey);
+    });
+
+    it('tracks the exact duplicate option selected via keyboard Tab (multi-select)', async () => {
+      const el = await multiSelectDuplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+
+      // Activate the second "SEA" and commit it with Tab (which also selects via
+      // makeSelection while letting focus leave the menu).
+      menu.navigateOptions('down');
+      await elementUpdated(menu);
+      menu.navigateOptions('down');
+      await elementUpdated(menu);
+      menu.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true
+      }));
+      await elementUpdated(menu);
+
+      expect(menu.optionSelected).to.be.an('array').with.lengthOf(1);
+      expect(menu.optionSelected[0] === options[1], 'Tab selects the exact active duplicate').to.be.true;
+      expect(menu._selectedKey).to.eql([options[1]._optionKey]);
+      expect(JSON.parse(menu.value)).to.eql(['SEA']);
+    });
+
+    it('keeps option keys stable across re-renders', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+      const options = getOptions(menu);
+      const keysBefore = options.map((option) => option._optionKey);
+
+      // Trigger re-renders via an attribute change and an explicit initItems pass.
+      menu.matchWord = 'SEA';
+      await elementUpdated(menu);
+      menu.initItems();
+      await elementUpdated(menu);
+
+      const keysAfter = getOptions(menu).map((option) => option._optionKey);
+      expect(keysAfter).to.eql(keysBefore);
+    });
+
+    it('isolates keys across separate menu instances', async () => {
+      const elA = await duplicateValueFixture();
+      const elB = await duplicateValueFixture();
+      const menuA = elA.querySelector('auro-menu');
+      const menuB = elB.querySelector('auro-menu');
+      await elementUpdated(menuA);
+      await elementUpdated(menuB);
+
+      expect(menuA._menuInstanceId).to.not.equal(menuB._menuInstanceId);
+
+      const keysA = getOptions(menuA).map((option) => option._optionKey);
+      const keysB = getOptions(menuB).map((option) => option._optionKey);
+      const overlap = keysA.filter((key) => keysB.includes(key));
+      expect(overlap).to.be.empty;
+    });
+
+    it('assigns fresh keys to dynamically rebuilt options and resolves duplicates', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+
+      const originalKeys = getOptions(menu).map((option) => option._optionKey);
+
+      // Simulate a combobox-style rebuild: replace the slotted options entirely.
+      menu.innerHTML = `
+        <auro-menuoption value="LAX">Los Angeles (LAX)</auro-menuoption>
+        <auro-menuoption value="LAX">Hollywood Burbank (LAX)</auro-menuoption>
+      `;
+      await oneEvent(menu, 'auroMenu-optionsChange');
+      await elementUpdated(menu);
+
+      const newOptions = getOptions(menu);
+      // New elements receive keys never used by the original set (counter never resets).
+      newOptions.forEach((option) => {
+        expect(option._optionKey).to.be.a('string');
+        expect(originalKeys).to.not.include(option._optionKey);
+      });
+
+      // Duplicate values in the new set remain unambiguous.
+      newOptions[1].click();
+      await elementUpdated(menu);
+      expect(menu.optionSelected).to.equal(newOptions[1]);
+    });
+
+    it('tracks the correct nested option when values duplicate across levels', async () => {
+      const el = await nestedDuplicateValueFixture();
+      const rootMenu = el.querySelector('auro-menu');
+      await elementUpdated(rootMenu);
+
+      const nestedSeaOption = el.querySelector('auro-menu auro-menu auro-menuoption[value="SEA"]');
+      const topSeaOption = el.querySelector('auro-menu > auro-menuoption[value="SEA"]');
+
+      // Both SEA options are in the root's flat items list with distinct keys.
+      expect(nestedSeaOption._optionKey).to.be.a('string');
+      expect(nestedSeaOption._optionKey).to.not.equal(topSeaOption._optionKey);
+
+      nestedSeaOption.click();
+      await elementUpdated(rootMenu);
+
+      expect(rootMenu.optionSelected).to.equal(nestedSeaOption);
+      expect(rootMenu.value).to.equal('SEA');
+    });
+
+    it('assigns keys to a dynamically inserted nested submenu', async () => {
+      const el = await duplicateValueFixture();
+      const menu = el.querySelector('auro-menu');
+      await elementUpdated(menu);
+
+      const submenu = document.createElement('auro-menu');
+      submenu.innerHTML = `<auro-menuoption value="SEA">Nested SEA</auro-menuoption>`;
+      menu.appendChild(submenu);
+      await oneEvent(menu, 'auroMenu-optionsChange');
+      await elementUpdated(menu);
+
+      const nestedOption = submenu.querySelector('auro-menuoption');
+      expect(nestedOption._optionKey).to.be.a('string');
+
+      nestedOption.click();
+      await elementUpdated(menu);
+      expect(menu.optionSelected).to.equal(nestedOption);
+    });
+  });
+
+  describe('resolveSelectedOption / resolveSelectedOptions utils', () => {
+    const makeOption = (value, key) => ({
+      value,
+      _optionKey: key,
+      hasAttribute: () => false
+    });
+
+    it('resolveSelectedOption prefers the keyed option over first-by-value', () => {
+      const items = [
+        makeOption('SEA', 'k1'),
+        makeOption('SEA', 'k2')
+      ];
+      expect(resolveSelectedOption(items, 'SEA', 'k2')).to.equal(items[1]);
+    });
+
+    it('resolveSelectedOption falls back to value when the key is stale', () => {
+      const items = [
+        makeOption('SEA', 'k1'),
+        makeOption('SEA', 'k2')
+      ];
+      expect(resolveSelectedOption(items, 'SEA', 'gone')).to.equal(items[0]);
+    });
+
+    it('resolveSelectedOption falls back to value when the keyed value no longer matches', () => {
+      const items = [
+        makeOption('PDX', 'k1'),
+        makeOption('SEA', 'k2')
+      ];
+      expect(resolveSelectedOption(items, 'SEA', 'k1')).to.equal(items[1]);
+    });
+
+    it('resolveSelectedOptions returns matches in DOM order regardless of key order', () => {
+      const items = [
+        makeOption('SEA', 'k1'),
+        makeOption('PDX', 'k2')
+      ];
+      const resolved = resolveSelectedOptions(items, [
+        'SEA',
+        'PDX'
+      ], [
+        'k2',
+        'k1'
+      ]);
+      expect(resolved).to.eql([
+        items[0],
+        items[1]
+      ]);
+    });
+
+    it('resolveSelectedOptions resolves duplicate values to distinct elements', () => {
+      const items = [
+        makeOption('SEA', 'k1'),
+        makeOption('SEA', 'k2')
+      ];
+      const resolved = resolveSelectedOptions(items, [
+        'SEA',
+        'SEA'
+      ], undefined);
+      expect(resolved).to.eql([
+        items[0],
+        items[1]
+      ]);
+    });
+
+    it('resolveSelectedOptions matches duplicates by count when only one is keyed', () => {
+      const items = [
+        makeOption('SEA', 'k1'),
+        makeOption('SEA', 'k2')
+      ];
+      // Two 'SEA' values but only the second option is resolved by key; the
+      // remaining occurrence must still fall back to the first option by count,
+      // not be dropped because a 'SEA' was already resolved.
+      const resolved = resolveSelectedOptions(items, [
+        'SEA',
+        'SEA'
+      ], [
+        'k2'
+      ]);
+      expect(resolved).to.eql([
+        items[0],
+        items[1]
+      ]);
+    });
+
+    it('resolveSelectedOptions bounds key resolution by count when more keys survive than values requested', () => {
+      const items = [
+        makeOption('SEA', 'k1'),
+        makeOption('SEA', 'k2')
+      ];
+      // Both duplicate options are still keyed (e.g. `value` was set directly to a
+      // single 'SEA' without clearing `_selectedKey`), but only one 'SEA' is now
+      // requested. Resolution must honor the value count and return exactly one
+      // option, not over-resolve both keys.
+      const resolved = resolveSelectedOptions(items, [
+        'SEA'
+      ], [
+        'k1',
+        'k2'
+      ]);
+      expect(resolved).to.eql([
+        items[0]
+      ]);
     });
   });
 

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -300,6 +300,38 @@ function runFullTest(mobileView) {
         });
       });
 
+      it('should re-select via Enter after deselecting the last selected option in multi-select mode', async () => {
+        const el = await multiSelectFixture();
+        const menuEl = el.querySelector('auro-menu');
+        const options = getOptions(menuEl);
+
+        // Highlight and select the first option so it becomes the only selection.
+        menuEl.index = 0;
+        menuEl.makeSelection();
+        await elementUpdated(menuEl);
+
+        expect(JSON.parse(menuEl.value)).to.eql(['option1']);
+        expect(options[0].hasAttribute('selected')).to.be.true;
+
+        // Deselect it without moving the highlight. This empties the whole
+        // selection, so value collapses to undefined and updated() resets
+        // `_index` to -1 while `optionActive` still points at option 0.
+        menuEl.makeSelection();
+        await elementUpdated(menuEl);
+
+        expect(menuEl.value).to.be.undefined;
+        expect(options[0].hasAttribute('selected')).to.be.false;
+
+        // Pressing Enter again on the still-highlighted option must re-select it,
+        // without first moving the highlight away and back.
+        menuEl.makeSelection();
+        await elementUpdated(menuEl);
+
+        expect(JSON.parse(menuEl.value)).to.eql(['option1']);
+        expect(options[0].hasAttribute('selected')).to.be.true;
+        expect(options[0].getAttribute('aria-selected')).to.equal('true');
+      });
+
       it('should not allow selection of disabled options in multi-select mode', async () => {
         const el = await multiSelectFixture();
         const menuEl = el.querySelector('auro-menu');

--- a/components/menu/test/testFixtures.js
+++ b/components/menu/test/testFixtures.js
@@ -69,6 +69,57 @@ export async function emptyItemsFixture() {
   `);
 }
 
+export async function duplicateValueFixture() {
+  return await fixture(html`
+    <div>
+      <auro-menu aria-label="test">
+        <auro-menuoption value="SEA">Seattle-Tacoma (SEA)</auro-menuoption>
+        <auro-menuoption value="SEA">Seattle Paine Field (SEA)</auro-menuoption>
+        <auro-menuoption value="PDX">Portland (PDX)</auro-menuoption>
+      </auro-menu>
+    </div>
+  `);
+}
+
+export async function multiSelectDuplicateValueFixture() {
+  return await fixture(html`
+    <div>
+      <auro-menu multiSelect aria-label="test">
+        <auro-menuoption value="SEA">Seattle-Tacoma (SEA)</auro-menuoption>
+        <auro-menuoption value="SEA">Seattle Paine Field (SEA)</auro-menuoption>
+        <auro-menuoption value="PDX">Portland (PDX)</auro-menuoption>
+      </auro-menu>
+    </div>
+  `);
+}
+
+export async function multiSelectDisabledDuplicateValueFixture() {
+  return await fixture(html`
+    <div>
+      <auro-menu multiSelect aria-label="test">
+        <auro-menuoption value="SEA">Seattle-Tacoma (SEA)</auro-menuoption>
+        <auro-menuoption disabled value="SEA">Seattle Paine Field (SEA)</auro-menuoption>
+        <auro-menuoption value="PDX">Portland (PDX)</auro-menuoption>
+      </auro-menu>
+    </div>
+  `);
+}
+
+export async function nestedDuplicateValueFixture() {
+  return await fixture(html`
+    <div>
+      <auro-menu aria-label="test">
+        <auro-menuoption value="SEA">Top-level SEA</auro-menuoption>
+        <auro-menu>
+          <auro-menuoption value="SEA">Nested SEA</auro-menuoption>
+          <auro-menuoption value="PDX">Nested PDX</auro-menuoption>
+        </auro-menu>
+        <auro-menuoption value="LAX">Top-level LAX</auro-menuoption>
+      </auro-menu>
+    </div>
+  `);
+}
+
 export async function multiSelectFixture() {
   return await fixture(html`
     <div>

--- a/components/select/apiExamples/duplicate-values-multiselect.html
+++ b/components/select/apiExamples/duplicate-values-multiselect.html
@@ -1,0 +1,12 @@
+<auro-select multiselect>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Choose airports</span>
+  <label slot="placeholder">Select one or more airports</label>
+  <span slot="label">Airports served</span>
+  <auro-menu>
+    <auro-menuoption value="seattle">Seattle&ndash;Tacoma International (SEA)</auro-menuoption>
+    <auro-menuoption value="seattle">Seattle Paine Field (PAE)</auro-menuoption>
+    <auro-menuoption value="portland">Portland International (PDX)</auro-menuoption>
+    <auro-menuoption value="spokane">Spokane International (GEG)</auro-menuoption>
+  </auro-menu>
+</auro-select>

--- a/components/select/apiExamples/duplicate-values.html
+++ b/components/select/apiExamples/duplicate-values.html
@@ -1,0 +1,11 @@
+<auro-select>
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Choose an airport</span>
+  <span slot="label">Departure airport</span>
+  <auro-menu>
+    <auro-menuoption value="seattle">Seattle&ndash;Tacoma International (SEA)</auro-menuoption>
+    <auro-menuoption value="seattle">Seattle Paine Field (PAE)</auro-menuoption>
+    <auro-menuoption value="portland">Portland International (PDX)</auro-menuoption>
+    <auro-menuoption value="spokane">Spokane International (GEG)</auro-menuoption>
+  </auro-menu>
+</auro-select>

--- a/components/select/docs/pages/customize.md
+++ b/components/select/docs/pages/customize.md
@@ -33,6 +33,7 @@
       <auro-anchorlink fluid href="#noValidate" class="level2 body-xs">No Validation</auro-anchorlink>
       <auro-anchorlink fluid href="#placeholder" class="level2 body-xs">Placeholder</auro-anchorlink>
       <auro-anchorlink fluid href="#loading" class="level2 body-xs">Loading</auro-anchorlink>
+      <auro-anchorlink fluid href="#nonUniqueValues" class="level2 body-xs">Non-Unique Option Values</auro-anchorlink>
     </auro-nav>
   </nav>
   <div class="mainContent">
@@ -389,6 +390,27 @@
         <auro-accordion alignRight>
         <span slot="trigger">See code</span>
         <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/loading.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </auro-accordion>
+        <auro-header level="3" id="nonUniqueValues">Non-Unique Option Values</auro-header>
+        <p>Two or more <code>auro-menuoption</code> elements may share the same <code>value</code>. This is common when the <code>value</code> represents a coarser grouping than the option label &mdash; for example, several airports that all serve the same city. The component tracks the specific option a user selects, so the correct label is displayed even when the underlying <code>value</code> is duplicated.</p>
+        <div class="exampleWrapper">
+        <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/duplicate-values.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </div>
+        <auro-accordion alignRight>
+        <span slot="trigger">See code</span>
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/duplicate-values.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </auro-accordion>
+        <p>In <code>multiselect</code> mode, options that share a <code>value</code> are tracked independently, so each can be selected and removed on its own. Selections are stored in DOM order regardless of the order in which they were chosen.</p>
+        <div class="exampleWrapper">
+        <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/duplicate-values-multiselect.html) -->
+        <!-- AURO-GENERATED-CONTENT:END -->
+        </div>
+        <auro-accordion alignRight>
+        <span slot="trigger">See code</span>
+        <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/duplicate-values-multiselect.html) -->
         <!-- AURO-GENERATED-CONTENT:END -->
         </auro-accordion>
       </section>

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1146,6 +1146,42 @@ function runTest(mobileView) {
           await expect(triggerText).to.equal('Seattle Paine Field (PAE)');
         });
 
+        it('holds two options that share a value as distinct selections in multiselect', async () => {
+          // Multi-select peer of the single-select duplicate-value guard above.
+          // Two options carry value="SEA"; selecting BOTH must keep them as two
+          // distinct elements (by identity) stored in DOM order, not collapse into
+          // one. Guards the duplicate-value fix (AB#1602086) from the consumer side
+          // for multiselect, mirroring duplicate-values-multiselect.html.
+          const el = await fixture(html`
+            <auro-select multiselect>
+              <span slot="label">Airport</span>
+              <auro-menu>
+                <auro-menuoption value="SEA">Seattle-Tacoma (SEA)</auro-menuoption>
+                <auro-menuoption value="SEA">Seattle Paine Field (PAE)</auro-menuoption>
+                <auro-menuoption value="PDX">Portland (PDX)</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+          await elementUpdated(el);
+
+          const menu = el.querySelector('auro-menu');
+          const opts = menu.querySelectorAll('auro-menuoption');
+
+          // Select the SECOND SEA first, then the FIRST — DOM order must win
+          // regardless of click order, and each must keep its own identity.
+          opts[1].click();
+          await elementUpdated(menu);
+          await elementUpdated(el);
+          opts[0].click();
+          await elementUpdated(menu);
+          await elementUpdated(el);
+
+          await expect(el.optionSelected.length).to.equal(2);
+          await expect(el.optionSelected[0]).to.equal(opts[0]);
+          await expect(el.optionSelected[1]).to.equal(opts[1]);
+          await expect(JSON.parse(el.value)).to.eql(['SEA', 'SEA']);
+        });
+
         it('should apply value from host attribute on initial render', async () => {
           const el = await fixture(html`
             <auro-select value="bar">

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1114,6 +1114,38 @@ function runTest(mobileView) {
           expect(triggerValueEl.textContent.trim()).to.equal('');
         });
 
+        it('displays the label of the exact option selected when two options share a value', async () => {
+          // Two options carry value="SEA" but render distinct labels. The trigger
+          // label is derived from the selected element (menu.optionSelected), so
+          // selecting the SECOND must surface ITS label — not the first value match.
+          // Guards the getOptionLabel(menu.optionSelected) display path for the
+          // duplicate-value fix (AB#1602086) from the consumer side.
+          const el = await fixture(html`
+            <auro-select>
+              <span slot="label">Airport</span>
+              <auro-menu>
+                <auro-menuoption value="SEA">Seattle-Tacoma (SEA)</auro-menuoption>
+                <auro-menuoption value="SEA">Seattle Paine Field (PAE)</auro-menuoption>
+                <auro-menuoption value="PDX">Portland (PDX)</auro-menuoption>
+              </auro-menu>
+            </auro-select>
+          `);
+          await elementUpdated(el);
+
+          const menu = el.querySelector('auro-menu');
+          const opts = menu.querySelectorAll('auro-menuoption');
+
+          opts[1].click();
+          await elementUpdated(menu);
+          await elementUpdated(el);
+
+          await expect(el.value).to.equal('SEA');
+          await expect(el.optionSelected).to.equal(opts[1]);
+
+          const triggerText = el.shadowRoot.querySelector('#value').textContent.trim();
+          await expect(triggerText).to.equal('Seattle Paine Field (PAE)');
+        });
+
         it('should apply value from host attribute on initial render', async () => {
           const el = await fixture(html`
             <auro-select value="bar">

--- a/docs/post-mortem/1602086.md
+++ b/docs/post-mortem/1602086.md
@@ -1,0 +1,116 @@
+# Post-Mortem: Menu Options Sharing a `value` Could Not Be Distinguished on Selection (AB#1602086)
+
+**Scope:** Fix an `auro-menu` bug where two or more `auro-menuoption`s with the **same `value`** were indistinguishable at selection time — clicking the second of two `value="SEA"` options selected/highlighted the *first*, and multi-select couldn't hold two same-value options independently. Real-world trigger: option lists where a value legitimately repeats (e.g. two airports both coded `SEA` — Seattle-Tacoma and Paine Field). Change is scoped to `auro-menu`'s selection logic plus new option-identity plumbing and regression tests. **Invisible to component consumers:** no new attributes, properties, events, slots, or public methods; `auro-menuoption.js` is byte-for-byte unchanged. Backward-compatible: programmatic `value` sets and async preselection still resolve first-by-value.
+
+## Reference Documents
+- Work item — [AB#1602086](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1602086)
+- Fix — PR [#1576](https://github.com/AlaskaAirlines/auro-formkit/pull/1576), commit `fix(menu): distinguish menu options that share a value` (AB#1602086)
+
+## Quick Reference
+
+| Symptom | Why it happens | Fix |
+|---|---|---|
+| Clicking the **second** of two options that share a `value` selects/highlights the **first** | Selection reconciliation matched value→option with `items.find(i => i.value === this.value)` — first-by-value, blind to which element was clicked | Track the user's exact pick by a private per-option key (`_optionKey`), and resolve value→option preferring that key |
+| The `selected` attribute / checkmark lands on the wrong duplicate | `updateItemsState` marked options via value comparison, so *both* duplicates (or the wrong one) matched | `isOptionSelected` already compares by identity (`===`); the fix routes reconciliation through identity too so only the clicked element is marked |
+| Multi-select can't hold two same-value options at once | Add/remove and `value` rebuild were keyed on `value`, so a second `SEA` collapsed into the first | Store `optionSelected` by element identity; rebuild `value`/`_selectedKey` from the selected set in DOM order |
+| Multi-select order followed click order, not menu order | `value` was appended in click sequence | `_sortSelectedByDomOrder()` re-sorts selection into DOM order before deriving `value` |
+| Looks like it needs a public API change | It doesn't — the disambiguator is internal state | `_optionKey`/`_selectedKey` are private, never reflected, never in generated docs |
+
+## What Landed vs. What Was Planned
+
+| Planned | Status |
+|---|---|
+| Reproduce the duplicate-value selection bug (single + multi) | Done — fixtures with two `value="SEA"` options; clicking index 1 resolved to index 0. |
+| Identify root cause | Done — value-only matching in `updated()` reconciliation and the toggle handlers. |
+| Give each option a stable, unique identity | Done — private `_optionKey`, instance-prefixed + monotonic + idempotent, assigned by the root menu. |
+| Track the user's exact selection | Done — `_selectedKey` (string in single-select, array in multi-select). |
+| Resolve value→option preferring the user's pick | Done — `resolveSelectedOption` / `resolveSelectedOptions` utils; key first, value fallback. |
+| Keep programmatic/preselection behavior unchanged | Done — key fallback to first-by-value; `selectByValue` clears the key (no positional intent). |
+| Multi-select stored/serialized in DOM order | Done — `_sortSelectedByDomOrder`. |
+| Regression guards | Done — `unique option keys (duplicate values)` + `resolveSelectedOption / resolveSelectedOptions utils` describe blocks; 480 tests pass, 99.8% coverage. |
+| Keep the change invisible to consumers | Done — no public API surface; verified generated `api.md` is unchanged. |
+
+## Root Cause
+
+`auro-menu` treated `value` as a unique key for the value↔option mapping. Selection reconciliation in `updated()` resolved the selected element(s) purely by value:
+
+```js
+// single-select (before)
+const matchingOption = this.items.find((item) => isSelectableByValue(item) && item.value === this.value);
+// multi-select (before)
+const matchingOptions = this.items.filter((item) => isSelectableByValue(item) && valueArray.includes(item.value));
+```
+
+`Array.prototype.find` returns the **first** match, so when two options shared a `value`, a click on the second resolved back to the first — the `selected` attribute, checkmark, and `optionSelected` all snapped to the wrong element. In multi-select, `value` and `optionSelected` were built by appending/removing `option.value`, so a second same-value option could not be represented distinctly and collapsed into the first.
+
+The invariant "`value` uniquely identifies an option" was never guaranteed by the component's contract — consumers can legitimately repeat a value (two airports sharing an IATA code). The bug was a missing element-identity layer, not a matching typo.
+
+## Resolution
+
+Two source files: `components/menu/src/auro-menu.js` (identity plumbing + selection logic) and `components/menu/src/auro-menu-utils.js` (two pure resolver functions). `auro-menuoption.js` is unchanged.
+
+**1. Per-option identity — `_optionKey`.** Each menu instance gets a unique `_menuInstanceId` (`menu-<n>` from a module-level monotonic counter). `_assignOptionKeys()`, run from `initItems`, stamps every option that lacks a key with `` `${_menuInstanceId}-${_optionKeyCounter}` ``. It is:
+- **Root-assigned only** — the root menu's `items` is a deep query that already includes nested submenu options, so one pass keys the whole tree; nested menus skip assignment.
+- **Idempotent** — guarded by `_optionKey === undefined`, so keys are stable across re-renders and slot changes.
+- **Monotonic** — the counter never resets, so a rebuilt option set (combobox filtering) gets fresh keys that never collide with retired ones.
+- **Private** — instance state only; never reflected as an attribute, never in the public API or generated docs.
+
+**2. User-selection tracking — `_selectedKey`.** `handleSelectState` records the clicked element's `_optionKey` (single) or the array of keys (multi). Deselect/clear/reset paths clear it. `selectByValue` clears it too — a programmatic set carries no positional intent, so reconciliation must fall back to first-by-value.
+
+**3. Key-preferring resolution.** `resolveSelectedOption(items, value, selectedKey)` and `resolveSelectedOptions(items, valueArray, selectedKeys)` (in `auro-menu-utils.js`) trust a key only when it still resolves to a selectable option whose value matches the request, then fall back to value matching for anything unresolved — the multi-select fallback matches duplicates **by count**, not mere presence, so a value that appears twice but is key-resolved once still matches its second occurrence. Results are returned in DOM order.
+
+**4. Identity-based selection state.** `isOptionSelected` compares by `===`; multi-select add/remove filter by identity; `_sortSelectedByDomOrder()` re-sorts `optionSelected` into DOM order and derives `value`/`_selectedKey` from it, so display and serialization follow menu order regardless of click order.
+
+## Backward Compatibility
+
+The key layer is additive and only engages when a user actively clicks; every prior behavior is preserved:
+- **Programmatic `value` / `selectByValue`** — `_selectedKey` is cleared/absent, so resolution is first-by-value (single) or value-in-DOM-order (multi), exactly as before. `selectByValue` clears the key directly; a consumer's **direct `value` property assignment** is distinguished from a user click by the `_valueChangeFromSelection` flag (set only by `handleSelectState` / `_sortSelectedByDomOrder`), so `updated()` drops the stale key on any programmatic set — a prior click on a duplicate can't bias a later programmatic value set back to that element.
+- **Async preselection** — options arriving after `value` is set have no `_selectedKey`; the value fallback matches them once they render (`handleSlotChange` re-runs matching).
+- **Non-duplicate menus** — with unique values the key path and the value path resolve to the same element; behavior is identical.
+
+## Verification
+- **Tests** (`components/menu/test/auro-menu.test.js`): two new describe blocks —
+  - `unique option keys (duplicate values)` — unique-key assignment, exact-click tracking (single), independent duplicate tracking + DOM-order storage (multi), key stability across re-renders, instance isolation, dynamic rebuild getting fresh keys, nested duplicate-across-levels, dynamically-inserted submenu keying, programmatic `selectByValue` clearing a stale key, and programmatic fallback to first-by-value.
+  - `resolveSelectedOption / resolveSelectedOptions utils` — key-preference, stale-key fallback, changed-value fallback, DOM-order regardless of key order, duplicate→distinct-element resolution, and count-based fallback when only one duplicate is keyed.
+  - New fixtures in `testFixtures.js`: `duplicateValueFixture`, `multiSelectDuplicateValueFixture`, `multiSelectDisabledDuplicateValueFixture`, `nestedDuplicateValueFixture`.
+- **Result:** full suite **480 passing, 0 failing**, code coverage **99.8%** (run via `npm test` so design-token CSS injection is present).
+- **Lint:** `eslint ./src/**/*.js` clean.
+- **Docs:** regenerated `docs/api.md` via `wca analyze` and diffed against `dev` — **no change** (see "What Went Wrong").
+
+## What Went Right
+- **Named the missing invariant, not the symptom.** Framing the bug as "`value` was assumed unique but isn't" pointed straight at an identity layer rather than patching individual `find`/`filter` calls.
+- **Identity was already half-present.** `isOptionSelected` compared by `===` before this change; routing reconciliation through the same identity made the `selected` attribute correct with no rework of the rendering path.
+- **Pure, separately-tested resolvers.** Extracting resolution into `resolveSelectedOption`/`resolveSelectedOptions` allowed exhaustive unit tests (stale keys, changed values, count-based duplicates) independent of DOM/lifecycle.
+- **Kept it genuinely invisible.** No public API surface changed, and that was *verified* by diffing regenerated docs — not just asserted.
+
+## What Went Wrong / What the Investigation Missed
+- **A private field nearly leaked into the public API docs.** An early draft documented `_optionKey` with a class-level `@property` JSDoc tag on `auro-menuoption`. `wca analyze` harvests `@property` tags into the generated `docs/api.md` **Properties table** — so the next `build:docs` would have advertised an internal field to consumers, directly contradicting the "invisible" goal. Caught by regenerating `api.md` to a temp file and diffing: the tag produced exactly one spurious row. Fixed by removing the tag; the field stays documented for maintainers at its assignment site (`_assignOptionKeys`).
+- **A util edge case survived the first review.** `resolveSelectedOptions`' value-fallback originally filtered unresolved values by *presence* (`resolved.some(o => o.value === val)`), which under-resolves duplicates when keys resolve only some of them. Unreachable via the component's own invariants (which keep `_selectedKey` full-length), but reachable for a direct caller of the exported util. Rewritten to decrement a per-value count and covered with a dedicated test.
+- **An incidental unrelated edit crept in.** A blank line in `auro-menuoption.js` was removed in passing; restored so that file has zero net diff.
+
+## Recommendations for Future Menu / Selection Work
+1. **Don't assume `value` is unique.** Any list component that lets consumers author options must treat `value` as non-unique. Match selection by **element identity**, deriving `value` from the selected set — never the reverse.
+2. **Regenerate and diff `api.md` before shipping any JSDoc change.** `wca analyze` turns `@property`/`@attr`/`@slot`/`@event`/`@csspart` tags into public docs. For internal state, document at the assignment/usage site with a plain comment, never a harvested tag. Confirm with `npx wca analyze 'scripts/wca/*.js' --outFiles /tmp/api.md && diff <(git show dev:components/<c>/docs/api.md) /tmp/api.md`.
+3. **Test exported utilities against their own contract, not just their in-component caller.** The count-based duplicate bug was invisible from inside the component because `_selectedKey` is always full-length there; only a direct-call test exposed it. If you export it, test it standalone.
+4. **Prefer monotonic, instance-prefixed keys over random ids.** Deterministic keys keep option identity stable across re-renders and collision-free across menus without an RNG, and they survive the combobox's rebuild-on-filter pattern (counter never resets → no reuse).
+
+## Latent issues parked (not in scope for AB#1602086)
+- **Cascading-update warning.** Lit logs "scheduled an update … after an update completed" during value reconciliation. This pre-dates the fix (multi-select reconciliation already reassigned `value` inside `updated()`); the DOM-order rebuild adds another reassignment on that existing path. Not user-visible and not addressed here; a broader refactor of the `updated()` reconciliation cycle would be the place to fix it.
+
+## Receipts
+
+**Fix (PR [#1576](https://github.com/AlaskaAirlines/auro-formkit/pull/1576)):**
+- `components/menu/src/auro-menu-utils.js` — added `resolveSelectedOption` and `resolveSelectedOptions` (key-preferring, count-based value fallback, DOM-ordered), wrapped in a scoped `eslint-disable no-underscore-dangle`.
+- `components/menu/src/auro-menu.js` — module-level `menuInstanceIdCounter`; per-instance `_menuInstanceId` / `_optionKeyCounter` / `_selectedKey`; `_assignOptionKeys()` (root-only, idempotent); identity-based `handleSelectState` / `handleDeselectState`; `_sortSelectedByDomOrder()`; `selectByValue` clears `_selectedKey`; `updated()` reconciliation routed through the resolver utils.
+- `components/menu/test/auro-menu.test.js` — two new describe blocks (component-level duplicate scenarios + util unit tests).
+- `components/menu/test/testFixtures.js` — `duplicateValueFixture`, `multiSelectDuplicateValueFixture`, `multiSelectDisabledDuplicateValueFixture`, `nestedDuplicateValueFixture`.
+- `components/select/test/auro-select.test.js` — consumer-side guard that the trigger label reflects the exact duplicate-value option selected (`getOptionLabel(menu.optionSelected)` path).
+- `components/combobox/src/auro-combobox.js` — two consumer-side guards so the menu's element-identity selection survives combobox's value↔input sync: (1) `updated()`'s `input.value !== value` branch no longer calls `menu.clearSelection()` when `menu.optionSelected.value` already matches the new value (a live user selection), which previously wiped `_selectedKey` and let the value-only re-resolution collapse onto the first same-value option; (2) `handleInputValueChange` skips `this.value = this.input.value` while `_syncingDisplayValue` is set, so writing the option's display **label** back no longer clobbers the machine value the selection listener set.
+- `components/combobox/test/testFixtures.js` / `components/combobox/test/auro-combobox.test.js` — `duplicateValueFixture` + regression test that selecting the second of two same-value options keeps its identity (`value`, `optionSelected`, and displayed label), run desktop and mobile.
+- `components/menu/src/auro-menuoption.js` — **unchanged** (net zero diff).
+- Generated `*-css.js` / `docs/api.md` — **not modified**; regenerating `api.md` yields no diff (the private key layer is deliberately absent from public docs).
+
+**Approaches considered and rejected (do not re-tread):**
+- **Documenting `_optionKey` as a public `@property`** — leaks a private field into `api.md`; removed. Internal state is documented at its assignment site only.
+- **Presence-based value fallback in `resolveSelectedOptions`** — under-resolves duplicates when keys partially resolve; replaced with count-based decrement.
+- **Not clearing `_selectedKey` on `selectByValue`** — a stale-but-still-valid key would snap a programmatic set back to a previously-clicked duplicate, violating the first-by-value contract for programmatic selection.

--- a/docs/post-mortem/1606433.md
+++ b/docs/post-mortem/1606433.md
@@ -1,0 +1,77 @@
+# Post-Mortem: Enter Could Not Re-Select an Option After Deselecting the Last Selection in Multi-Select (AB#1606433)
+
+**Scope:** Fix an `auro-menu` multi-select bug where pressing **Enter** on the highlighted option did nothing when the *previous* Enter had deselected the **last remaining** selection. Toggling the same highlighted option off-then-on required moving the highlight away and back — a broken keyboard interaction. The fix recovers the selection index from the still-highlighted option inside `makeSelection()`. Change is scoped to `auro-menu`'s keyboard-selection path plus one regression test. **Invisible to component consumers:** no new attributes, properties, events, slots, or public methods; behavior only changes for the previously-broken empty-selection edge.
+
+## Reference Documents
+- Work item — [AB#1606433](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1606433)
+- Fix — commit `dc128a325` `fix(menu): re-select highlighted option via Enter after emptying selection` (AB#1606433), branch `jbaker/nonUniqueMenuOptions`
+
+## Quick Reference
+
+| Symptom | Why it happens | Fix |
+|---|---|---|
+| In multi-select, Enter re-selects a highlighted option **only** if other options remain selected — but no-ops when the prior Enter emptied the whole selection | Emptying the selection collapses `value` to `undefined`; `updated()`'s no-match reconcile branch resets `_index = -1` while `optionActive` still points at the highlighted option | In `makeSelection()`, recover `_index` from `optionActive` when it has been reset to `-1` |
+| `makeSelection()` reads `items[-1]` → `undefined` and returns early | Selection is keyed off `this.items[this._index]`, and `_index` is stale (`-1`) even though the visible highlight is correct | Re-derive `_index = items.indexOf(optionActive)` before reading `items[_index]` |
+| Moving the highlight away and back "fixes" it | Navigating re-sets `_index` via the nav handlers, masking the stale `-1` | No longer needed — `makeSelection()` self-heals the index from the active option |
+
+## Root Cause
+
+In multi-select, `makeSelection()` acts on `this.items[this._index]`. Two independent pieces of state describe "the current option": `_index` (numeric, used by `makeSelection`) and `optionActive` (element, the visible highlight). They are normally kept in lockstep by the navigation handlers and by `handleDeselectState`, which sets `_index` to the toggled option.
+
+But when a deselect empties the entire selection, `optionSelected` collapses to `undefined`. The `updated()` value-matching reconciliation then takes its **no-match** branch and resets `_index = -1` ([auro-menu.js:538](../../components/menu/src/auro-menu.js#L538) / [:556](../../components/menu/src/auro-menu.js#L556)) — even though `optionActive` still correctly points at the highlighted option. On the next Enter, `makeSelection()` reads `this.items[-1]` → `undefined` and returns early ([auro-menu.js:1006](../../components/menu/src/auro-menu.js#L1006)), so the toggle silently no-ops. When other options remain selected the reconcile path doesn't reset `_index`, which is why the bug only surfaces on the empty-selection transition, and why navigating away and back (which re-sets `_index`) appears to fix it.
+
+The root cause is a **desync between `_index` and `optionActive`** across the empty-selection reconcile, not a fault in the toggle logic itself. `auro-combobox` already avoids the same class of desync in its keyboard strategy via `reconcileMenuIndex` ([comboboxKeyboardStrategy.js:39](../../components/combobox/src/comboboxKeyboardStrategy.js#L39)); `auro-menu`'s `makeSelection` had no equivalent.
+
+## Resolution
+
+One source change in `components/menu/src/auro-menu.js`, inside `makeSelection()` and guarded to the exact broken state: when `_index < 0` but `optionActive` is set and present in `items`, re-derive `_index` from the highlighted option before reading `items[_index]`:
+
+```js
+// Recover `_index` from the highlighted option when it has been reset to -1.
+if (this._index < 0 && this.optionActive && this.items) {
+  const activeIndex = this.items.indexOf(this.optionActive);
+  if (activeIndex >= 0) {
+    this._index = activeIndex;
+  }
+}
+```
+
+This mirrors `auro-combobox`'s `reconcileMenuIndex` fallback: treat `optionActive` (the thing the user can see) as the source of truth for "which option Enter acts on" whenever the numeric index has been invalidated. The guard is tight — it engages only when `_index` is negative and a valid active option exists — so no already-correct path is disturbed.
+
+## Backward Compatibility
+
+The recovery is purely additive and only engages in the previously-broken state (`_index < 0` with a valid `optionActive`):
+- **Single-select and non-empty multi-select** — `_index` is already valid, the guard is skipped, behavior is identical.
+- **No active highlight** (`optionActive` unset) — guard is skipped; `makeSelection()` still early-returns as before.
+- **Mouse selection** — routes through `handleMouseSelect`/identity, unaffected by this index recovery.
+- No public API surface changes; the only observable difference is that a formerly dead Enter now toggles, as users already expect.
+
+## Verification
+- **Test** (`components/menu/test/auro-menu.test.js`): new regression case *"should re-select via Enter after deselecting the last selected option in multi-select mode"* — selects option 0 (making it the only selection), deselects it **without moving the highlight** (emptying the selection so `value` collapses to `undefined` and `_index` resets to `-1`), then presses Enter again and asserts the option is re-selected (`value`, `selected` attribute, and `aria-selected="true"`). The test fails against the pre-fix source (the third Enter no-ops).
+- **Result:** full menu suite **502 passing, 0 failing**, code coverage **99.81%** (run via `npm test` so design-token CSS injection is present, per repo convention).
+
+## What Went Right
+- **Named the desync, not the symptom.** Framing the bug as "`_index` and `optionActive` fell out of sync" pointed straight at an index-recovery guard rather than reworking the toggle or the reconcile branch.
+- **Reused an existing, proven pattern.** `auro-combobox`'s `reconcileMenuIndex` already solved this class of desync; mirroring it kept the fix small, familiar, and consistent across components.
+- **Minimal blast radius.** A 13-line guard scoped to `_index < 0` leaves every healthy path byte-for-byte unchanged.
+
+## What Went Wrong / What the Investigation Missed
+- **Two sources of truth for "the current option" were allowed to drift.** `_index` (numeric) and `optionActive` (element) are reconciled in some paths but not the empty-selection reconcile. This fix reconciles them at the point of use; the deeper cleanup would be to derive `_index` from `optionActive` everywhere (or drop the numeric index entirely) rather than patch at each consumer.
+
+## Recommendations for Future Menu / Selection Work
+1. **Treat the visible highlight (`optionActive`) as the source of truth for keyboard actions.** Numeric indices go stale across reconciliation; the element the user sees does not. Derive the index from the active element at the point of action.
+2. **When one component already solved a keyboard-state bug, mirror it.** `auro-combobox`'s `reconcileMenuIndex` predates this fix; parity across the menu/select/combobox keyboard paths prevents the same edge from reappearing per-component.
+3. **Test the empty-selection transition explicitly.** Multi-select bugs cluster around the "last item removed" boundary where `value` collapses to `undefined`; assert re-selection *without* moving the highlight to catch index-desync regressions.
+
+## Latent issues parked (not in scope for AB#1606433)
+- **Dual `_index` / `optionActive` state.** The underlying design keeps a numeric index alongside the active element and reconciles them in several places. Consolidating to a single source of truth would remove this whole class of desync bug but is a broader refactor of the selection/navigation cycle, out of scope here.
+
+## Receipts
+
+**Fix (branch `jbaker/nonUniqueMenuOptions`, commit `dc128a325`):**
+- `components/menu/src/auro-menu.js` — in `makeSelection()`, recover `_index` from `optionActive` when it has been reset to `-1` (guarded `_index < 0 && optionActive && items`, using `items.indexOf(optionActive)`), before reading `this.items[this._index]`.
+- `components/menu/test/auro-menu.test.js` — regression test covering select → deselect (emptying the selection) → re-select via Enter without moving the highlight.
+
+**Approaches considered and rejected (do not re-tread):**
+- **Suppressing the `_index = -1` reset in the `updated()` no-match branch** — that reset is correct for the general no-match case (there is genuinely no selected option); special-casing it would entangle reconcile with keyboard state. Recovering the index at the point of use (`makeSelection`) is narrower and matches the established combobox pattern.
+- **Requiring the highlight to move to re-arm Enter** — that is the buggy behavior itself; Enter must toggle the visibly-active option unconditionally.

--- a/docs/post-mortem/1606433.md
+++ b/docs/post-mortem/1606433.md
@@ -4,7 +4,7 @@
 
 ## Reference Documents
 - Work item — [AB#1606433](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1606433)
-- Fix — commit `dc128a325` `fix(menu): re-select highlighted option via Enter after emptying selection` (AB#1606433), branch `jbaker/nonUniqueMenuOptions`
+- Fix — PR [#1576](https://github.com/AlaskaAirlines/auro-formkit/pull/1576), commit `fix(menu): re-select highlighted option via Enter after emptying selection` (AB#1606433)
 
 ## Quick Reference
 
@@ -68,7 +68,7 @@ The recovery is purely additive and only engages in the previously-broken state 
 
 ## Receipts
 
-**Fix (branch `jbaker/nonUniqueMenuOptions`, commit `dc128a325`):**
+**Fix (PR [#1576](https://github.com/AlaskaAirlines/auro-formkit/pull/1576)):**
 - `components/menu/src/auro-menu.js` — in `makeSelection()`, recover `_index` from `optionActive` when it has been reset to `-1` (guarded `_index < 0 && optionActive && items`, using `items.indexOf(optionActive)`), before reading `this.items[this._index]`.
 - `components/menu/test/auro-menu.test.js` — regression test covering select → deselect (emptying the selection) → re-select via Enter without moving the highlight.
 


### PR DESCRIPTION
auro-menu previously resolved a selection value→option with a first-by-value match, so clicking the second of two options sharing a `value` (e.g. two airports coded "SEA") selected the first, and multi-select could not hold two same-value options independently.

Each option now receives a private, auto-generated `_optionKey` assigned by the root menu, and the user's exact pick is tracked via `_selectedKey`. Selection reconciliation in updated() prefers the keyed option and falls back to first-by-value for programmatic sets and async preselection, so existing behavior is preserved. Multi-select stores selections by element identity and rebuilds `value`/`_selectedKey` in DOM order via `_sortSelectedByDomOrder()`.

- Add `resolveSelectedOption` / `resolveSelectedOptions` key-aware resolvers to auro-menu-utils.js
- Add duplicate-value fixtures, regression tests, and util unit tests (480 menu tests pass, 99.8% coverage; select/combobox suites green)
- Add duplicate-value API examples and customize docs for menu/select/combobox

No public API change: no new attributes, properties, events, or slots; `auro-menuoption.js` is unchanged. `value` remains the public identity.

See post-mortem docs/post-mortem/1602086.md (lines 33-63) for the root cause and resolution behind these changes.

Co-authored-by AI: Claude Opus 4.8

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure auro-menu, auro-select, and auro-combobox correctly distinguish and preserve user selections when multiple menu options share the same value, while keeping behavior unchanged for programmatic value setting and existing APIs.

New Features:
- Support for non-unique option values in auro-menu, auro-select, and auro-combobox, with accurate label display and independent tracking of duplicate-value options in single- and multi-select modes.

Bug Fixes:
- Fix auro-menu selection so clicks and keyboard selection on duplicate-value options resolve to the exact option chosen rather than the first match.
- Fix multi-select behavior so duplicate-value options can be selected and deselected independently, with selections stored in DOM order instead of click order.
- Fix a multi-select keyboard issue where Enter could not re-select a highlighted option after deselecting the last remaining selection.
- Fix combobox value↔menu synchronization so the selected option’s identity and machine value are not clobbered when labels differ from values or values are duplicated.

Enhancements:
- Introduce internal per-option keys and key-aware resolver utilities to disambiguate menu options that share a value without changing the public API.
- Improve internal value reconciliation in auro-menu to handle disabled duplicate-value options and avoid selection loops.
- Align combobox and menu keyboard/index reconciliation behavior to keep highlighted and selected options in sync.

Documentation:
- Document support for non-unique option values in menu, select, and combobox customization guides, with new API examples for single- and multi-select duplicate-value scenarios.
- Add post-mortem documents detailing the root cause, resolution, and follow-ups for duplicate-value selection and multi-select keyboard re-selection issues.

Tests:
- Add extensive regression tests and fixtures for duplicate-value scenarios in menu, select, and combobox, including nested menus, disabled duplicates, keyboard interaction, and utility-level resolution logic.