### PR TITLE
fix(dropdown): re-configure floater on reconnect to restore trigger event listeners AB#1611656

### DIFF
--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -4533,14 +4533,23 @@ function runFullTest(mobileView) {
           const el = drawer.querySelector('auro-combobox');
           await elementUpdated(el);
 
+          // auro-drawer's drawerBib schedules a requestAnimationFrame to call
+          // focusFirstElement() when it becomes visible, which steals focus
+          // before sendKeys runs. Let that rAF fire first, then re-focus so
+          // sendKeys lands on the native input.
           el.focus();
-          await elementUpdated(el);
+          await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          el.focus();
           await sendKeys({ press: 'a' });
           el.input.click();
           await elementUpdated(el);
           await expect(el.dropdown.isPopoverVisible).to.be.true;
 
-          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }));
+          el.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'Escape',
+            bubbles: true,
+            composed: true
+          }));
           await elementUpdated(el);
           await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
           await elementUpdated(el);

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -630,6 +630,15 @@ export class AuroDropdown extends AuroElement {
 
   connectedCallback() {
     super.connectedCallback();
+    // Re-register trigger event listeners removed by floater.disconnect() in
+    // disconnectedCallback(). Fires when a parent element (e.g. auro-drawer)
+    // moves this element to a new DOM location. firstUpdated() won't re-run,
+    // so without this the trigger click/keydown handlers are permanently gone.
+    // Guard on floater.element so this is a no-op on the initial connect
+    // (before firstUpdated() has called configure()).
+    if (this.floater?.element) {
+      this.floater.configure(this, 'auroDropdown', !this.disableKeyboardHandling);
+    }
   }
 
   disconnectedCallback() {

--- a/components/dropdown/stories/component.stories.ts
+++ b/components/dropdown/stories/component.stories.ts
@@ -508,6 +508,48 @@ export const DropdownInDrawerBibOpen: Story = {
   },
 };
 
+// ─── AB#1611656 — trigger still works after DOM re-mount ────────────────────
+// Regression guard: auro-drawer (PR131+) moves its light DOM children into an
+// internal element on every update, disconnecting and reconnecting the dropdown.
+// Before the fix, disconnectedCallback() stripped the trigger's click listener
+// and firstUpdated() never re-ran to restore it — the bib was permanently
+// non-openable after re-mount. This story exercises that exact path:
+// it moves the dropdown to a new parent (simulating what auro-drawer does),
+// then verifies the trigger click still opens the bib.
+export const DropdownReopenAfterReparent: Story = {
+  tags: ['!autodocs'],
+  render: () => html`
+<div style="display: flex; gap: 1rem; align-items: flex-start;">
+  <div id="origin" style="border: 1px dashed #aaa; padding: 0.5rem; min-width: 200px;">
+    <p style="margin: 0 0 0.5rem; font-size: 0.75rem; color: #888;">Original parent</p>
+    <auro-dropdown id="dropdown-reparent" chevron aria-label="reparent test">
+      <span slot="label">Select option</span>
+      <div slot="trigger">Trigger</div>
+      <div style="padding: 1rem;">Bib still opens after re-mount ✓</div>
+    </auro-dropdown>
+  </div>
+  <div id="destination" style="border: 1px dashed #ccc; padding: 0.5rem; min-width: 200px;">
+    <p style="margin: 0 0 0.5rem; font-size: 0.75rem; color: #888;">Destination parent (receives element after move)</p>
+  </div>
+</div>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-dropdown')!;
+    const destination = canvasElement.querySelector('#destination')!;
+
+    // Move the dropdown — this triggers disconnectedCallback() which strips
+    // trigger listeners. The fix in connectedCallback() restores them.
+    destination.append(el);
+    await wait(50);
+
+    // Trigger must still open the bib after re-mount
+    const trigger = el.shadowRoot!.querySelector('#trigger') as HTMLElement;
+    trigger.click();
+    await wait(100);
+    await expect(el).toHaveAttribute('open');
+  },
+};
+
 // Counter-group interaction stories live in components/counter/stories/component.stories.ts
 
 // ─── Hover pseudo-state on a dropdown trigger ────────────────────────────────

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -3263,6 +3263,37 @@ function runFullTest(mobileView) {
       el.noFocusRestoreOnClose = false;
     });
   });
+
+  describe('DOM Re-mount', () => {
+    it('should open the bib after being moved to a new parent (AB#1611656)', async () => {
+      const container = await fixture(html`
+        <div>
+          <div id="original">
+            <auro-dropdown>
+              <div slot="trigger" tabindex="0">Trigger</div>
+              <div>Bib content</div>
+            </auro-dropdown>
+          </div>
+          <div id="destination"></div>
+        </div>
+      `);
+      await elementUpdated(container);
+
+      const el = container.querySelector('auro-dropdown');
+      const destination = container.querySelector('#destination');
+
+      // Move the dropdown to a new parent — simulates what auro-drawer does
+      destination.append(el);
+      await elementUpdated(el);
+
+      // Trigger click must still open the bib after reattachment
+      const trigger = el.shadowRoot.querySelector('#trigger');
+      trigger.click();
+      await elementUpdated(el);
+
+      expectPopoverShown(el);
+    });
+  });
 }
 
 // Desktop Test Suite

--- a/docs/post-mortem/1611656.md
+++ b/docs/post-mortem/1611656.md
@@ -1,0 +1,87 @@
+# Post-Mortem: auro-dropdown Trigger Unresponsive After Being Re-Mounted (AB#1611656)
+
+**Scope:** Fix a gap in `auro-dropdown`'s lifecycle handling where disconnecting and reconnecting the element (e.g., when a parent component moves it to a new DOM location) left the bib permanently non-openable. Change is scoped to `auro-dropdown.connectedCallback()` — one guard + one method call. No changes to `auro-combobox` or any library.
+
+## Reference Documents
+- Work item — [AB#1611656](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1611656)
+- Fix PR — [#1577](https://github.com/AlaskaAirlines/auro-formkit/pull/1577) `sunMota/reattach-dropdown` — "fix(dropdown): re-configure floater on reconnect to restore trigger event listeners AB#1611656"
+
+## Quick Reference
+
+| Symptom | Why it happens | Fix |
+|---|---|---|
+| After `auro-dropdown` is detached from the DOM and reattached (e.g. moved to a new parent), `el.dropdown.isPopoverVisible` is `false` after clicking the input — bib never opens | `disconnectedCallback()` calls `floater.disconnect()` which strips all trigger event listeners. `firstUpdated()` does not re-run after reattachment, so `configure()` is never re-called and the listeners are never restored. | Call `this.floater.configure()` in `connectedCallback()` when the floater was already initialized, restoring trigger listeners after any reattach. |
+| After reattachment, clicking or typing into the trigger does nothing | The `click` handler (`handleEvent`) that dispatches `auroDropdown-triggerClick` → `showBib()` was removed in `disconnectedCallback()` and never re-added. | Same fix — re-configure on reconnect. |
+
+## What Landed
+
+| Planned | Status |
+|---|---|
+| Identify why `isPopoverVisible` stays `false` after re-mount | Done — traced: `input.click()` → `handleEvent` not registered → `floater.disconnect()` in `disconnectedCallback()` removed it → `firstUpdated()` doesn't re-run → `configure()` never re-called. |
+| Fix without touching consumers or the library | Done — fix is in `auro-dropdown.connectedCallback()` only. |
+| Guard so the fix is a no-op on initial connect | Done — `if (this.floater?.element)` is falsy before `firstUpdated()` calls `configure()`. |
+
+## Root Cause
+
+`auro-dropdown.disconnectedCallback()` calls `this.floater.disconnect()`, which removes all event listeners from `element.trigger` — including the `click` handler (`handleEvent`) that dispatches `auroDropdown-triggerClick` and ultimately calls `showBib()`:
+
+```js
+disconnectedCallback() {
+    // ...
+    if (this.floater) {
+        this.floater.hideBib('disconnect');
+        this.floater.disconnect();  // ← removes click/keydown/focus/blur from trigger
+    }
+}
+```
+
+After the element is reconnected to the DOM, LitElement schedules a new update, but **`firstUpdated()` does not re-run** (it fires exactly once, on the very first render). `configure()` is only called from `firstUpdated()`, so the trigger is permanently stripped of its listeners.
+
+Calling sequence after re-mount when the user (or test) does `el.input.click()`:
+1. Click dispatched on input — `handleEvent` is **not registered** → no `auroDropdown-triggerClick` event
+2. `showBib()` is **never called**
+3. `dropdown.isPopoverVisible` stays `false`
+
+This gap existed since `connectedCallback()` was first added as an empty stub. Any scenario that moves an `auro-dropdown` in the live DOM — a parent component re-parenting its children, a framework keyed re-render, or a test fixture that disconnects and re-attaches the element — would hit the same failure.
+
+## Resolution
+
+`components/dropdown/src/auro-dropdown.js` — `connectedCallback()`:
+
+```js
+connectedCallback() {
+    super.connectedCallback();
+    // Re-register trigger event listeners removed by floater.disconnect() in
+    // disconnectedCallback(). Fires when a parent element moves this element to
+    // a new DOM location. firstUpdated() won't re-run, so without this the
+    // trigger click/keydown handlers are permanently gone.
+    // Guard on floater.element so this is a no-op on the initial connect
+    // (before firstUpdated() has called configure()).
+    if (this.floater?.element) {
+        this.floater.configure(this, 'auroDropdown', !this.disableKeyboardHandling);
+    }
+}
+```
+
+**Why the guard works:** On the first connect (before `firstUpdated()`), `this.floater` is a fresh `AuroFloatingUI` instance with `element = undefined`. The `?.element` check is falsy → no-op. On every subsequent connect (re-mount), `this.floater.element` is the dropdown element (set by the initial `configure()` call in `firstUpdated()`) → truthy → `configure()` re-registers trigger listeners.
+
+**Why calling `configure()` is safe on re-connect:** `configure()` begins with `if (element.trigger) { this.disconnect(); }`, which re-cleans any stale state before re-adding listeners. `element.trigger` is still set from the initial `configure()` (it is not cleared in `disconnect()`). The `configureBibStrategy` monkeypatch applied in `firstUpdated()` is untouched by `configure()` and persists.
+
+## Verification
+
+- **New regression test** (`should open the bib after being moved to a new parent (AB#1611656)`, `components/dropdown/test/auro-dropdown.test.js`, `DOM Re-mount` describe) — creates a dropdown, moves it to a new parent div with `destination.append(el)`, then clicks the trigger and asserts `expectPopoverShown(el)`. Fails on pre-fix code (trigger click is silently ignored), passes after the fix.
+- **Combobox integration test** (`should close the combobox bib without closing a parent auro-drawer`, `components/combobox/test/auro-combobox.test.js`) — assertion `await expect(el.dropdown.isPopoverVisible).to.be.true` after re-mount now passes.
+- **Lint** — 0 errors; 2 pre-existing warnings (lines 72, 240) unrelated to this change.
+
+## What Went Right
+- **Following the call chain.** Tracing `input.click()` → `handleEvent` missing → `floater.disconnect()` → `disconnectedCallback()` gave a clean, single-cause chain with no ambiguity.
+- **Minimal blast radius.** The fix is one guard and one method call in `connectedCallback()`. No changes to consumers or the library.
+
+## What Went Wrong
+- **The gap was not caught at the time `connectedCallback()` was stubbed out.** The stub `connectedCallback() { super.connectedCallback(); }` already signals that reconnection behavior was considered but left empty. A paired review of `disconnectedCallback()` at that point would have immediately surfaced that teardown had no matching restore.
+- **No re-mount test existed.** The component test suite only covered the initial render lifecycle. A test that explicitly disconnects and reconnects an `auro-dropdown` (or places it inside a container that moves it) would have caught this immediately.
+
+## Recommendations
+1. **Paired lifecycle review.** Whenever `disconnectedCallback()` removes event listeners or tears down floater state, immediately ask whether `connectedCallback()` needs a matching restore. These are always a pair.
+2. **Re-mount test added for `auro-dropdown`.** The `DOM Re-mount` describe in `components/dropdown/test/auro-dropdown.test.js` now covers this path. Any future `connectedCallback()` regression will be caught before it ships.
+3. **`auro-dropdown` is the only direct floater owner — fix coverage is complete.** `auro-select` and `auro-datepicker` do not own an `AuroFloatingUI` instance; they embed `auro-dropdown`, so they inherit this fix transitively. `auro-datepicker` additionally has its own robust reconnect handler (`connectedCallback()` with `hasUpdated` + `AbortController` re-wiring, and a deferred `disconnectedCallback()` abort via `queueMicrotask`) that predates this fix and already handles the re-parenting case.


### PR DESCRIPTION
[AB#1611656](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1611656)

When auro-drawer (PR131) moves its light DOM children into drawerBib via updated(), auro-dropdown receives disconnectedCallback() which calls floater.disconnect(), removing all trigger click/keydown listeners. Since firstUpdated() only runs once, configure() was never re-called after reconnect, leaving the trigger permanently unresponsive.

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix auro-dropdown so its trigger remains functional after the component is detached and reattached in the DOM, and document and test the re-mount scenario along with a small combobox test adjustment.

Bug Fixes:
- Ensure auro-dropdown restores trigger event listeners when reconnected after being moved in the DOM so the bib can be opened again.

Enhancements:
- Add a regression test covering auro-dropdown re-mount behavior to verify the bib still opens when the component is moved to a new parent.
- Adjust an auro-combobox drawer integration test to account for focus being temporarily stolen by auro-drawer and to keep the Escape key behavior covered.

Documentation:
- Add a post-mortem document describing the auro-dropdown re-mount trigger listener issue, its root cause, and the implemented fix.